### PR TITLE
feat: adjust GovernorBravo test cases according to vault change

### DIFF
--- a/tests/Governance/GovernorBravo/QueueTest.js
+++ b/tests/Governance/GovernorBravo/QueueTest.js
@@ -4,16 +4,30 @@ const {
   encodeParameters,
   advanceBlocks,
   freezeTime,
-  mineBlock
+  mineBlock,
+  bnbUnsigned
 } = require('../../Utils/BSC');
-
-async function enfranchise(xvs, actor, amount) {
-  await send(xvs, 'transfer', [actor, bnbMantissa(amount)]);
-  await send(xvs, 'delegate', [actor], {from: actor});
-}
 
 describe('GovernorBravo#queue/1', () => {
   let root, a1, a2, accounts;
+
+  async function enfranchise(xvs, xvsVault, actor, amount) {
+    await send(xvsVault, 'delegate', [actor], { from: actor });
+    await send(xvs, 'approve', [xvsVault._address, bnbMantissa(1e10)], { from: actor });
+    // in test cases, we transfer enough token to actor for convenience
+    await send(xvs, 'transfer', [actor, bnbMantissa(amount)]);
+    await send(xvsVault, 'deposit', [xvs._address, 0, bnbMantissa(amount)], { from: actor });
+  }
+
+  async function makeVault(xvs, actor) {
+    const xvsVault = await deploy('XVSVault', []);
+    const xvsStore = await deploy('XVSStore', []);
+    await send(xvsStore, 'setNewOwner', [xvsVault._address], { from: actor });
+    await send(xvsVault, 'setXvsStore', [xvs._address, xvsStore._address], { from: actor });
+    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300, 0], { from: actor }); // lock period 300ms
+    return xvsVault;
+  }
+
   beforeAll(async () => {
     [root, a1, a2, ...accounts] = saddle.accounts;
   });
@@ -22,11 +36,12 @@ describe('GovernorBravo#queue/1', () => {
     it("reverts on queueing overlapping actions in same proposal", async () => {
       const timelock = await deploy('TimelockHarness', [root, 86400 * 2]);
       const xvs = await deploy('XVS', [root]);
-      const gov = await deploy('GovernorBravoImmutable', [timelock._address, xvs._address, root, 86400, 1, "100000000000000000000000"]);
+      const xvsVault = await makeVault(xvs, root);
+      const gov = await deploy('GovernorBravoImmutable', [timelock._address, xvsVault._address, root, 86400, 1, "100000000000000000000000"]);
       await send(gov, '_initiate');
       const txAdmin = await send(timelock, 'harnessSetAdmin', [gov._address]);
 
-      await enfranchise(xvs, a1, 3e6);
+      await enfranchise(xvs, xvsVault, a1, 3e6);
       await mineBlock();
 
       const targets = [xvs._address, xvs._address];
@@ -47,12 +62,13 @@ describe('GovernorBravo#queue/1', () => {
     it("reverts on queueing overlapping actions in different proposals, works if waiting", async () => {
       const timelock = await deploy('TimelockHarness', [root, 86400 * 2]);
       const xvs = await deploy('XVS', [root]);
-      const gov = await deploy('GovernorBravoImmutable', [timelock._address, xvs._address, root, 86400, 1, "100000000000000000000000"]);
+      const xvsVault = await makeVault(xvs, root);
+      const gov = await deploy('GovernorBravoImmutable', [timelock._address, xvsVault._address, root, 86400, 1, "100000000000000000000000"]);
       await send(gov, '_initiate');
       const txAdmin = await send(timelock, 'harnessSetAdmin', [gov._address]);
 
-      await enfranchise(xvs, a1, 3e6);
-      await enfranchise(xvs, a2, 3e6);
+      await enfranchise(xvs, xvsVault, a1, 3e6);
+      await enfranchise(xvs, xvsVault, a2, 3e6);
       await mineBlock();
 
       const targets = [xvs._address];


### PR DESCRIPTION
## Description

GovernorBravo regards staked XVS tokens in Vault as voting power, which is different from the original implementation of Compound. We need to adjust these cases according to our vault changes.

## Checklist

- [ ] I have update all GovernorBravo related test cases and all cases pass
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
