### PR TITLE
Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+
+<!-- Describe your changes here -->
+
+Resolves #<!-- issue id -->
+
+## Checklist
+<!--
+  Any non-WIP PR should have all the checkmarks set.
+  If a checkmark is not applicable to your PR, mark it as done
+-->
+- [ ] I have updated the documentation to account for the changes in the code.
+- [ ] If I added new functionality, I added tests covering it.
+- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
+- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).


### PR DESCRIPTION
## Description

Problem: We want all non-WIP PRs to follow a certain set of rules,
e.g., we want them to clearly relate to one of the issues, contain
tests and docs for the new functionality, and comply with our
contribution policy.

Solution: Add a PR template with a related issue field and several
checkmarks that the contributor needs to set.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).