### PR TITLE
multiple Governance Contracts

### DIFF
--- a/contracts/Governance/GovernorAlpha2.sol
+++ b/contracts/Governance/GovernorAlpha2.sol
@@ -1,0 +1,332 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+contract GovernorAlpha2 {
+    /// @notice The name of this contract
+    string public constant name = "Venus Governor Alpha";
+
+    /// @notice The number of votes in support of a proposal required in order for a quorum to be reached and for a vote to succeed
+    function quorumVotes() public pure returns (uint) { return 600000e18; } // 600,000 = 2% of XVS
+
+    /// @notice The number of votes required in order for a voter to become a proposer
+    function proposalThreshold() public pure returns (uint) { return 300000e18; } // 300,000 = 1% of XVS
+
+    /// @notice The maximum number of actions that can be included in a proposal
+    function proposalMaxOperations() public pure returns (uint) { return 30; } // 30 actions
+
+    /// @notice The delay before voting on a proposal may take place, once proposed
+    function votingDelay() public pure returns (uint) { return 1; } // 1 block
+
+    /// @notice The duration of voting on a proposal, in blocks
+    function votingPeriod() public pure returns (uint) { return 60 * 60 * 24 * 3 / 3; } // ~3 days in blocks (assuming 3s blocks)
+
+    /// @notice The address of the Venus Protocol Timelock
+    TimelockInterface public timelock;
+
+    /// @notice The address of the Venus governance token
+    XVSInterface public xvs;
+
+    /// @notice The address of the Governor Guardian
+    address public guardian;
+
+    /// @notice The total number of proposals
+    uint public proposalCount;
+
+    struct Proposal {
+        /// @notice Unique id for looking up a proposal
+        uint id;
+
+        /// @notice Creator of the proposal
+        address proposer;
+
+        /// @notice The timestamp that the proposal will be available for execution, set once the vote succeeds
+        uint eta;
+
+        /// @notice the ordered list of target addresses for calls to be made
+        address[] targets;
+
+        /// @notice The ordered list of values (i.e. msg.value) to be passed to the calls to be made
+        uint[] values;
+
+        /// @notice The ordered list of function signatures to be called
+        string[] signatures;
+
+        /// @notice The ordered list of calldata to be passed to each call
+        bytes[] calldatas;
+
+        /// @notice The block at which voting begins: holders must delegate their votes prior to this block
+        uint startBlock;
+
+        /// @notice The block at which voting ends: votes must be cast prior to this block
+        uint endBlock;
+
+        /// @notice Current number of votes in favor of this proposal
+        uint forVotes;
+
+        /// @notice Current number of votes in opposition to this proposal
+        uint againstVotes;
+
+        /// @notice Flag marking whether the proposal has been canceled
+        bool canceled;
+
+        /// @notice Flag marking whether the proposal has been executed
+        bool executed;
+
+        /// @notice Receipts of ballots for the entire set of voters
+        mapping (address => Receipt) receipts;
+    }
+
+    /// @notice Ballot receipt record for a voter
+    struct Receipt {
+        /// @notice Whether or not a vote has been cast
+        bool hasVoted;
+
+        /// @notice Whether or not the voter supports the proposal
+        bool support;
+
+        /// @notice The number of votes the voter had, which were cast
+        uint96 votes;
+    }
+
+    /// @notice Possible states that a proposal may be in
+    enum ProposalState {
+        Pending,
+        Active,
+        Canceled,
+        Defeated,
+        Succeeded,
+        Queued,
+        Expired,
+        Executed
+    }
+
+    /// @notice The official record of all proposals ever proposed
+    mapping (uint => Proposal) public proposals;
+
+    /// @notice The latest proposal for each proposer
+    mapping (address => uint) public latestProposalIds;
+
+    /// @notice The EIP-712 typehash for the contract's domain
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    /// @notice The EIP-712 typehash for the ballot struct used by the contract
+    bytes32 public constant BALLOT_TYPEHASH = keccak256("Ballot(uint256 proposalId,bool support)");
+
+    /// @notice An event emitted when a new proposal is created
+    event ProposalCreated(uint id, address proposer, address[] targets, uint[] values, string[] signatures, bytes[] calldatas, uint startBlock, uint endBlock, string description);
+
+    /// @notice An event emitted when a vote has been cast on a proposal
+    event VoteCast(address voter, uint proposalId, bool support, uint votes);
+
+    /// @notice An event emitted when a proposal has been canceled
+    event ProposalCanceled(uint id);
+
+    /// @notice An event emitted when a proposal has been queued in the Timelock
+    event ProposalQueued(uint id, uint eta);
+
+    /// @notice An event emitted when a proposal has been executed in the Timelock
+    event ProposalExecuted(uint id);
+
+    constructor(address timelock_, address xvs_, address guardian_, uint256 lastProposalId_) public {
+        timelock = TimelockInterface(timelock_);
+        xvs = XVSInterface(xvs_);
+        guardian = guardian_;
+        proposalCount = lastProposalId_;
+    }
+
+    function propose(address[] memory targets, uint[] memory values, string[] memory signatures, bytes[] memory calldatas, string memory description) public returns (uint) {
+        require(xvs.getPriorVotes(msg.sender, sub256(block.number, 1)) > proposalThreshold(), "GovernorAlpha::propose: proposer votes below proposal threshold");
+        require(targets.length == values.length && targets.length == signatures.length && targets.length == calldatas.length, "GovernorAlpha::propose: proposal function information arity mismatch");
+        require(targets.length != 0, "GovernorAlpha::propose: must provide actions");
+        require(targets.length <= proposalMaxOperations(), "GovernorAlpha::propose: too many actions");
+
+        uint latestProposalId = latestProposalIds[msg.sender];
+        if (latestProposalId != 0) {
+          ProposalState proposersLatestProposalState = state(latestProposalId);
+          require(proposersLatestProposalState != ProposalState.Active, "GovernorAlpha::propose: found an already active proposal");
+          require(proposersLatestProposalState != ProposalState.Pending, "GovernorAlpha::propose: found an already pending proposal");
+        }
+
+        uint startBlock = add256(block.number, votingDelay());
+        uint endBlock = add256(startBlock, votingPeriod());
+
+        proposalCount++;
+        Proposal memory newProposal = Proposal({
+            id: proposalCount,
+            proposer: msg.sender,
+            eta: 0,
+            targets: targets,
+            values: values,
+            signatures: signatures,
+            calldatas: calldatas,
+            startBlock: startBlock,
+            endBlock: endBlock,
+            forVotes: 0,
+            againstVotes: 0,
+            canceled: false,
+            executed: false
+        });
+
+        proposals[newProposal.id] = newProposal;
+        latestProposalIds[newProposal.proposer] = newProposal.id;
+
+        emit ProposalCreated(newProposal.id, msg.sender, targets, values, signatures, calldatas, startBlock, endBlock, description);
+        return newProposal.id;
+    }
+
+    function queue(uint proposalId) public {
+        require(state(proposalId) == ProposalState.Succeeded, "GovernorAlpha::queue: proposal can only be queued if it is succeeded");
+        Proposal storage proposal = proposals[proposalId];
+        uint eta = add256(block.timestamp, timelock.delay());
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            _queueOrRevert(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], eta);
+        }
+        proposal.eta = eta;
+        emit ProposalQueued(proposalId, eta);
+    }
+
+    function _queueOrRevert(address target, uint value, string memory signature, bytes memory data, uint eta) internal {
+        require(!timelock.queuedTransactions(keccak256(abi.encode(target, value, signature, data, eta))), "GovernorAlpha::_queueOrRevert: proposal action already queued at eta");
+        timelock.queueTransaction(target, value, signature, data, eta);
+    }
+
+    function execute(uint proposalId) public payable {
+        require(state(proposalId) == ProposalState.Queued, "GovernorAlpha::execute: proposal can only be executed if it is queued");
+        Proposal storage proposal = proposals[proposalId];
+        proposal.executed = true;
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            timelock.executeTransaction.value(proposal.values[i])(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+        }
+        emit ProposalExecuted(proposalId);
+    }
+
+    function cancel(uint proposalId) public {
+        ProposalState state = state(proposalId);
+        require(state != ProposalState.Executed, "GovernorAlpha::cancel: cannot cancel executed proposal");
+
+        Proposal storage proposal = proposals[proposalId];
+        require(msg.sender == guardian || xvs.getPriorVotes(proposal.proposer, sub256(block.number, 1)) < proposalThreshold(), "GovernorAlpha::cancel: proposer above threshold");
+
+        proposal.canceled = true;
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            timelock.cancelTransaction(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+        }
+
+        emit ProposalCanceled(proposalId);
+    }
+
+    function getActions(uint proposalId) public view returns (address[] memory targets, uint[] memory values, string[] memory signatures, bytes[] memory calldatas) {
+        Proposal storage p = proposals[proposalId];
+        return (p.targets, p.values, p.signatures, p.calldatas);
+    }
+
+    function getReceipt(uint proposalId, address voter) public view returns (Receipt memory) {
+        return proposals[proposalId].receipts[voter];
+    }
+
+    function state(uint proposalId) public view returns (ProposalState) {
+        require(proposalCount >= proposalId && proposalId > 0, "GovernorAlpha::state: invalid proposal id");
+        Proposal storage proposal = proposals[proposalId];
+        if (proposal.canceled) {
+            return ProposalState.Canceled;
+        } else if (block.number <= proposal.startBlock) {
+            return ProposalState.Pending;
+        } else if (block.number <= proposal.endBlock) {
+            return ProposalState.Active;
+        } else if (proposal.forVotes <= proposal.againstVotes || proposal.forVotes < quorumVotes()) {
+            return ProposalState.Defeated;
+        } else if (proposal.eta == 0) {
+            return ProposalState.Succeeded;
+        } else if (proposal.executed) {
+            return ProposalState.Executed;
+        } else if (block.timestamp >= add256(proposal.eta, timelock.GRACE_PERIOD())) {
+            return ProposalState.Expired;
+        } else {
+            return ProposalState.Queued;
+        }
+    }
+
+    function castVote(uint proposalId, bool support) public {
+        return _castVote(msg.sender, proposalId, support);
+    }
+
+    function castVoteBySig(uint proposalId, bool support, uint8 v, bytes32 r, bytes32 s) public {
+        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), getChainId(), address(this)));
+        bytes32 structHash = keccak256(abi.encode(BALLOT_TYPEHASH, proposalId, support));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "GovernorAlpha::castVoteBySig: invalid signature");
+        return _castVote(signatory, proposalId, support);
+    }
+
+    function _castVote(address voter, uint proposalId, bool support) internal {
+        require(state(proposalId) == ProposalState.Active, "GovernorAlpha::_castVote: voting is closed");
+        Proposal storage proposal = proposals[proposalId];
+        Receipt storage receipt = proposal.receipts[voter];
+        require(receipt.hasVoted == false, "GovernorAlpha::_castVote: voter already voted");
+        uint96 votes = xvs.getPriorVotes(voter, proposal.startBlock);
+
+        if (support) {
+            proposal.forVotes = add256(proposal.forVotes, votes);
+        } else {
+            proposal.againstVotes = add256(proposal.againstVotes, votes);
+        }
+
+        receipt.hasVoted = true;
+        receipt.support = support;
+        receipt.votes = votes;
+
+        emit VoteCast(voter, proposalId, support, votes);
+    }
+
+    function __acceptAdmin() public {
+        require(msg.sender == guardian, "GovernorAlpha::__acceptAdmin: sender must be gov guardian");
+        timelock.acceptAdmin();
+    }
+
+    function __abdicate() public {
+        require(msg.sender == guardian, "GovernorAlpha::__abdicate: sender must be gov guardian");
+        guardian = address(0);
+    }
+
+    function __queueSetTimelockPendingAdmin(address newPendingAdmin, uint eta) public {
+        require(msg.sender == guardian, "GovernorAlpha::__queueSetTimelockPendingAdmin: sender must be gov guardian");
+        timelock.queueTransaction(address(timelock), 0, "setPendingAdmin(address)", abi.encode(newPendingAdmin), eta);
+    }
+
+    function __executeSetTimelockPendingAdmin(address newPendingAdmin, uint eta) public {
+        require(msg.sender == guardian, "GovernorAlpha::__executeSetTimelockPendingAdmin: sender must be gov guardian");
+        timelock.executeTransaction(address(timelock), 0, "setPendingAdmin(address)", abi.encode(newPendingAdmin), eta);
+    }
+
+    function add256(uint256 a, uint256 b) internal pure returns (uint) {
+        uint c = a + b;
+        require(c >= a, "addition overflow");
+        return c;
+    }
+
+    function sub256(uint256 a, uint256 b) internal pure returns (uint) {
+        require(b <= a, "subtraction underflow");
+        return a - b;
+    }
+
+    function getChainId() internal pure returns (uint) {
+        uint chainId;
+        assembly { chainId := chainid() }
+        return chainId;
+    }
+}
+
+interface TimelockInterface {
+    function delay() external view returns (uint);
+    function GRACE_PERIOD() external view returns (uint);
+    function acceptAdmin() external;
+    function queuedTransactions(bytes32 hash) external view returns (bool);
+    function queueTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external returns (bytes32);
+    function cancelTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external;
+    function executeTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external payable returns (bytes memory);
+}
+
+interface XVSInterface {
+    function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
+}

--- a/networks/testnet.json
+++ b/networks/testnet.json
@@ -1,0 +1,237 @@
+{
+    "Contracts": {
+      "VenusLens": "0x40e42Ad74AA4c61B577387821e845a8892E65002",
+      "WhitepaperInterestRateModel": "0xdE9beC5102ee897a2c934321309517dD6c0106F4",
+      "Comptroller": "0xb3BEf8955E047B734EBBe6903eD2e3C467cBC0bb",
+      "Unitroller": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",
+      "VaiUnitroller": "0xf70C3C6b749BbAb89C081737334E74C9aFD4BE16",
+      "VaiController": "0xada3E8CF9d5Bc965B38c84EA2306DC6AaDa68127",
+      "vBep20Delegate": "0xAF1b4826c8396A99139af3c9359044D34c8d1f1f",
+      "SXP": "0x75107940Cf1121232C0559c747A986DEfbc69DA9",
+      "VAI": "0x5fFbE5302BadED40941A403228E6AD03f93752d9",
+      "USDC": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
+      "USDT": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
+      "BUSD": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
+      "XVS": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
+      "vUSDC": "0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7",
+      "vUSDT": "0xb7526572FFE56AB9D7489838Bf2E18e3323b441A",
+      "vBUSD": "0x08e0A5575De71037aE36AbfAfb516595fE68e5e4",
+      "vSXP": "0x74469281310195A04840Daf6EdF576F559a3dE80",
+      "vBNB": "0x2E7222e51c0f6e98610A1543Aa3836E092CDe62c",
+      "vXVS": "0x6d6F697e34145Bb95c54E77482d97cc261Dc237E",
+      "Timelock": "0xce10739590001705F7FF231611ba4A48B2820327",
+      "GovernorAlpha": "0x1723E473EeE90799Fb62742A5511884D29798564",
+      "GovernorAlpha2": "0xC588bA63301907Cff1AfB9294c8F666936a70910",
+      "VenusPriceOracle": "0xd61c7Fa07dF7241812eA6D21744a61f1257D1818",
+      "Base200bps_Slope2000bps_Jump2000bps_Kink90":  "0x3d845879cdB70bCC9aF73145d7FFD6C5FF8C1c6c"
+    },
+    "Accounts": {
+        "admin": "0x2Ce1d0ffD7E869D9DF33e28552b12DdDed326706",
+        "Guardian" : "0x2Ce1d0ffD7E869D9DF33e28552b12DdDed326706",
+        "eta": 1634292896
+    },
+    "Blocks": {
+      "VenusLens": 2918075,
+      "WhitepaperInterestRateModel": 2821193,
+      "Comptroller": 3855578,
+      "Unitroller": 2802486,
+      "VaiUnitroller": 3226318,
+      "VaiController": 3855597,
+      "vBep20Delegate": 2803834,
+      "SXP": 2801890,
+      "VAI": 3226301,
+      "USDC": 2801851,
+      "USDT": 2801864,
+      "BUSD": 2801879,
+      "XVS": 2802593,
+      "vUSDC": 2824822,
+      "vUSDT": 2824840,
+      "vBUSD": 2824859,
+      "vSXP": 2824876,
+      "vBNB": 2821647,
+      "vXVS": 3557911,
+      "Timelock": 2806175,
+      "GovernorAlpha": 2806251,
+      "GovernorAlpha2": 0,
+      "VenusPriceOracle": 3553192,
+      "Base200bps_Slope2000bps_Jump2000bps_Kink90": 2803749
+    },
+    "VenusLens": {
+      "name": "VenusLens",
+      "contract": "VenusLens"
+    },
+    "Unitroller": {
+      "description": "Unitroller",
+      "address": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D"
+    },
+    "Comptroller": {
+      "Comptroller": {
+        "address": "0xb3BEf8955E047B734EBBe6903eD2e3C467cBC0bb",
+        "contract": "Comptroller",
+        "description": "Venus Comptroller Contract"
+      }
+    },
+    "Timelock": {
+      "Timelock": {
+        "address": "0xce10739590001705F7FF231611ba4A48B2820327",
+        "contract": "Timelock",
+        "description": "Timelock"
+      }
+    },
+    "Constructors": {
+      "VenusLens": "0x",
+      "WhitepaperInterestRateModel": "00000000000000000000000000000000000000000000000000470de4df820000000000000000000000000000000000000000000000000000016345785d8a0000",
+      "Comptroller": "0x",
+      "Unitroller": "0x",
+      "VaiUnitroller": "0x",
+      "VaiController": "0x",
+      "vBep20Delegate": "0x",
+      "VAI": "0000000000000000000000000000000000000000000000000000000000000061",
+      "XVS": "0000000000000000000000002ce1d0ffd7e869d9df33e28552b12ddded326706",
+      "vUSDC": "0x",
+      "vUSDT": "0x",
+      "vBUSD": "0x",
+      "vSXP": "0x",
+      "vBNB": "0x",
+      "vXVS": "0x",
+      "Timelock": "0000000000000000000000002ce1d0ffd7e869d9df33e28552b12ddded3267060000000000000000000000000000000000000000000000000000000000000258",
+      "GovernorAlpha": "000000000000000000000000ce10739590001705f7ff231611ba4a48b2820327000000000000000000000000b9e0e753630434d7863528cc73cb7ac638a7c8ff0000000000000000000000002ce1d0ffd7e869d9df33e28552b12ddded326706",
+      "GovernorAlpha2": "0x000000000000000000000000ce10739590001705f7ff231611ba4a48b2820327000000000000000000000000b9e0e753630434d7863528cc73cb7ac638a7c8ff0000000000000000000000002ce1d0ffd7e869d9df33e28552b12ddded3267060000000000000000000000000000000000000000000000000000000000000064",
+      "VenusPriceOracle": "0x000000000000000000000000da7a001b254cd22e46d3eab04d937489c93174c3",
+      "Base200bps_Slope2000bps_Jump2000bps_Kink90":  "00000000000000000000000000000000000000000000000000470de4df82000000000000000000000000000000000000000000000000000002c68af0bb1400000000000000000000000000000000000000000000000000001bc16d674ec800000000000000000000000000000000000000000000000000000c7d713b49da0000"
+    },
+    "Tokens": {
+      "SXP": {
+        "name": "Swipe Token",
+        "symbol": "SXP",
+        "decimals": 18,
+        "address": "0x75107940Cf1121232C0559c747A986DEfbc69DA9",
+        "contract": "SwipeToken"
+      },
+      "VAI": {
+        "name": "Venus Stablecoin",
+        "symbol": "VAI",
+        "decimals": 18,
+        "address": "0x5fFbE5302BadED40941A403228E6AD03f93752d9"
+      },
+      "USDC": {
+        "name": "USD Coin",
+        "symbol": "USDC",
+        "decimals": 6,
+        "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
+        "contract": "FaucetToken"
+      },
+      "USDT": {
+        "name": "Tether",
+        "symbol": "USDT",
+        "decimals": 6,
+        "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
+        "contract": "FaucetToken"
+      },
+      "XVS": {
+        "name": "Venus",
+        "symbol": "XVS",
+        "decimals": 18,
+        "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff"
+      },
+      "BNB": {
+        "name": "BNB",
+        "symbol": "BNB",
+        "decimals": 18,
+        "address": "0x0000000000000000000000000000000000000000"
+      }
+    },
+    "VTokenDelegate": {
+      "VTokenDelegate": {
+        "address": "0xAF1b4826c8396A99139af3c9359044D34c8d1f1f",
+        "contract": "VBep20Delegate",
+        "description": "Delegate VBep20Delegate"
+      }
+    },
+    "vTokens": {
+      "vUSDC": {
+        "name": "Venus USDC",
+        "symbol": "vUSDC",
+        "decimals": 8,
+        "address": "0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7",
+        "initial_exchange_rate_mantissa": "20000000000000000",
+        "admin": "0x2Ce1d0ffD7E869D9DF33e28552b12DdDed326706",
+        "underlying": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
+        "contract": "VBep20Immutable"
+      },
+      "vUSDT": {
+        "name": "Venus USDT",
+        "symbol": "vUSDT",
+        "decimals": 8,
+        "address": "0xb7526572FFE56AB9D7489838Bf2E18e3323b441A",
+        "initial_exchange_rate_mantissa": "20000000000000000",
+        "admin": "0x2Ce1d0ffD7E869D9DF33e28552b12DdDed326706",
+        "underlying": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
+        "contract": "VBep20Immutable"
+      },
+      "vBUSD": {
+        "name": "Venus BUSD",
+        "symbol": "vBUSD",
+        "decimals": 8,
+        "address": "0x08e0A5575De71037aE36AbfAfb516595fE68e5e4",
+        "initial_exchange_rate_mantissa": "20000000000000000",
+        "admin": "0x2Ce1d0ffD7E869D9DF33e28552b12DdDed326706",
+        "underlying": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
+        "contract": "VBep20Immutable"
+      },
+      "vSXP": {
+        "name": "Venus SXP",
+        "symbol": "vSXP",
+        "decimals": 8,
+        "address": "0x74469281310195A04840Daf6EdF576F559a3dE80",
+        "initial_exchange_rate_mantissa": "20000000000000000",
+        "admin": "0x2Ce1d0ffD7E869D9DF33e28552b12DdDed326706",
+        "underlying": "0x75107940Cf1121232C0559c747A986DEfbc69DA9",
+        "contract": "VBep20Immutable"
+      },
+      "vBNB": {
+        "name": "Venus BNB",
+        "symbol": "vBNB",
+        "decimals": 8,
+        "address": "0x2E7222e51c0f6e98610A1543Aa3836E092CDe62c",
+        "initial_exchange_rate_mantissa": "20000000000000000",
+        "admin": "0x2Ce1d0ffD7E869D9DF33e28552b12DdDed326706",
+        "underlying": "",
+        "contract": "VBNB"
+      },
+      "vXVS": {
+        "name": "Venus XVS",
+        "symbol": "vXVS",
+        "decimals": 8,
+        "address": "0x6d6F697e34145Bb95c54E77482d97cc261Dc237E",
+        "initial_exchange_rate_mantissa": "20000000000000000",
+        "admin": "0x2Ce1d0ffD7E869D9DF33e28552b12DdDed326706",
+        "underlying": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
+        "contract": "VBep20Immutable"
+      }
+    },
+    "InterestRateModel": {
+      "Base200bps_Slope2000bps_Jump20000bps_Kink90": {
+        "name": "Base200bps_Slope2000bps_Jump20000bps_Kink90",
+        "contract": "JumpRateModel",
+        "description": "JumpRateModel  baseRate=20000000000000000 multiplier=200000000000000000 jump=2000000000000000000 kink=900000000000000000",
+        "address": "0x3d845879cdB70bCC9aF73145d7FFD6C5FF8C1c6c",
+        "base": "20000000000000000",
+        "slope": "200000000000000000",
+        "jump": "2000000000000000000",
+        "kink": "900000000000000000"
+      },
+      "Base200bps_Slope1000bps": {
+        "name": "Base200bps_Slope1000bps",
+        "contract": "WhitePaperInterestRateModel",
+        "description": "WhitePaperInterestRateModel  baseRate=20000000000000000 multiplier=100000000000000000",
+        "address": "0xdE9beC5102ee897a2c934321309517dD6c0106F4",
+        "base": "20000000000000000",
+        "slope": "100000000000000000"
+      }
+    },
+    "PriceOracle": {
+      "description": "VenusPriceOracle",
+      "address": "0xd61c7Fa07dF7241812eA6D21744a61f1257D1818"
+    }
+  }

--- a/saddle.config.js
+++ b/saddle.config.js
@@ -156,6 +156,31 @@ module.exports = {
         {unlocked: 0}
       ]
     },
+    testnet: {
+      providers: [
+        {env: "PROVIDER"},
+        {file: "~/.bsc/testnet-url"}
+      ],
+      web3: {
+        gas: [
+          {env: "GAS"},
+          {default: "5900000"}
+        ],
+        gas_price: [
+          {env: "GAS_PRICE"},
+          {default: "20000000000"} //20 GWei
+        ],
+        options: {
+          transactionConfirmationBlocks: 1,
+          transactionBlockTimeout: 500
+        }
+      },
+      accounts: [
+        {env: "ACCOUNT"},
+        {file: "~/.bsc/testnet"},                        // Load from given file with contents as the private key (e.g. 0x...)
+        {unlocked: 0}
+      ]
+    },
     kovan: {
       providers: [
         {env: "PROVIDER"},

--- a/script/deploy/governor-alpha-2/accept-governor-alpha-2-as-admin.js
+++ b/script/deploy/governor-alpha-2/accept-governor-alpha-2-as-admin.js
@@ -1,0 +1,11 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+
+  const governorAlpha2ContractInstance = await saddle.getContractAt('GovernorAlpha2', governorAlpha2Address);
+
+  await governorAlpha2ContractInstance.methods.__acceptAdmin().send();
+
+})();

--- a/script/deploy/governor-alpha-2/cast-vote-on-governor-alpha-2.js
+++ b/script/deploy/governor-alpha-2/cast-vote-on-governor-alpha-2.js
@@ -1,0 +1,13 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  //Timelock
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+
+  const governorAlpha2ContractInstance = await saddle.getContractAt('GovernorAlpha2', governorAlpha2Address);
+
+  const castVoteTxn = await governorAlpha2ContractInstance.methods.castVote(101, true).send();
+
+  console.log(`casted Vote on GovernorAlpha2 with transactionStatus: ${castVoteTxn.status}`);
+})();

--- a/script/deploy/governor-alpha-2/create-proposal-on-governor-alpha-2.js
+++ b/script/deploy/governor-alpha-2/create-proposal-on-governor-alpha-2.js
@@ -1,0 +1,20 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+
+  const governorAlpha2ContractInstance = await saddle.getContractAt('GovernorAlpha2', governorAlpha2Address);
+  const timelockAddress =  contractConfigData.Contracts.Timelock;
+  const payload = web3.eth.abi.encodeParameter('address', '0x0000000000000000000000000000000000000000');
+
+  const txn = await governorAlpha2ContractInstance.methods.propose(
+    [timelockAddress],
+    [0],
+    ['_setPendingAdmin(address)'], 
+    [payload],
+    "test on governorAlpha2 for _setPendingAdmin to 0x address ").send();
+
+  console.log(`GovernorAlpha2 - proposed ZeroAddress as PendingAdmin for timelock :: with transactionStatus ${txn.status}`);  
+
+})();

--- a/script/deploy/governor-alpha-2/deploy-governor-alpha-2.js
+++ b/script/deploy/governor-alpha-2/deploy-governor-alpha-2.js
@@ -1,0 +1,13 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {
+  const timelockAddress = contractConfigData.Contracts.Timelock;
+  const xvsAddress = contractConfigData.Tokens.XVS.address;
+  const guardian = contractConfigData.Accounts.Guardian;
+  const constructorArgumentArray = [timelockAddress, xvsAddress, guardian, 100];
+  console.log(`Deploying GovernorAlpha2 with timelockAddress, xvsAddress, guardian in constructorArguments: ${constructorArgumentArray}`);
+  
+  let deployedGovernorAlpha2 = await saddle.deploy('GovernorAlpha2', constructorArgumentArray);
+  const constructorData = web3.eth.abi.encodeParameters(['address','address','address', 'uint256'], constructorArgumentArray);
+  console.log(`Deployed GovernorAlpha2 to ${deployedGovernorAlpha2._address} with constructorData: ${constructorData}`);
+})();

--- a/script/deploy/governor-alpha-2/execute-proposal-on-governor-alpha-2.js
+++ b/script/deploy/governor-alpha-2/execute-proposal-on-governor-alpha-2.js
@@ -1,0 +1,14 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+
+  const governorAlpha2ContractInstance = await saddle.getContractAt('GovernorAlpha2', governorAlpha2Address);
+
+  const proposalId = 101;
+
+  const castVoteTxn = await governorAlpha2ContractInstance.methods.execute(proposalId).send();
+
+  console.log(`executed Proposal: ${proposalId} on GovernorAlpha2 with transactionStatus: ${castVoteTxn.status}`);
+})();

--- a/script/deploy/governor-alpha-2/query-on-governor-alpha-2.js
+++ b/script/deploy/governor-alpha-2/query-on-governor-alpha-2.js
@@ -1,0 +1,17 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+
+  const governorAlpha2ContractInstance = await saddle.getContractAt('GovernorAlpha2', governorAlpha2Address);
+
+  const proposalCount = await governorAlpha2ContractInstance.methods.proposalCount().call();
+
+  console.log(`proposalCount on governorAlpha2 ${governorAlpha2Address} is: ${proposalCount}`);
+
+  const votingPeriod = await governorAlpha2ContractInstance.methods.votingPeriod().call();
+
+  console.log(`votingPeriod on governorAlpha2 ${governorAlpha2Address} is: ${votingPeriod}`);
+
+})();

--- a/script/deploy/governor-alpha-2/query-proposal-governor-alpha-2.js
+++ b/script/deploy/governor-alpha-2/query-proposal-governor-alpha-2.js
@@ -1,0 +1,12 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+
+  const governorAlpha2ContractInstance = await saddle.getContractAt('GovernorAlpha2', governorAlpha2Address);
+
+  const proposalInfo = await governorAlpha2ContractInstance.methods.proposals(101).call();
+
+  console.log(`proposalInfo on governorAlpha2 ${governorAlpha2Address} is: ${JSON.stringify(proposalInfo)}`);
+})();

--- a/script/deploy/governor-alpha-2/queue-proposal-on-governor-alpha-2.js
+++ b/script/deploy/governor-alpha-2/queue-proposal-on-governor-alpha-2.js
@@ -1,0 +1,14 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+
+  const governorAlpha2ContractInstance = await saddle.getContractAt('GovernorAlpha2', governorAlpha2Address);
+
+  const proposalId = 101;
+
+  const castVoteTxn = await governorAlpha2ContractInstance.methods.queue(proposalId).send();
+
+  console.log(`Queued Proposal: ${proposalId} on GovernorAlpha2 with transactionStatus: ${castVoteTxn.status}`);
+})();

--- a/script/deploy/governor-alpha/deploy-guide.md
+++ b/script/deploy/governor-alpha/deploy-guide.md
@@ -1,0 +1,17 @@
+# GovernorAlpha Deployment Guide
+
+1. GovernorAlpha2
+
+ - deploy GovernorAlpha2 Contract to bsc-testnet
+
+```sh
+npx saddle script script/deploy/governor-alpha/deploy-governor-alpha-2.js -n testnet
+```
+
+Copy GovernorAlpha2 address from command console to JSON object in testnet.json
+
+2. set GovernorAlpha2 as admin to Timelock
+
+```sh
+npx saddle script script/deploy/governor-alpha/set-goveror-alpha-2-as-admin.js -n testnet
+```

--- a/script/deploy/governor-alpha/execute-governor-alpha-2-as-timelock-admin.js
+++ b/script/deploy/governor-alpha/execute-governor-alpha-2-as-timelock-admin.js
@@ -1,0 +1,19 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {
+
+  const governorAlphaAddress = contractConfigData.Contracts.GovernorAlpha;
+
+  const governorAlphaContractInstance = await saddle.getContractAt('GovernorAlpha', governorAlphaAddress);
+
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+  const eta = contractConfigData.Accounts.eta;
+
+  console.log(`execute SetTimelockPendingAdmin with governorAlpha2: ${governorAlpha2Address} - eta: ${eta}`);
+
+  const executeSetTimelockPendingAdminTxn = 
+  await governorAlphaContractInstance.methods.__executeSetTimelockPendingAdmin(governorAlpha2Address, eta).send();
+
+  console.log(`executeSetTimelockPendingAdminTxn is: ${executeSetTimelockPendingAdminTxn.status}`);
+                                                                       
+})();

--- a/script/deploy/governor-alpha/query-on-governor-alpha.js
+++ b/script/deploy/governor-alpha/query-on-governor-alpha.js
@@ -1,0 +1,12 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  const governorAlphaAddress = contractConfigData.Contracts.GovernorAlpha;
+
+  const governorAlphaContractInstance = await saddle.getContractAt('GovernorAlpha', governorAlphaAddress);
+
+  const proposalCount = await governorAlphaContractInstance.methods.proposalCount().call();
+
+  console.log(`proposalCount on governorAlpha ${governorAlphaAddress} is: ${proposalCount}`);
+})();

--- a/script/deploy/governor-alpha/queue-governor-alpha-2-as-timelock-admin.js
+++ b/script/deploy/governor-alpha/queue-governor-alpha-2-as-timelock-admin.js
@@ -1,0 +1,24 @@
+const contractConfigData = require("../../../networks/testnet.json");
+const { bnbUnsigned } = require('../utils/web3-utils');
+
+(async () => {  
+
+  const governorAlphaAddress = contractConfigData.Contracts.GovernorAlpha;
+
+  const governorAlphaContractInstance = await saddle.getContractAt('GovernorAlpha', governorAlphaAddress);
+
+  const governorAlpha2Address = contractConfigData.Contracts.GovernorAlpha2;
+
+  const delay = bnbUnsigned(600);
+  const blockNumber = await saddle.web3.eth.getBlockNumber();
+  const block = await saddle.web3.eth.getBlock(blockNumber);
+  const timestamp = block.timestamp;
+  const eta = bnbUnsigned(timestamp).add(delay).add(120);
+
+  console.log(`queueing SetTimelockPendingAdmin with governorAlpha2: ${governorAlpha2Address} - configuredDelay: ${delay},  eta: ${eta}`);
+
+  const queueSetTimelockPendingAdminTxn = 
+    await governorAlphaContractInstance.methods.__queueSetTimelockPendingAdmin(governorAlpha2Address, eta).send();
+
+  console.log(`queueSetTimelockPendingAdminTxn is: ${queueSetTimelockPendingAdminTxn.status}`);                                                                              
+})();

--- a/script/deploy/timelock/query-on-timelock.js
+++ b/script/deploy/timelock/query-on-timelock.js
@@ -1,0 +1,12 @@
+const contractConfigData = require("../../../networks/testnet.json");
+
+(async () => {  
+
+  const timelockAddress = contractConfigData.Contracts.Timelock;
+
+  const timelockContractInstance = await saddle.getContractAt('Timelock', timelockAddress);
+
+  const delay = await timelockContractInstance.methods.delay().call();
+
+  console.log(`delay on Timelock ${timelockAddress} is: ${delay}`);
+})();

--- a/script/deploy/utils/web3-utils.js
+++ b/script/deploy/utils/web3-utils.js
@@ -1,0 +1,125 @@
+"use strict";
+
+const BigNum = require('bignumber.js');
+const ethers = require('ethers');
+
+function address(n) {
+  return `0x${n.toString(16).padStart(40, '0')}`;
+}
+
+function encodeParameters(types, values) {
+  const abi = new ethers.utils.AbiCoder();
+  return abi.encode(types, values);
+}
+
+function sleep(timeout) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve();
+    }, timeout);
+  });
+}
+
+async function bnbBalance(addr) {
+  return ethers.utils.bigNumberify(new BigNum(await web3.eth.getBalance(addr)).toFixed());
+}
+
+async function bnbGasCost(receipt) {
+  const tx = await web3.eth.getTransaction(receipt.transactionHash);
+  const gasUsed = new BigNum(receipt.gasUsed);
+  const gasPrice = new BigNum(tx.gasPrice);
+  return ethers.utils.bigNumberify(gasUsed.times(gasPrice).toFixed());
+}
+
+function bnbExp(num) { return bnbMantissa(num, 1e18) }
+function bnbDouble(num) { return bnbMantissa(num, 1e36) }
+function bnbMantissa(num, scale = 1e18) {
+  if (num < 0)
+    return ethers.utils.bigNumberify(new BigNum(2).pow(256).plus(num).toFixed());
+  return ethers.utils.bigNumberify(new BigNum(num).times(scale).toFixed());
+}
+
+function bnbUnsigned(num) {
+  return ethers.utils.bigNumberify(new BigNum(num).toFixed());
+}
+
+function mergeInterface(into, from) {
+  const key = (item) => item.inputs ? `${item.name}/${item.inputs.length}` : item.name;
+  const existing = into.options.jsonInterface.reduce((acc, item) => {
+    acc[key(item)] = true;
+    return acc;
+  }, {});
+  const extended = from.options.jsonInterface.reduce((acc, item) => {
+    if (!(key(item) in existing))
+      acc.push(item)
+    return acc;
+  }, into.options.jsonInterface.slice());
+  into.options.jsonInterface = into.options.jsonInterface.concat(from.options.jsonInterface);
+  return into;
+}
+
+function getContractDefaults() {
+  return { gas: 20000000, gasPrice: 20000 };
+}
+
+function keccak256(values) {
+  return ethers.utils.keccak256(values);
+}
+
+function unlockedAccounts() {
+  let provider = web3.currentProvider;
+  if (provider._providers)
+    provider = provider._providers.find(p => p._ganacheProvider)._ganacheProvider;
+  return provider.manager.state.unlocked_accounts;
+}
+
+function unlockedAccount(a) {
+  return unlockedAccounts()[a.toLowerCase()];
+}
+
+async function getblockNumber() {
+  let { result: num } = await rpc({ method: 'eth_blockNumber' });
+  return parseInt(num);
+}
+
+async function getBlockTimestamp() {
+  const blockNumber = await getblockNumber();
+  const blockRsp = await rpc({method: 'eth_getBlockByNumber', params: [blockNumber]});
+  return blockRsp ? blockTimestampRsp.timestamp : 0;
+}
+
+async function rpc(request) {
+  return new Promise((okay, fail) => web3.currentProvider.send(request, (err, res) => err ? fail(err) : okay(res)));
+}
+
+async function both(contract, method, args = [], opts = {}) {
+  const reply = await call(contract, method, args, opts);
+  const receipt = await send(contract, method, args, opts);
+  return { reply, receipt };
+}
+
+async function sendFallback(contract, opts = {}) {
+  const receipt = await web3.eth.sendTransaction({ to: contract._address, ...Object.assign(getContractDefaults(), opts) });
+  return Object.assign(receipt, { events: receipt.logs });
+}
+
+module.exports = {
+  address,
+  encodeParameters,
+  bnbBalance,
+  bnbGasCost,
+  bnbExp,
+  bnbDouble,
+  bnbMantissa,
+  bnbUnsigned,
+  mergeInterface,
+  keccak256,
+  unlockedAccounts,
+  unlockedAccount,
+  getblockNumber,
+  getBlockTimestamp,
+  rpc,
+  both,
+  sendFallback,
+  sleep
+};


### PR DESCRIPTION
## Description

New GovernorAlpha contract: GovernorAlpha2 
 - identical to GovernorAlpha contract, with additional changes as listed below:
     - increased `proposalMaxOperations` from 10 to 30
     - constructor with addtional argument: `lastProposalId_`
     
```js
    constructor(address timelock_, address xvs_, address guardian_, uint256 lastProposalId_) public {
        timelock = TimelockInterface(timelock_);
        xvs = XVSInterface(xvs_);
        guardian = guardian_;
        proposalCount = lastProposalId_;
    }
```

- `lastProposalId_` will be set to `proposalCount`
-  Proposals on new `GovernorAlpha2` start from the index where the `GovernorAlpha` ended
     - ended on `GovernorAlpha`  means, all new proposals to be made on `GovernorAlpha2`

## Deployment summary:

1. query the `proposalCount` of `GovernorAlpha` Contract
2. use the value queried as the constructor argument of `GovernorAlpha2`


