### PR TITLE
Add a guardian to Governor Bravo

### DIFF
--- a/contracts/Governance/GovernorBravoInterfaces.sol
+++ b/contracts/Governance/GovernorBravoInterfaces.sol
@@ -40,6 +40,9 @@ contract GovernorBravoEvents {
 
     /// @notice Emitted when pendingAdmin is accepted, which means admin is updated
     event NewAdmin(address oldAdmin, address newAdmin);
+
+    /// @notice Emitted when the new guardian address is set
+    event NewGuardian(address oldGuardian, address newGuardian);
 }
 
 contract GovernorBravoDelegatorStorage {
@@ -163,6 +166,9 @@ contract GovernorBravoDelegateStorageV1 is GovernorBravoDelegatorStorage {
 
     /// @notice The maximum number of actions that can be included in a proposal
     uint public proposalMaxOperations;
+
+    /// @notice A privileged role that can cancel any proposal
+    address public guardian;
 }
 
 interface TimelockInterface {


### PR DESCRIPTION
## Description

Add governance guardian to governor bravo
    
Problem: We need to retain the guardian capabilities after we migrate to bravo. We need the right to veto the proposals because the current XVS allocation allows malicious actors to take over the governance — we need to mitigate this risk, introducing some degree of centralization (the right to veto the proposals).
    
Solution: Add governance guardian who can cancel the proposals but CAN NOT change the governance contract.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
