### PR TITLE
Vault fixes based on the audit feedback

### DIFF
--- a/contracts/Governance/GovernorBravoDelegate.sol
+++ b/contracts/Governance/GovernorBravoDelegate.sol
@@ -60,6 +60,7 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
         require(votingPeriod_ >= MIN_VOTING_PERIOD && votingPeriod_ <= MAX_VOTING_PERIOD, "GovernorBravo::initialize: invalid voting period");
         require(votingDelay_ >= MIN_VOTING_DELAY && votingDelay_ <= MAX_VOTING_DELAY, "GovernorBravo::initialize: invalid voting delay");
         require(proposalThreshold_ >= MIN_PROPOSAL_THRESHOLD && proposalThreshold_ <= MAX_PROPOSAL_THRESHOLD, "GovernorBravo::initialize: invalid proposal threshold");
+        require(newGuardian != address(0), "GovernorBravo::initialize: invalid guardian");
 
         timelock = TimelockInterface(timelock_);
         xvsVault = XvsVaultInterface(xvsVault_);
@@ -294,6 +295,7 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
       */
     function _setGuardian(address newGuardian) external {
         require(msg.sender == guardian || msg.sender == admin, "GovernorBravo::_setGuardian: admin or guardian only");
+        require(newGuardian != address(0), "GovernorBravo::_setGuardian: cannot live without a guardian");
         address oldGuardian = guardian;
         guardian = newGuardian;
 

--- a/contracts/Governance/GovernorBravoDelegate.sol
+++ b/contracts/Governance/GovernorBravoDelegate.sol
@@ -359,8 +359,11 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
       * @param proposalMaxOperations_ Max proposal operations
       */
     function _setProposalMaxOperations(uint proposalMaxOperations_) external {
-        require(msg.sender == admin, "GovernorBravo::_initiate: admin only");
+        require(msg.sender == admin, "GovernorBravo::_setProposalMaxOperations: admin only");
+        uint oldProposalMaxOperations = proposalMaxOperations;
         proposalMaxOperations = proposalMaxOperations_;
+
+        emit ProposalMaxOperationsUpdated(oldProposalMaxOperations, proposalMaxOperations_);
     }
 
     /**

--- a/contracts/Governance/GovernorBravoInterfaces.sol
+++ b/contracts/Governance/GovernorBravoInterfaces.sol
@@ -43,6 +43,9 @@ contract GovernorBravoEvents {
 
     /// @notice Emitted when the new guardian address is set
     event NewGuardian(address oldGuardian, address newGuardian);
+
+    /// @notice Emitted when the maximum number of operations in one proposal is updated
+    event ProposalMaxOperationsUpdated(uint oldMaxOperations, uint newMaxOperations);
 }
 
 contract GovernorBravoDelegatorStorage {

--- a/contracts/Utils/ECDSA.sol
+++ b/contracts/Utils/ECDSA.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// Adapted from OpenZeppelin Contracts v4.3.2 (utils/cryptography/ECDSA.sol)
+
+// SPDX-Copyright-Text: OpenZeppelin, 2021
+// SPDX-Copyright-Text: Venus, 2021
+
+pragma solidity ^0.5.16;
+
+/**
+ * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
+ *
+ * These functions can be used to verify that a message was signed by the holder
+ * of the private keys of a given address.
+ */
+contract ECDSA {
+    enum RecoverError {
+        NoError,
+        InvalidSignature,
+        InvalidSignatureLength,
+        InvalidSignatureS,
+        InvalidSignatureV
+    }
+
+    function _throwError(RecoverError error) private pure {
+        if (error == RecoverError.NoError) {
+            return; // no error: do nothing
+        } else if (error == RecoverError.InvalidSignature) {
+            revert("ECDSA: invalid signature");
+        } else if (error == RecoverError.InvalidSignatureLength) {
+            revert("ECDSA: invalid signature length");
+        } else if (error == RecoverError.InvalidSignatureS) {
+            revert("ECDSA: invalid signature 's' value");
+        } else if (error == RecoverError.InvalidSignatureV) {
+            revert("ECDSA: invalid signature 'v' value");
+        }
+    }
+
+    /**
+     * @dev Returns the address that signed a hashed message (`hash`) with
+     * `signature`. This address can then be used for verification purposes.
+     *
+     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * this function rejects them by requiring the `s` value to be in the lower
+     * half order, and the `v` value to be either 27 or 28.
+     *
+     * IMPORTANT: `hash` _must_ be the result of a hash operation for the
+     * verification to be secure: it is possible to craft signatures that
+     * recover to arbitrary addresses for non-hashed data. A safe way to ensure
+     * this is by receiving a hash of the original message (which may otherwise
+     * be too long), and then calling {toEthSignedMessageHash} on it.
+     */
+    function recover(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal pure returns (address) {
+        (address recovered, RecoverError error) = tryRecover(hash, v, r, s);
+        _throwError(error);
+        return recovered;
+    }
+
+    /**
+     * @dev Returns the address that signed a hashed message (`hash`) with
+     * `signature` or error string. This address can then be used for verification purposes.
+     *
+     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * this function rejects them by requiring the `s` value to be in the lower
+     * half order, and the `v` value to be either 27 or 28.
+     *
+     * IMPORTANT: `hash` _must_ be the result of a hash operation for the
+     * verification to be secure: it is possible to craft signatures that
+     * recover to arbitrary addresses for non-hashed data. A safe way to ensure
+     * this is by receiving a hash of the original message (which may otherwise
+     * be too long), and then calling {toEthSignedMessageHash} on it.
+     *
+     * Documentation for signature generation:
+     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]
+     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]
+     *
+     * _Available since v4.3._
+     */
+    function tryRecover(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal pure returns (address, RecoverError) {
+        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (301): 0 < s < secp256k1n ÷ 2 + 1, and for v in (302): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            return (address(0), RecoverError.InvalidSignatureS);
+        }
+        if (v != 27 && v != 28) {
+            return (address(0), RecoverError.InvalidSignatureV);
+        }
+
+        // If the signature is valid (and not malleable), return the signer address
+        address signer = ecrecover(hash, v, r, s);
+        if (signer == address(0)) {
+            return (address(0), RecoverError.InvalidSignature);
+        }
+
+        return (signer, RecoverError.NoError);
+    }
+}

--- a/contracts/XVSVault/XVSStore.sol
+++ b/contracts/XVSVault/XVSStore.sol
@@ -36,7 +36,7 @@ contract XVSStore {
     }
 
     // Safe reward token transfer function, just in case if rounding error causes pool to not have enough tokens.
-    function safeRewardTransfer(address token, address _to, uint256 _amount) public onlyOwner {
+    function safeRewardTransfer(address token, address _to, uint256 _amount) external onlyOwner {
         require(rewardTokens[token] == true, "only reward token can");
 
         if (address(token) != address(0)) {
@@ -49,21 +49,21 @@ contract XVSStore {
         }
     }
 
-    function setNewAdmin(address _admin) public onlyAdmin {
+    function setNewAdmin(address _admin) external onlyAdmin {
         require(_admin != address(0), "new admin is the zero address");
         address oldAdmin = admin;
         admin = _admin;
         emit AdminTransferred(oldAdmin, _admin);
     }
 
-    function setNewOwner(address _owner) public onlyAdmin {
+    function setNewOwner(address _owner) external onlyAdmin {
         require(_owner != address(0), "new owner is the zero address");
         address oldOwner = owner;
         owner = _owner;
         emit OwnerTransferred(oldOwner, _owner);
     }
 
-    function setRewardToken(address _tokenAddress, bool status) public {
+    function setRewardToken(address _tokenAddress, bool status) external {
         require(msg.sender == admin || msg.sender == owner, "only admin or owner can");
         rewardTokens[_tokenAddress] = status;
     }

--- a/contracts/XVSVault/XVSStore.sol
+++ b/contracts/XVSVault/XVSStore.sol
@@ -42,9 +42,9 @@ contract XVSStore {
         if (address(token) != address(0)) {
             uint256 tokenBalance = IBEP20(token).balanceOf(address(this));
             if (_amount > tokenBalance) {
-                IBEP20(token).transfer(_to, tokenBalance);
+                IBEP20(token).safeTransfer(_to, tokenBalance);
             } else {
-                IBEP20(token).transfer(_to, _amount);
+                IBEP20(token).safeTransfer(_to, _amount);
             }
         }
     }
@@ -69,6 +69,6 @@ contract XVSStore {
     }
 
     function emergencyRewardWithdraw(address _tokenAddress, uint256 _amount) external onlyOwner {
-        IBEP20(_tokenAddress).transfer(address(msg.sender), _amount);
+        IBEP20(_tokenAddress).safeTransfer(address(msg.sender), _amount);
     }
 }

--- a/contracts/XVSVault/XVSStore.sol
+++ b/contracts/XVSVault/XVSStore.sol
@@ -9,11 +9,17 @@ contract XVSStore {
     /// @notice The Admin Address
     address public admin;
 
+    /// @notice The pending admin address
+    address public pendingAdmin;
+
     /// @notice The Owner Address
     address public owner;
 
     /// @notice The reward tokens
     mapping(address => bool) public rewardTokens;
+
+    /// @notice Emitted when pendingAdmin is changed
+    event NewPendingAdmin(address oldPendingAdmin, address newPendingAdmin);
 
     /// @notice Event emitted when admin changed
     event AdminTransferred(address indexed oldAdmin, address indexed newAdmin);
@@ -49,11 +55,22 @@ contract XVSStore {
         }
     }
 
-    function setNewAdmin(address _admin) external onlyAdmin {
-        require(_admin != address(0), "new admin is the zero address");
+    function setPendingAdmin(address _admin) external onlyAdmin {
+        address oldPendingAdmin = pendingAdmin;
+        pendingAdmin = _admin;
+        emit NewPendingAdmin(oldPendingAdmin, _admin);
+    }
+
+    function acceptAdmin() external {
+        require(msg.sender == pendingAdmin, "only pending admin");
         address oldAdmin = admin;
-        admin = _admin;
-        emit AdminTransferred(oldAdmin, _admin);
+        address oldPendingAdmin = pendingAdmin;
+
+        admin = pendingAdmin;
+        pendingAdmin = address(0);
+
+        emit NewPendingAdmin(oldPendingAdmin, pendingAdmin);
+        emit AdminTransferred(oldAdmin, admin);
     }
 
     function setNewOwner(address _owner) external onlyAdmin {

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -700,15 +700,6 @@ contract XVSVault is XVSVaultStorage {
         admin = address(0);
     }
 
-    /**
-     * @dev Set the current admin to new address
-     */
-    function setNewAdmin(address newAdmin) external onlyAdmin {
-        require(newAdmin != address(0), "new owner is the zero address");
-        emit AdminTransferred(admin, newAdmin);
-        admin = newAdmin;
-    }
-
     /*** Admin Functions ***/
 
     function _become(XVSVaultProxy xvsVaultProxy) external {

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -145,7 +145,7 @@ contract XVSVault is XVSVaultStorage {
                 );
             IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, msg.sender, pending);
         }
-        pool.token.transferFrom(
+        pool.token.safeTransferFrom(
             address(msg.sender),
             address(this),
             _amount
@@ -249,7 +249,7 @@ contract XVSVault is XVSVaultStorage {
         IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, msg.sender, pending);
         user.amount = user.amount.sub(_amount);
         user.rewardDebt = user.amount.mul(pool.accRewardPerShare).div(1e12);
-        pool.token.transfer(address(msg.sender), _amount);
+        pool.token.safeTransfer(address(msg.sender), _amount);
 
         emit ExecutedWithdrawal(msg.sender, _rewardToken, _pid, _amount);
     }

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
+import "../Utils/ECDSA.sol";
 import "../Utils/SafeBEP20.sol";
 import "../Utils/IBEP20.sol";
 import "./XVSVaultProxy.sol";
@@ -12,7 +13,7 @@ interface IXVSStore {
     function setRewardToken(address _tokenAddress, bool status) external;
 }
 
-contract XVSVault is XVSVaultStorage {
+contract XVSVault is XVSVaultStorage, ECDSA {
     using SafeMath for uint256;
     using SafeBEP20 for IBEP20;
 
@@ -560,8 +561,7 @@ contract XVSVault is XVSVaultStorage {
         bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes("XVSVault")), getChainId(), address(this)));
         bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
-        address signatory = ecrecover(digest, v, r, s);
-        require(signatory != address(0), "XVSVault::delegateBySig: invalid signature");
+        address signatory = ECDSA.recover(digest, v, r, s);
         require(nonce == nonces[signatory]++, "XVSVault::delegateBySig: invalid nonce");
         require(block.timestamp <= expiry, "XVSVault::delegateBySig: signature expired");
         return _delegate(signatory, delegatee);

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -563,7 +563,7 @@ contract XVSVault is XVSVaultStorage {
         address signatory = ecrecover(digest, v, r, s);
         require(signatory != address(0), "XVSVault::delegateBySig: invalid signature");
         require(nonce == nonces[signatory]++, "XVSVault::delegateBySig: invalid nonce");
-        require(now <= expiry, "XVSVault::delegateBySig: signature expired");
+        require(block.timestamp <= expiry, "XVSVault::delegateBySig: signature expired");
         return _delegate(signatory, delegatee);
     }
 

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -102,7 +102,10 @@ contract XVSVault is XVSVaultStorage {
         IBEP20 _token,
         uint256 _rewardPerBlock,
         uint256 _lockPeriod
-    ) public onlyAdmin {
+    )
+        external
+        onlyAdmin
+    {
         require(address(xvsStore) != address(0), "Store contract addres is empty");
 
         massUpdatePools(_rewardToken);
@@ -146,7 +149,7 @@ contract XVSVault is XVSVaultStorage {
         uint256 _pid,
         uint256 _allocPoint
     )
-        public
+        external
         onlyAdmin
     {
         _ensureValidPool(_rewardToken, _pid);
@@ -166,7 +169,10 @@ contract XVSVault is XVSVaultStorage {
     function setRewardAmountPerBlock(
         address _rewardToken,
         uint256 _rewardAmount
-    ) public onlyAdmin {
+    )
+        external
+        onlyAdmin
+    {
         massUpdatePools(_rewardToken);
         uint256 oldReward = rewardTokenAmountsPerBlock[_rewardToken];
         rewardTokenAmountsPerBlock[_rewardToken] = _rewardAmount;
@@ -180,7 +186,7 @@ contract XVSVault is XVSVaultStorage {
         uint256 _pid,
         uint256 _newPeriod
     )
-        public
+        external
         onlyAdmin
     {
         _ensureValidPool(_rewardToken, _pid);
@@ -199,7 +205,7 @@ contract XVSVault is XVSVaultStorage {
      * @param _amount The amount to deposit to vault
      */
     function deposit(address _rewardToken, uint256 _pid, uint256 _amount)
-        public
+        external
         nonReentrant
     {
         _ensureValidPool(_rewardToken, _pid);
@@ -302,7 +308,7 @@ contract XVSVault is XVSVaultStorage {
      * @param _pid The Pool Index
      */
     function executeWithdrawal(address _rewardToken, uint256 _pid)
-        public
+        external
         nonReentrant
     {
         _ensureValidPool(_rewardToken, _pid);
@@ -333,7 +339,7 @@ contract XVSVault is XVSVaultStorage {
      * @param _amount The amount to withdraw to vault
      */
     function requestWithdrawal(address _rewardToken, uint256 _pid, uint256 _amount)
-        public
+        external
         nonReentrant
     {
         _ensureValidPool(_rewardToken, _pid);
@@ -363,7 +369,7 @@ contract XVSVault is XVSVaultStorage {
      * @param _user The User Address
      */
     function getEligibleWithdrawalAmount(address _rewardToken, uint256 _pid, address _user)
-        public
+        external
         view
         returns (uint withdrawalAmount)
     {
@@ -385,7 +391,7 @@ contract XVSVault is XVSVaultStorage {
      * @param _user The User Address
      */
     function getRequestedAmount(address _rewardToken, uint256 _pid, address _user)
-        public
+        external
         view
         returns (uint256)
     {
@@ -401,7 +407,7 @@ contract XVSVault is XVSVaultStorage {
      * @param _user The User Address
      */
     function getWithdrawalRequests(address _rewardToken, uint256 _pid, address _user)
-        public
+        external
         view
         returns (WithdrawalRequest[] memory)
     {
@@ -411,7 +417,7 @@ contract XVSVault is XVSVaultStorage {
 
     // View function to see pending XVSs on frontend.
     function pendingReward(address _rewardToken, uint256 _pid, address _user)
-        public
+        external
         view
         returns (uint256)
     {
@@ -485,7 +491,7 @@ contract XVSVault is XVSVaultStorage {
         uint256 _pid,
         address _user
     )
-        public
+        external
         view
         returns (uint256 amount, uint256 rewardDebt, uint256 pendingWithdrawals)
     {
@@ -535,7 +541,7 @@ contract XVSVault is XVSVaultStorage {
      * @notice Delegate votes from `msg.sender` to `delegatee`
      * @param delegatee The address to delegate votes to
      */
-    function delegate(address delegatee) public {
+    function delegate(address delegatee) external {
         return _delegate(msg.sender, delegatee);
     }
 
@@ -548,7 +554,9 @@ contract XVSVault is XVSVaultStorage {
      * @param r Half of the ECDSA signature pair
      * @param s Half of the ECDSA signature pair
      */
-    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s) public {
+    function delegateBySig(address delegatee, uint nonce, uint expiry, uint8 v, bytes32 r, bytes32 s)
+        external
+    {
         bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes("XVSVault")), getChainId(), address(this)));
         bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
@@ -680,14 +688,14 @@ contract XVSVault is XVSVaultStorage {
     /**
      * @dev Returns the address of the current admin
      */
-    function getAdmin() public view returns (address) {
+    function getAdmin() external view returns (address) {
         return admin;
     }
 
     /**
      * @dev Burn the current admin
      */
-    function burnAdmin() public onlyAdmin {
+    function burnAdmin() external onlyAdmin {
         emit AdminTransferred(admin, address(0));
         admin = address(0);
     }
@@ -695,7 +703,7 @@ contract XVSVault is XVSVaultStorage {
     /**
      * @dev Set the current admin to new address
      */
-    function setNewAdmin(address newAdmin) public onlyAdmin {
+    function setNewAdmin(address newAdmin) external onlyAdmin {
         require(newAdmin != address(0), "new owner is the zero address");
         emit AdminTransferred(admin, newAdmin);
         admin = newAdmin;
@@ -703,12 +711,12 @@ contract XVSVault is XVSVaultStorage {
 
     /*** Admin Functions ***/
 
-    function _become(XVSVaultProxy xvsVaultProxy) public {
+    function _become(XVSVaultProxy xvsVaultProxy) external {
         require(msg.sender == xvsVaultProxy.admin(), "only proxy admin can change brains");
         require(xvsVaultProxy._acceptImplementation() == 0, "change not authorized");
     }
 
-    function setXvsStore(address _xvs, address _xvsStore) public onlyAdmin {
+    function setXvsStore(address _xvs, address _xvsStore) external onlyAdmin {
         address oldXvsContract = xvsAddress;
         address oldStore = xvsStore;
         xvsAddress = _xvs;

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -63,14 +63,11 @@ contract XVSVault is XVSVaultStorage {
         uint256 _allocPoint,
         IBEP20 _token,
         uint256 _rewardPerBlock,
-        uint256 _lockPeriod,
-        bool _withUpdate
+        uint256 _lockPeriod
     ) public onlyAdmin {
         require(address(xvsStore) != address(0), "Store contract addres is empty");
 
-        if (_withUpdate) {
-            massUpdatePools(_rewardToken);
-        }
+        massUpdatePools(_rewardToken);
 
         PoolInfo[] storage poolInfo = poolInfos[_rewardToken];
 
@@ -100,12 +97,9 @@ contract XVSVault is XVSVaultStorage {
     function set(
         address _rewardToken,
         uint256 _pid,
-        uint256 _allocPoint,
-        bool _withUpdate
+        uint256 _allocPoint
     ) public onlyAdmin {
-        if (_withUpdate) {
-            massUpdatePools(_rewardToken);
-        }
+        massUpdatePools(_rewardToken);
 
         PoolInfo[] storage poolInfo = poolInfos[_rewardToken];
         totalAllocPoints[_rewardToken] = totalAllocPoints[_rewardToken].sub(poolInfo[_pid].allocPoint).add(
@@ -119,6 +113,7 @@ contract XVSVault is XVSVaultStorage {
         address _rewardToken,
         uint256 _rewardAmount
     ) public onlyAdmin {
+        massUpdatePools(_rewardToken);
         rewardTokenAmountsPerBlock[_rewardToken] = _rewardAmount;
     }
 

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -57,7 +57,13 @@ contract XVSVault is XVSVaultStorage {
         return poolInfos[rewardToken].length;
     }
 
-    // Add a new token pool. Can only be called by the admin.
+    /**
+     * @notice Add a new token pool. Can only be called by the admin.
+     * @dev This vault DOES NOT support deflationary tokens — it expects that
+     *   the amount of transferred tokens would equal the actually deposited
+     *   amount. In practice this means that this vault DOES NOT support USDT
+     *   and similar tokens (that do not provide these guarantees).
+     */
     function add(
         address _rewardToken,
         uint256 _allocPoint,

--- a/scenario/src/Contract/GovernorBravo.ts
+++ b/scenario/src/Contract/GovernorBravo.ts
@@ -47,11 +47,13 @@ export interface GovernorBravoMethods {
   setBlockTimestamp(blockTimestamp: encodedNumber): Sendable<void>;
   state(proposalId: encodedNumber): Callable<number>;
   proposalThreshold(): Callable<number>;
+  proposalMaxOperations(): Callable<number>;
   votingPeriod(): Callable<number>;
   votingDelay(): Callable<number>;
   _setVotingDelay(newVotingDelay: encodedNumber): Sendable<void>;
   _setVotingPeriod(newVotingPeriod: encodedNumber): Sendable<void>;
   _setProposalThreshold(newProposalThreshold: encodedNumber): Sendable<void>;
+  _setProposalMaxOperations(newProposalMaxOperations: encodedNumber): Sendable<void>;
   _initiate(governorAlpha: string): Sendable<void>;
   _initiate(): Sendable<void>;
   _setImplementation(address: string): Sendable<void>;

--- a/scenario/src/Contract/XVSVault.ts
+++ b/scenario/src/Contract/XVSVault.ts
@@ -37,8 +37,8 @@ export interface XVSVaultImplMethods {
   _become(xvsVaultProxy: string): Sendable<void>;
   setXvsStore(xvs: string, xvsStore: string): Sendable<void>;
   add(
-    rewardToken: string, allocPoint: encodedNumber, token: string, rewardPerBlock: encodedNumber,
-    lockPeriod: encodedNumber, withUpdate: boolean
+    rewardToken: string, allocPoint: encodedNumber, token: string,
+    rewardPerBlock: encodedNumber, lockPeriod: encodedNumber
   ): Sendable<void>;
   deposit(rewardToken: string, pid: number, amount: encodedNumber): Sendable<void>;
   requestWithdrawal(rewardToken: string, pid: number, amount: encodedNumber): Sendable<void>;

--- a/scenario/src/Event/GovernorBravoEvent.ts
+++ b/scenario/src/Event/GovernorBravoEvent.ts
@@ -168,6 +168,27 @@ async function setProposalThreshold(
   return world;
 }
 
+async function setProposalMaxOperations(
+  world: World,
+  from: string,
+  governor: GovernorBravo,
+  newProposalMaxOperations: NumberV
+): Promise<World> {
+  let invokation = await invoke(
+    world,
+    governor.methods._setProposalMaxOperations(newProposalMaxOperations.encode()),
+    from
+  );
+
+  world = addAction(
+    world,
+    `Set proposal max operations to ${newProposalMaxOperations.show()}`,
+    invokation
+  );
+
+  return world;
+}
+
 async function setImplementation(
   world: World,
   from: string,
@@ -463,6 +484,21 @@ export function governorBravoCommands() {
       ],
       (world, from, { governor, newProposalThreshold }) =>
         setProposalThreshold(world, from, governor, newProposalThreshold),
+      { namePos: 1 }
+    ),
+    new Command<{ governor: GovernorBravo; newProposalMaxOperations: NumberV }>(
+      `
+        #### SetProposalMaxOperations
+        * "GovernorBravo <Governor> SetProposalMaxOperations <Number>" - Sets the max number of operations per one proposal
+        * E.g. "GovernorBravo GovernorBravoScenario SetProposalMaxOperations 42"
+    `,
+      "SetProposalMaxOperations",
+      [
+        new Arg("governor", getGovernorV),
+        new Arg("newProposalMaxOperations", getNumberV),
+      ],
+      (world, from, { governor, newProposalMaxOperations }) =>
+        setProposalMaxOperations(world, from, governor, newProposalMaxOperations),
       { namePos: 1 }
     ),
     new Command<{ governor: GovernorBravo; governorAlpha: AddressV }>(

--- a/scenario/src/Event/XVSVaultEvent.ts
+++ b/scenario/src/Event/XVSVaultEvent.ts
@@ -70,15 +70,13 @@ async function addPool(
   allocPoint: NumberV,
   token: string,
   rewardPerBlock: NumberV,
-  lockPeriod: NumberV,
-  withUpdate: BoolV
+  lockPeriod: NumberV
 ): Promise<World> {
   let invokation = await invoke(
     world,
     xvsVault.methods.add(
       rewardToken, allocPoint.encode(), token,
-      rewardPerBlock.encode(), lockPeriod.encode(),
-      withUpdate.val
+      rewardPerBlock.encode(), lockPeriod.encode()
     ),
     from,
     NoErrorReporter
@@ -245,15 +243,14 @@ export function xvsVaultCommands() {
       allocPoint: NumberV,
       token: AddressV,
       rewardPerBlock: NumberV,
-      lockPeriod: NumberV,
-      withUpdate: BoolV
+      lockPeriod: NumberV
     }>(
       `
         #### Add
 
-        * "XVSVault Add rewardToken:<Address> allocPoint:<Number> token:<Address> rewardPerBlock:<Number> withUpdate:<Bool>"
+        * "XVSVault Add rewardToken:<Address> allocPoint:<Number> token:<Address> rewardPerBlock:<Number>"
             - Adds a new token pool
-        * E.g. "XVSVault Add (Address XVS) 1000 (Address XVS) 12345 False"
+        * E.g. "XVSVault Add (Address XVS) 1000 (Address XVS) 12345"
       `,
       "Add",
       [
@@ -262,13 +259,12 @@ export function xvsVaultCommands() {
         new Arg("allocPoint", getNumberV),
         new Arg("token", getAddressV),
         new Arg("rewardPerBlock", getNumberV),
-        new Arg("lockPeriod", getNumberV),
-        new Arg("withUpdate", getBoolV),
+        new Arg("lockPeriod", getNumberV)
       ],
-      (world, from, { xvsVault, rewardToken, allocPoint, token, rewardPerBlock, lockPeriod, withUpdate }) =>
+      (world, from, { xvsVault, rewardToken, allocPoint, token, rewardPerBlock, lockPeriod }) =>
           addPool(
             world, from, xvsVault, rewardToken.val, allocPoint,
-            token.val, rewardPerBlock, lockPeriod, withUpdate
+            token.val, rewardPerBlock, lockPeriod
           )
     ),
 

--- a/scenario/src/Value/GovernorBravoValue.ts
+++ b/scenario/src/Value/GovernorBravoValue.ts
@@ -67,6 +67,13 @@ async function getProposalThreshold(
   return new NumberV(await governor.methods.proposalThreshold().call());
 }
 
+async function getProposalMaxOperations(
+  world: World,
+  governor: GovernorBravo
+): Promise<NumberV> {
+  return new NumberV(await governor.methods.proposalMaxOperations().call());
+}
+
 async function getVotingPeriod(
   world: World,
   governor: GovernorBravo
@@ -146,7 +153,7 @@ export function governorBravoFetchers() {
     new Fetcher<{ governor: GovernorBravo }, NumberV>(
       `
         #### ProposalThreshold
-        * "GovernorBravo <Governor> ProposalThreshold" - Returns the proposal threshold of the given governorBravo 
+        * "GovernorBravo <Governor> ProposalThreshold" - Returns the proposal threshold of the given governorBravo
         * E.g. "GovernorBravo GovernorBravoScenario ProposalThreshold"
       `,
       "ProposalThreshold",
@@ -157,8 +164,20 @@ export function governorBravoFetchers() {
 
     new Fetcher<{ governor: GovernorBravo }, NumberV>(
       `
+        #### ProposalMaxOperations
+        * "GovernorBravo <Governor> ProposalMaxOperations" - Returns the max number of operations per one proposal
+        * E.g. "GovernorBravo GovernorBravoScenario ProposalMaxOperations"
+      `,
+      "ProposalMaxOperations",
+      [new Arg("governor", getGovernorV)],
+      (world, { governor }) => getProposalMaxOperations(world, governor),
+      { namePos: 1 }
+    ),
+
+    new Fetcher<{ governor: GovernorBravo }, NumberV>(
+      `
         #### VotingPeriod
-        * "GovernorBravo <Governor> VotingPeriod" - Returns the voting period of the given governorBravo 
+        * "GovernorBravo <Governor> VotingPeriod" - Returns the voting period of the given governorBravo
         * E.g. "GovernorBravo GovernorBravoScenario VotingPeriod"
       `,
       "VotingPeriod",
@@ -170,7 +189,7 @@ export function governorBravoFetchers() {
     new Fetcher<{ governor: GovernorBravo }, NumberV>(
       `
         #### VotingDelay
-        * "GovernorBravo <Governor> VotingDelay" - Returns the voting delay of the given governorBravo 
+        * "GovernorBravo <Governor> VotingDelay" - Returns the voting delay of the given governorBravo
         * E.g. "GovernorBravo GovernorBravoScenario VotingDelay"
       `,
       "VotingDelay",

--- a/spec/scenario/CoreMacros
+++ b/spec/scenario/CoreMacros
@@ -317,4 +317,4 @@ Macro DeployVault xvs
     XVSStore Deploy
     XVSStore SetNewOwner (Address XVSVault)
     XVSVault SetXvsStore (Address xvs) (Address XVSStore)
-    XVSVault Add (Address xvs) 1000 (Address xvs) 300 12345 False
+    XVSVault Add (Address xvs) 1000 (Address xvs) 300 12345

--- a/spec/scenario/GovernorBravo/Admin.scen
+++ b/spec/scenario/GovernorBravo/Admin.scen
@@ -88,6 +88,12 @@ Test "Enforce Proposal Threshold min"
 	GovernorBravo LegitGov SetProposalThreshold 15000e18
 	Assert Revert "revert GovernorBravo::_setProposalThreshold: invalid proposal threshold"
 
+Test "Set Proposal Max Operations"
+	DeployGov
+	GovernorBravo LegitGov SetProposalMaxOperations 42
+	Assert Log ProposalMaxOperationsUpdated (newMaxOperations 42)
+	Assert Equal (GovernorBravo LegitGov ProposalMaxOperations) 42
+
 Test "Enforce admin"
 	DeployGov
 	AllowFailures
@@ -101,6 +107,8 @@ Test "Enforce admin"
 	Assert Revert "revert GovernorBravo::_initiate: admin only"
 	From Robert (GovernorBravo LegitGov SetImplementation (Address BravoDelegateHarness))
 	Assert Revert "revert GovernorBravoDelegator::_setImplementation: admin only"
+	From Robert (GovernorBravo LegitGov SetProposalMaxOperations 42)
+	Assert Revert "revert GovernorBravo::_setProposalMaxOperations: admin only"
 
 Test "Transfer Admin"
 	DeployGov

--- a/spec/scenario/GovernorBravo/Admin.scen
+++ b/spec/scenario/GovernorBravo/Admin.scen
@@ -126,3 +126,9 @@ Test "Only guardian and admin can set new guardian"
 	AllowFailures
 	From Robert (GovernorBravo LegitGov SetGuardian Admin)
 	Assert Revert "revert GovernorBravo::_setGuardian: admin or guardian only"
+
+Test "Guardian cannot be zero"
+	DeployGov
+	AllowFailures
+	From Guardian (GovernorBravo LegitGov SetGuardian (Address Zero))
+	Assert Revert "revert GovernorBravo::_setGuardian: cannot live without a guardian"

--- a/tests/Governance/GovernorBravo/CastVoteTest.js
+++ b/tests/Governance/GovernorBravo/CastVoteTest.js
@@ -32,8 +32,8 @@ describe("governorBravo#castVote/2", () => {
     xvs = await deploy('XVSScenario', [root]);
     await send(xvsStore, 'setNewOwner', [xvsVault._address], { from: root });
     await send(xvsVault, 'setXvsStore', [xvs._address, xvsStore._address], { from: root });
-    // address _rewardToken, uint256 _allocPoint, IBEP20 _token, uint256 _rewardPerBlock, uint256 _lockPeriod, bool _withUpdate
-    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300, 0], { from: root }); // lock period 300ms
+    // address _rewardToken, uint256 _allocPoint, IBEP20 _token, uint256 _rewardPerBlock, uint256 _lockPeriod
+    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300], { from: root }); // lock period 300s
     await send(xvsVault, 'delegate', [root]);
 
     govDelegate = await deploy('GovernorBravoDelegateHarness');

--- a/tests/Governance/GovernorBravo/ProposeTest.js
+++ b/tests/Governance/GovernorBravo/ProposeTest.js
@@ -28,7 +28,7 @@ describe('GovernorBravo#propose/5', () => {
     xvsStore = await deploy('XVSStore', []);
     await send(xvsStore, 'setNewOwner', [xvsVault._address], { from: root });
     await send(xvsVault, 'setXvsStore', [xvs._address, xvsStore._address], { from: root });
-    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300, 0], { from: root }); // lock period 300ms
+    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300], { from: root }); // lock period 300s
 
     gov = await deploy(
       'GovernorBravoImmutable',

--- a/tests/Governance/GovernorBravo/QueueTest.js
+++ b/tests/Governance/GovernorBravo/QueueTest.js
@@ -24,7 +24,7 @@ describe('GovernorBravo#queue/1', () => {
     const xvsStore = await deploy('XVSStore', []);
     await send(xvsStore, 'setNewOwner', [xvsVault._address], { from: actor });
     await send(xvsVault, 'setXvsStore', [xvs._address, xvsStore._address], { from: actor });
-    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300, 0], { from: actor }); // lock period 300ms
+    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300], { from: actor }); // lock period 300s
     return xvsVault;
   }
 

--- a/tests/Governance/GovernorBravo/StateTest.js
+++ b/tests/Governance/GovernorBravo/StateTest.js
@@ -43,7 +43,7 @@ describe('GovernorBravo#state/1', () => {
     const xvsStore = await deploy('XVSStore', []);
     await send(xvsStore, 'setNewOwner', [xvsVault._address], { from: root });
     await send(xvsVault, 'setXvsStore', [xvs._address, xvsStore._address], { from: root });
-    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300, 0], { from: root }); // lock period 300ms
+    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300], { from: root }); // lock period 300s
     
     delay = bnbUnsigned(2 * 24 * 60 * 60).mul(2)
     timelock = await deploy('TimelockHarness', [root, delay]);

--- a/tests/Governance/XVSVaultGovernanceTest.js
+++ b/tests/Governance/XVSVaultGovernanceTest.js
@@ -1,0 +1,82 @@
+const {
+  address,
+  bnbUnsigned,
+  minerStart,
+  minerStop,
+  unlockedAccount,
+  mineBlock
+} = require('../Utils/BSC');
+
+const EIP712 = require('../Utils/EIP712');
+
+describe('XVSVault governance', () => {
+  const name = 'XVSVault';
+
+  let root, a1, a2, accounts, chainId;
+  let xvs, xvsVault, xvsStore;
+
+  async function deployVault(root) {
+    xvsVault = await deploy('XVSVault', []);
+    xvsStore = await deploy('XVSStore', []);
+    xvs = await deploy('XVSScenario', [root]);
+    await send(xvsStore, 'setNewOwner', [xvsVault._address], { from: root });
+    await send(xvsVault, 'setXvsStore', [xvs._address, xvsStore._address], { from: root });
+    // address _rewardToken, uint256 _allocPoint, IBEP20 _token, uint256 _rewardPerBlock, uint256 _lockPeriod
+    await send(xvsVault, 'add', [xvs._address, 100, xvs._address, bnbUnsigned(1e16), 300], { from: root }); // lock period 300s
+  }
+
+  beforeEach(async () => {
+    [root, a1, a2, ...accounts] = saddle.accounts;
+    chainId = 1; // await web3.eth.net.getId(); See: https://github.com/trufflesuite/ganache-core/issues/515
+    await deployVault(root);
+  });
+
+  describe('delegateBySig', () => {
+    const Domain = (xvsVault) => ({ name, chainId, verifyingContract: xvsVault._address });
+    const Types = {
+      Delegation: [
+        { name: 'delegatee', type: 'address' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'expiry', type: 'uint256' }
+      ]
+    };
+
+    it('reverts if the signatory is invalid', async () => {
+      const delegatee = root, nonce = 0, expiry = 0;
+      await expect(
+        send(xvsVault, 'delegateBySig', [delegatee, nonce, expiry, 0, '0xbad', '0xbad'])
+      ).rejects.toRevert("revert ECDSA: invalid signature 's' value");
+    });
+
+    it('reverts if the nonce is bad ', async () => {
+      const delegatee = root, nonce = 1, expiry = 0;
+      const { v, r, s } = EIP712.sign(
+        Domain(xvsVault), 'Delegation', { delegatee, nonce, expiry }, Types, unlockedAccount(a1).secretKey
+      );
+      await expect(
+        send(xvsVault, 'delegateBySig', [delegatee, nonce, expiry, v, r, s])
+      ).rejects.toRevert("revert XVSVault::delegateBySig: invalid nonce");
+    });
+
+    it('reverts if the signature has expired', async () => {
+      const delegatee = root, nonce = 0, expiry = 0;
+      const { v, r, s } = EIP712.sign(
+        Domain(xvsVault), 'Delegation', { delegatee, nonce, expiry }, Types, unlockedAccount(a1).secretKey
+      );
+      await expect(
+        send(xvsVault, 'delegateBySig', [delegatee, nonce, expiry, v, r, s])
+      ).rejects.toRevert("revert XVSVault::delegateBySig: signature expired");
+    });
+
+    it('delegates on behalf of the signatory', async () => {
+      const delegatee = root, nonce = 0, expiry = 10e9;
+      const { v, r, s } = EIP712.sign(
+        Domain(xvsVault), 'Delegation', { delegatee, nonce, expiry }, Types, unlockedAccount(a1).secretKey
+      );
+      expect(await call(xvsVault, 'delegates', [a1])).toEqual(address(0));
+      const tx = await send(xvsVault, 'delegateBySig', [delegatee, nonce, expiry, v, r, s]);
+      expect(tx.gasUsed < 80000);
+      expect(await call(xvsVault, 'delegates', [a1])).toEqual(root);
+    });
+  });
+});

--- a/tests/XVSVault/xvsVaultTest.js
+++ b/tests/XVSVault/xvsVaultTest.js
@@ -77,8 +77,8 @@ describe('XVSVault', () => {
         100,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0], { from: root });
+        defaultLockPeriod
+        ], { from: root });
 
       const poolInfo = await call(xvsVault, 'poolInfos', [xvs._address, 0]);
       expect(poolInfo['token']).toEqual(xvs._address);
@@ -95,8 +95,8 @@ describe('XVSVault', () => {
         100,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0], { from: root });
+        defaultLockPeriod
+        ], { from: root });
 
       let poolInfo = await call(xvsVault, 'poolInfos', [xvs._address, 0]);
       expect(poolInfo['allocPoint']).toEqual('100');
@@ -104,8 +104,8 @@ describe('XVSVault', () => {
       await send(xvsVault, 'set', [
         xvs._address,
         0,
-        1000,
-        0], { from: root });
+        1000
+        ], { from: root });
 
       poolInfo = await call(xvsVault, 'poolInfos', [xvs._address, 0]);
       expect(poolInfo['token']).toEqual(xvs._address);
@@ -123,8 +123,7 @@ describe('XVSVault', () => {
         100,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
       await send(xvs, 'transfer', [notAdmin, tokenAmount], { from: root });
 
@@ -158,8 +157,7 @@ describe('XVSVault', () => {
         100,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
       await send(xvs, 'transfer', [notAdmin, tokenAmount], { from: root });
       await send(xvs, 'approve', [xvsVault._address, tokenAmount], { from: notAdmin });
@@ -184,8 +182,7 @@ describe('XVSVault', () => {
         100,
         sxp._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
       await send(sxp, 'transfer', [notAdmin, tokenAmount], { from: root });
       await send(sxp, 'approve', [xvsVault._address, tokenAmount], { from: notAdmin });
@@ -309,14 +306,14 @@ describe('XVSVault', () => {
         await send(
             xvsVault,
             'add',
-            [xvs._address, 100, sxp._address, rewardPerBlock, lockPeriod1, 0],
+            [xvs._address, 100, sxp._address, rewardPerBlock, lockPeriod1],
             { from: root }
         );
         const lockPeriod2 = '654321';
         await send(
           xvsVault,
           'add',
-          [sxp._address, 100, xvs._address, rewardPerBlock, lockPeriod2, 0],
+          [sxp._address, 100, xvs._address, rewardPerBlock, lockPeriod2],
           { from: root }
         );
         const pool1 = await call(xvsVault, 'poolInfos', [xvs._address, 0]);
@@ -330,7 +327,7 @@ describe('XVSVault', () => {
           await send(
             xvsVault,
             'add',
-            [rewardToken._address, 100, stakingToken._address, rewardPerBlock, 0, 0],
+            [rewardToken._address, 100, stakingToken._address, rewardPerBlock, 0],
             { from: root }
           );
           // pair (reward token, pid) uniquely identifies a pool
@@ -366,8 +363,7 @@ describe('XVSVault', () => {
         100,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
       await send(xvs, 'transfer', [notAdmin, tokenAmount], { from: root });
       await send(xvs, 'approve', [xvsVault._address, tokenAmount], { from: notAdmin });
@@ -417,16 +413,14 @@ describe('XVSVault', () => {
         100,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
       await send(xvsVault, 'add', [
         xvs._address,
         100,
         sxp._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
 
       await send(xvsVault, 'add', [
@@ -434,16 +428,14 @@ describe('XVSVault', () => {
         200,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
       await send(xvsVault, 'add', [
         sxp._address,
         200,
         sxp._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
 
       const totalAllocPoint1 = await call(xvsVault, 'totalAllocPoints', [xvs._address]);
@@ -459,16 +451,14 @@ describe('XVSVault', () => {
         100,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
       await send(xvsVault, 'add', [
         xvs._address,
         100,
         sxp._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
 
       await send(xvsVault, 'add', [
@@ -476,16 +466,14 @@ describe('XVSVault', () => {
         200,
         xvs._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
       await send(xvsVault, 'add', [
         sxp._address,
         200,
         sxp._address,
         rewardPerBlock,
-        defaultLockPeriod,
-        0
+        defaultLockPeriod
       ], { from: root });
 
       await send(xvs, 'transfer', [notAdmin, tokenAmount], { from: root });


### PR DESCRIPTION
## Description

- [x] PVE001 Update pools in add, set, setRewardPerBlock
- [x] PVE002 Use SafeERC20 for transfers
- [x] PVE003 Support or forbid deflationary tokens
- [x] PVE004 Validate pools explicitly
- [x] PVE005 Add meaningful events for important state changes
- [ ] PVE006 Write deployment doc (to ensure the correct owners/admins of the vault, store) — will work on this with @defistar 
- [ ] PVE007 Update VenusLens to acount for the new governance — will be addressed in a separate PR
- [x] PVE008 Acknowledge VAI domain separator issue — won't fix, no changes required

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
