### PR TITLE
Split supply/borrow XVS rewards

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -1159,6 +1159,20 @@ contract Comptroller is ComptrollerV5Storage, ComptrollerInterfaceG2, Comptrolle
     function _become(Unitroller unitroller) public {
         require(msg.sender == unitroller.admin(), "only unitroller admin can");
         require(unitroller._acceptImplementation() == 0, "not authorized");
+
+        // TODO: Remove this post upgrade
+        Comptroller(address(unitroller))._upgradeSplitXVSRewards();
+    }
+
+    function _upgradeSplitXVSRewards() public {
+        require(msg.sender == comptrollerImplementation, "only brains can become itself");
+
+        // venusSpeeds -> venusBorrowSpeeds & venusSupplySpeeds
+        for (uint i = 0; i < allMarkets.length; i ++) {
+            address market = address(allMarkets[i]);
+            venusBorrowSpeeds[market] = venusSupplySpeeds[market] = venusSpeeds[market];
+            delete venusSpeeds[market];
+        }
     }
 
     /**

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -178,10 +178,6 @@ contract ComptrollerV4Storage is ComptrollerV3Storage {
     /// @notice Fee percent of accrued interest with decimal 18
     uint256 public treasuryPercent;
 }
-contract ComptrollerV5Storage is ComptrollerV4Storage {
-    /// @notice The portion of XVS that each contributor receives per block
-    mapping(address => uint) public venusContributorSpeeds;
 
-    /// @notice Last block at which a contributor's XVS rewards have been allocated
-    mapping(address => uint) public lastContributorBlock;
+contract ComptrollerV5Storage is ComptrollerV4Storage {
 }

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -101,10 +101,12 @@ contract ComptrollerV1Storage is UnitrollerAdminStorage {
     /// @notice A list of all markets
     VToken[] public allMarkets;
 
-    /// @notice The rate at which the flywheel distributes XVS, per block
+    /// @notice (DEPRECATED) The rate at which the flywheel distributes XVS, per block
+    /// @dev This field is deprecated. venusBorrowSpeeds and venusSupplySpeeds now contain the rates for borrow & supply.
     uint public venusRate;
 
-    /// @notice The portion of venusRate that each market currently receives
+    /// @notice (DEPRECATED) The portion of venusRate that each market currently receives
+    /// @dev This field is deprecated. The contract now uses venusBorrowSpeeds and venusSupplySpeeds.
     mapping(address => uint) public venusSpeeds;
 
     /// @notice The Venus market supply state for each market
@@ -180,4 +182,12 @@ contract ComptrollerV4Storage is ComptrollerV3Storage {
 }
 
 contract ComptrollerV5Storage is ComptrollerV4Storage {
+    // The new asymetric speeds will take over the old venusSpeeds.
+    // The old venusSpeeds field will become DEPRECATED following the V4 -> V5 upgrade.
+
+    /// @notice The rate at which XVS is distributed to the corresponding borrow market (per block)
+    mapping(address => uint) public venusBorrowSpeeds;
+
+    /// @notice The rate at which XVS is distributed to the corresponding supply market (per block)
+    mapping(address => uint) public venusSupplySpeeds;
 }

--- a/scenario/src/Contract/Comptroller.ts
+++ b/scenario/src/Contract/Comptroller.ts
@@ -47,10 +47,12 @@ interface ComptrollerMethods {
   venusSupplierIndex(market: string, account: string): Callable<string>
   venusBorrowerIndex(market: string, account: string): Callable<string>
   venusSpeeds(string): Callable<string>
+  venusSupplySpeeds(string): Callable<string>
+  venusBorrowSpeeds(string): Callable<string>
   claimVenus(string): Sendable<void>
   _grantXVS(account: string, encodedNumber): Sendable<void>
   _setVenusRate(encodedNumber): Sendable<void>
-  _setVenusSpeed(vToken: string, encodedNumber): Sendable<void>
+  _setVenusSpeed(vToken: string, newSupplySpeed: encodedNumber, newBorrowSpeed: encodedNumber): Sendable<void>
   mintedVAIs(string): Callable<number>
   _setMarketBorrowCaps(vTokens:string[], borrowCaps:encodedNumber[]): Sendable<void>
   _setBorrowCapGuardian(string): Sendable<void>

--- a/scenario/src/Event/ComptrollerEvent.ts
+++ b/scenario/src/Event/ComptrollerEvent.ts
@@ -288,12 +288,24 @@ async function setVenusRate(world: World, from: string, comptroller: Comptroller
   return world;
 }
 
-async function setVenusSpeed(world: World, from: string, comptroller: Comptroller, vToken: VToken, speed: NumberV): Promise<World> {
-  let invokation = await invoke(world, comptroller.methods._setVenusSpeed(vToken._address, speed.encode()), from, ComptrollerErrorReporter);
+async function setVenusSpeed(
+    world: World,
+    from: string,
+    comptroller: Comptroller,
+    vToken: VToken,
+    supplySpeed: NumberV,
+    borrowSpeed: NumberV
+  ): Promise<World> {
+  let invokation = await invoke(
+      world,
+      comptroller.methods._setVenusSpeed(vToken._address, supplySpeed.encode(), borrowSpeed.encode()),
+      from,
+      ComptrollerErrorReporter
+  );
 
   world = addAction(
     world,
-    `Venus speed for market ${vToken._address} set to ${speed.show()}`,
+    `Venus speeds for market ${vToken._address} set to ${supplySpeed.show()} (supply), ${borrowSpeed.show()} (borrow)`,
     invokation
   );
 
@@ -711,18 +723,20 @@ export function comptrollerCommands() {
       ],
       (world, from, {comptroller, rate}) => setVenusRate(world, from, comptroller, rate)
     ),
-    new Command<{comptroller: Comptroller, vToken: VToken, speed: NumberV}>(`
+    new Command<{comptroller: Comptroller, vToken: VToken, supplySpeed: NumberV, borrowSpeed: NumberV}>(`
       #### SetVenusSpeed
-      * "Comptroller SetVenusSpeed <vToken> <rate>" - Sets XVS speed for market
-      * E.g. "Comptroller SetVenusSpeed vToken 1000
+      * "Comptroller SetVenusSpeed <vToken> <rate>" - Sets XVS speed for market (for suppliers and borrowers separately)
+      * E.g. "Comptroller SetVenusSpeed vToken 1000 2000
       `,
       "SetVenusSpeed",
       [
         new Arg("comptroller", getComptroller, {implicit: true}),
         new Arg("vToken", getVTokenV),
-        new Arg("speed", getNumberV)
+        new Arg("supplySpeed", getNumberV),
+        new Arg("borrowSpeed", getNumberV)
       ],
-      (world, from, {comptroller, vToken, speed}) => setVenusSpeed(world, from, comptroller, vToken, speed)
+      (world, from, {comptroller, vToken, supplySpeed, borrowSpeed}) =>
+          setVenusSpeed(world, from, comptroller, vToken, supplySpeed, borrowSpeed)
     ),
     new Command<{comptroller: Comptroller, vTokens: VToken[], borrowCaps: NumberV[]}>(`
       #### SetMarketBorrowCaps

--- a/scenario/src/Value/ComptrollerValue.ts
+++ b/scenario/src/Value/ComptrollerValue.ts
@@ -371,7 +371,7 @@ export function comptrollerFetchers() {
         #### CallNum
 
         * "CallNum signature:<String> ...callArgs<CoreValue>" - Simple direct call method
-          * E.g. "Comptroller CallNum \"venusSpeeds(address)\" (Address Coburn)"
+          * E.g. "Comptroller CallNum \"venusSupplySpeeds(address)\" (Address Coburn)"
       `,
       "CallNum",
       [
@@ -467,7 +467,7 @@ export function comptrollerFetchers() {
       }
     ),
     new Fetcher<{comptroller: Comptroller, VToken: VToken}, NumberV>(`
-        #### VenusSpeed
+        #### VenusSpeed (DEPRECATED)
 
         * "Comptroller VenusSpeed vZRX
       `,
@@ -478,6 +478,34 @@ export function comptrollerFetchers() {
       ],
       async (world, {comptroller, VToken}) => {
         return new NumberV(await comptroller.methods.venusSpeeds(VToken._address).call());
+      }
+    ),
+    new Fetcher<{comptroller: Comptroller, VToken: VToken}, NumberV>(`
+        #### VenusSupplySpeed
+
+        * "Comptroller VenusSupplySpeed vZRX
+      `,
+      "VenusSupplySpeed",
+      [
+        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("VToken", getVTokenV),
+      ],
+      async (world, {comptroller, VToken}) => {
+        return new NumberV(await comptroller.methods.venusSupplySpeeds(VToken._address).call());
+      }
+    ),
+    new Fetcher<{comptroller: Comptroller, VToken: VToken}, NumberV>(`
+        #### VenusBorrowSpeed
+
+        * "Comptroller VenusBorrowSpeed vZRX
+      `,
+      "VenusBorrowSpeed",
+      [
+        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("VToken", getVTokenV),
+      ],
+      async (world, {comptroller, VToken}) => {
+        return new NumberV(await comptroller.methods.venusBorrowSpeeds(VToken._address).call());
       }
     ),
     new Fetcher<{ comptroller: Comptroller, address: AddressV }, NumberV>(`

--- a/script/saddle/flywheelInit.js
+++ b/script/saddle/flywheelInit.js
@@ -145,8 +145,9 @@ let filterInitialized = async (borrowersByVToken) => {
 	let batchSize = 75;
 	console.log(`Calling venusBorrowerIndex for borrowers in batches of ${batchSize}...\n`);
 	for(let vTokenAddr of Object.keys(borrowersByVToken)) {
-		let speed = await call(Comptroller, 'venusSpeeds', [vTokenAddr]);
-		if (Number(speed) != 0){
+		let supplySpeed = await call(Comptroller, 'venusSupplySpeeds', [vTokenAddr]);
+		let borrowSpeed = await call(Comptroller, 'venusBorrowSpeeds', [vTokenAddr]);
+		if (Number(supplySpeed) != 0 || Number(borrowSpeed) != 0 ){
 			for (let borrowerChunk of getChunks(borrowersByVToken[vTokenAddr], batchSize)) {
 				try {
 					let indices = await Promise.all(borrowerChunk.map(

--- a/spec/scenario/Flywheel/Grants.scen
+++ b/spec/scenario/Flywheel/Grants.scen
@@ -49,8 +49,8 @@ Macro InitSpeeds
     Mint Coburn 6e18 vBAT--tokenbalance = 6e18 / 2e9 = 3e9
     EnterMarkets Coburn vBAT
     Borrow Coburn 1e18 vZRX
-    Comptroller SetVenusSpeed vZRX 1
-    Comptroller SetVenusSpeed vBAT 1
+    Comptroller SetVenusSpeed vZRX 1 1
+    Comptroller SetVenusSpeed vBAT 1 1
     Comptroller RefreshVenusSpeeds
     Comptroller Send "setXVSAddress(address)" (Address XVS)
 

--- a/spec/scenario/Flywheel/VenusSpeed.scen
+++ b/spec/scenario/Flywheel/VenusSpeed.scen
@@ -44,8 +44,8 @@ Macro InitSpeeds
     Mint Coburn 6e18 vBAT--tokenbalance = 6e18 / 2e9 = 3e9
     EnterMarkets Coburn vBAT
     Borrow Coburn 1e18 vZRX
-    Comptroller SetVenusSpeed vZRX 1
-    Comptroller SetVenusSpeed vBAT 1
+    Comptroller SetVenusSpeed vZRX 1 1
+    Comptroller SetVenusSpeed vBAT 1 1
     Comptroller RefreshVenusSpeeds
     Comptroller Send "setXVSAddress(address)" (Address XVS)
 
@@ -56,19 +56,19 @@ Test "XVS speed can be set per market"
     Assert Equal (Comptroller VenusAccrued Geoff) 0
     Assert Equal (Bep20 XVS TokenBalance Geoff) 0
     -- Venus speed can be set
-    Comptroller SetVenusSpeed vZRX 2
+    Comptroller SetVenusSpeed vZRX 2 2
     FastForward 1000 Blocks
     Comptroller ClaimVenus Geoff
     Assert Equal (Comptroller VenusAccrued Geoff) 0
     Assert Equal (Bep20 XVS TokenBalance Geoff) 2000
     -- Venus speed can be changed
-    Comptroller SetVenusSpeed vZRX 4
+    Comptroller SetVenusSpeed vZRX 4 4
     FastForward 1000 Blocks
     Comptroller ClaimVenus Geoff
     Assert Equal (Comptroller VenusAccrued Geoff) 0
     Assert Equal (Bep20 XVS TokenBalance Geoff) 6000
     -- Venus speed can be removed
-    Comptroller SetVenusSpeed vZRX 0
+    Comptroller SetVenusSpeed vZRX 0 0
     FastForward 1000 Blocks
     Comptroller ClaimVenus Geoff
     Assert Equal (Comptroller VenusAccrued Geoff) 0
@@ -83,7 +83,7 @@ Test "Set xvs rate is removed"
 Test "XVS is not claimed automatically"
     GrantsComptroller
     InitSpeeds
-    Comptroller SetVenusSpeed vZRX 2
+    Comptroller SetVenusSpeed vZRX 2 2
     FastForward 100000 Blocks
     -- Check xvs is not claimed automatically
     Mint Geoff 50e18 vZRX

--- a/spec/scenario/MintBnb.scen
+++ b/spec/scenario/MintBnb.scen
@@ -7,7 +7,7 @@ GasTest "Send Mint 1 vBNB"
     Expect Changes (VToken vBNB UnderlyingBalance Geoff) +0.005e18
     SendMintBnb Geoff 0.005e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
-    Assert LastGas LessThan 1.2e5
+    Assert LastGas LessThan 1.21e5
 
 GasTest "Call Mint 1 vBNB"
     NewComptroller
@@ -16,7 +16,7 @@ GasTest "Call Mint 1 vBNB"
     Expect Changes (VToken vBNB UnderlyingBalance Geoff) +0.005e18
     CallMintBnb Geoff 0.005e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
-    Assert LastGas LessThan 1.2e5
+    Assert LastGas LessThan 1.21e5
 
 Test "Mint with insufficient bnb balance"
     NewComptroller

--- a/tests/Contracts/ComptrollerHarness.sol
+++ b/tests/Contracts/ComptrollerHarness.sol
@@ -156,7 +156,7 @@ contract ComptrollerHarness is Comptroller {
         uint m = allMarkets.length;
         uint n = 0;
         for (uint i = 0; i < m; i++) {
-            if (venusSpeeds[address(allMarkets[i])] > 0) {
+            if (isVenusMarket(address(allMarkets[i]))) {
                 n++;
             }
         }
@@ -164,11 +164,15 @@ contract ComptrollerHarness is Comptroller {
         address[] memory venusMarkets = new address[](n);
         uint k = 0;
         for (uint i = 0; i < m; i++) {
-            if (venusSpeeds[address(allMarkets[i])] > 0) {
+            if (isVenusMarket(address(allMarkets[i]))) {
                 venusMarkets[k++] = address(allMarkets[i]);
             }
         }
         return venusMarkets;
+    }
+
+    function isVenusMarket(address market) internal view returns (bool) {
+        return venusSupplySpeeds[market] > 0 || venusBorrowSpeeds[market] > 0;
     }
 }
 

--- a/tests/Contracts/ComptrollerHarness.sol
+++ b/tests/Contracts/ComptrollerHarness.sol
@@ -68,7 +68,7 @@ contract ComptrollerHarness is Comptroller {
         Exp[] memory utilities = new Exp[](allMarkets_.length);
         for (uint i = 0; i < allMarkets_.length; i++) {
             VToken vToken = allMarkets_[i];
-            if (venusSpeeds[address(vToken)] > 0) {
+            if (venusSupplySpeeds[address(vToken)] > 0 || venusBorrowSpeeds[address(vToken)] > 0) {
                 Exp memory assetPrice = Exp({mantissa: oracle.getUnderlyingPrice(vToken)});
                 Exp memory utility = mul_(assetPrice, vToken.totalBorrows());
                 utilities[i] = utility;
@@ -79,7 +79,7 @@ contract ComptrollerHarness is Comptroller {
         for (uint i = 0; i < allMarkets_.length; i++) {
             VToken vToken = allMarkets[i];
             uint newSpeed = totalUtility.mantissa > 0 ? mul_(venusRate, div_(utilities[i], totalUtility)) : 0;
-            setVenusSpeedInternal(vToken, newSpeed);
+            setVenusSpeedInternal(vToken, newSpeed, newSpeed);
         }
     }
 
@@ -131,7 +131,7 @@ contract ComptrollerHarness is Comptroller {
     function harnessAddVenusMarkets(address[] memory vTokens) public {
         for (uint i = 0; i < vTokens.length; i++) {
             // temporarily set venusSpeed to 1 (will be fixed by `harnessRefreshVenusSpeeds`)
-            setVenusSpeedInternal(VToken(vTokens[i]), 1);
+            setVenusSpeedInternal(VToken(vTokens[i]), 1, 1);
         }
     }
 

--- a/tests/Contracts/ComptrollerScenario.sol
+++ b/tests/Contracts/ComptrollerScenario.sol
@@ -83,7 +83,7 @@ contract ComptrollerScenario is Comptroller {
         Exp[] memory utilities = new Exp[](allMarkets_.length);
         for (uint i = 0; i < allMarkets_.length; i++) {
             VToken vToken = allMarkets_[i];
-            if (venusSpeeds[address(vToken)] > 0) {
+            if (venusSupplySpeeds[address(vToken)] > 0 || venusBorrowSpeeds[address(vToken)] > 0) {
                 Exp memory assetPrice = Exp({mantissa: oracle.getUnderlyingPrice(vToken)});
                 Exp memory utility = mul_(assetPrice, vToken.totalBorrows());
                 utilities[i] = utility;
@@ -94,7 +94,7 @@ contract ComptrollerScenario is Comptroller {
         for (uint i = 0; i < allMarkets_.length; i++) {
             VToken vToken = allMarkets[i];
             uint newSpeed = totalUtility.mantissa > 0 ? mul_(venusRate, div_(utilities[i], totalUtility)) : 0;
-            setVenusSpeedInternal(vToken, newSpeed);
+            setVenusSpeedInternal(vToken, newSpeed, newSpeed);
         }
     }
 }

--- a/tests/Flywheel/FlywheelTest.js
+++ b/tests/Flywheel/FlywheelTest.js
@@ -517,7 +517,7 @@ describe('Flywheel', () => {
       const tx = await send(comptroller, 'claimVenus', [a2]);
       const a2AccruedPost = await venusAccrued(comptroller, a2);
       const xvsBalancePost = await xvsBalance(comptroller, a2);
-      expect(tx.gasUsed).toBeLessThan(400000);
+      expect(tx.gasUsed).toBeLessThan(500000);
       expect(speed).toEqualNumber(venusRate);
       expect(a2AccruedPre).toEqualNumber(0);
       expect(a2AccruedPost).toEqualNumber(0);

--- a/tests/Flywheel/FlywheelTest.js
+++ b/tests/Flywheel/FlywheelTest.js
@@ -13,6 +13,7 @@ const {
 } = require('../Utils/BSC');
 
 const venusRate = bnbUnsigned(1e18);
+const venusInitialIndex = 1e36;
 
 async function venusAccrued(comptroller, user) {
   return bnbUnsigned(await call(comptroller, 'venusAccrued', [user]));
@@ -174,7 +175,7 @@ describe('Flywheel', () => {
       ]);
 
       const {index, block} = await call(comptroller, 'venusBorrowState', [mkt._address]);
-      expect(index).toEqualNumber(0);
+      expect(index).toEqualNumber(venusInitialIndex);
       expect(block).toEqualNumber(100);
       const speed = await call(comptroller, 'venusSpeeds', [mkt._address]);
       expect(speed).toEqualNumber(0);
@@ -240,7 +241,7 @@ describe('Flywheel', () => {
       ]);
 
       const {index, block} = await call(comptroller, 'venusSupplyState', [mkt._address]);
-      expect(index).toEqualNumber(0);
+      expect(index).toEqualNumber(venusInitialIndex);
       expect(block).toEqualNumber(100);
       const speed = await call(comptroller, 'venusSpeeds', [mkt._address]);
       expect(speed).toEqualNumber(0);
@@ -377,7 +378,7 @@ describe('Flywheel', () => {
       await send(comptroller, "harnessDistributeBorrowerVenus", [mkt._address, a1, bnbExp(1.1)]);
       expect(await venusAccrued(comptroller, a1)).toEqualNumber(0);
       expect(await xvsBalance(comptroller, a1)).toEqualNumber(0);
-      expect(await call(comptroller, 'venusBorrowerIndex', [mkt._address, a1])).toEqualNumber(0);
+      expect(await call(comptroller, 'venusBorrowerIndex', [mkt._address, a1])).toEqualNumber(venusInitialIndex);
     });
   });
 

--- a/tests/Flywheel/GasTest.js
+++ b/tests/Flywheel/GasTest.js
@@ -18,13 +18,13 @@ describe.skip('Flywheel trace ops', () => {
     [root, a1, a2, a3, ...accounts] = saddle.accounts;
     comptroller = await makeComptroller();
     market = await makeVToken({comptroller, supportMarket: true, underlyingPrice: 3, interestRateModelOpts});
-    await send(comptroller, '_addVenusMarkets', [[market].map(c => c._address)]);
+    await send(comptroller, 'harnessAddVenusMarkets', [[market].map(c => c._address)]);
   });
 
   it('update supply index SSTOREs', async () => {
     await send(comptroller, 'setBlockNumber', [100]);
     await send(market, 'harnessSetTotalBorrows', [bnbUnsigned(11e18)]);
-    await send(comptroller, 'setVenusSpeed', [market._address, bnbExp(0.5)]);
+    await send(comptroller, '_setVenusSpeed', [market._address, bnbExp(0.5), bnbExp(0.5)]);
 
     const tx = await send(comptroller, 'harnessUpdateVenusSupplyIndex', [market._address]);
 
@@ -42,7 +42,7 @@ describe.skip('Flywheel trace ops', () => {
   it('update borrow index SSTOREs', async () => {
     await send(comptroller, 'setBlockNumber', [100]);
     await send(market, 'harnessSetTotalBorrows', [bnbUnsigned(11e18)]);
-    await send(comptroller, 'setVenusSpeed', [market._address, bnbExp(0.5)]);
+    await send(comptroller, '_setVenusSpeed', [market._address, bnbExp(0.5), bnbExp(0.5)]);
 
     const tx = await send(comptroller, 'harnessUpdateVenusBorrowIndex', [market._address, bnbExp(1.1)]);
 

--- a/tests/Utils/Venus.js
+++ b/tests/Utils/Venus.js
@@ -489,6 +489,16 @@ async function quickMintVAI(comptroller, vai, vaiMinter, vaiMintAmount, opts = {
   expect(await send(vai, 'harnessIncrementTotalSupply', [vaiMintAmount], { vaiMinter })).toSucceed();
 }
 
+async function quickBorrow(vToken, borrower, borrowAmount, opts = {}) {
+  // make sure to accrue interest
+  await fastForward(vToken, 1);
+
+  if (dfn(opts.exchangeRate))
+    expect(await send(vToken, 'harnessSetExchangeRate', [etherMantissa(opts.exchangeRate)])).toSucceed();
+
+  return send(vToken, 'borrow', [borrowAmount], { from: borrower });
+}
+
 async function preSupply(vToken, account, tokens, opts = {}) {
   if (dfn(opts.total, true)) {
     expect(await send(vToken, 'harnessSetTotalSupply', [tokens])).toSucceed();
@@ -582,6 +592,7 @@ module.exports = {
   quickMint,
   quickMintVAI,
 
+  quickBorrow,
   preSupply,
   quickRedeem,
   quickRedeemUnderlying,

--- a/tests/gasProfiler.js
+++ b/tests/gasProfiler.js
@@ -184,7 +184,7 @@ describe('Gas report', () => {
       let interestRateModelOpts = {borrowRate: 0.000001};
       vToken = await makeVToken({comptroller, supportMarket: true, underlyingPrice: 2, interestRateModelOpts});
       if (patch == 'unitroller') {
-        await send(comptroller, '_setVenusSpeed', [vToken._address, bnbExp(0.05)]);
+        await send(comptroller, '_setVenusSpeed', [vToken._address, bnbExp(0.05), bnbExp(0.05)]);
       } else {
         await send(comptroller, '_addVenusMarkets', [[vToken].map(c => c._address)]);
         await send(comptroller, 'setVenusSpeed', [vToken._address, bnbExp(0.05)]);


### PR DESCRIPTION
## Description

We need to set separate XVS speeds for borrow and supply (mostly because of the excessive XVS borrowing issue but also because this adds flexibility our risk team needs to adjust the rewards params).

There are also some bugs in the reward distribution mechanism that we inherited from Compound (see the corresponding [bug report](https://www.comp.xyz/t/comptroller-compspeed-bug/2111)).

This PR splits `venusSpeeds` into separate `venusSupplySpeeds` and `venusBorrowSpeeds` and fixes the distribution bugs by moving the market initialization into a separate internal function. The PR is loosely based on https://github.com/compound-finance/compound-protocol/pull/144, though some design decisions are different.

Docs, tests, and simulations are in progress, hence WIP.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
