### PR TITLE
Change implementation var name to more conventional

### DIFF
--- a/contracts/XVSVault/XVSVaultProxy.sol
+++ b/contracts/XVSVault/XVSVaultProxy.sol
@@ -58,14 +58,14 @@ contract XVSVaultProxy is XVSVaultAdminStorage, XVSVaultErrorReporter {
         }
 
         // Save current values for inclusion in log
-        address oldImplementation = xvsVaultImplementation;
+        address oldImplementation = implementation;
         address oldPendingImplementation = pendingXVSVaultImplementation;
 
-        xvsVaultImplementation = pendingXVSVaultImplementation;
+        implementation = pendingXVSVaultImplementation;
 
         pendingXVSVaultImplementation = address(0);
 
-        emit NewImplementation(oldImplementation, xvsVaultImplementation);
+        emit NewImplementation(oldImplementation, implementation);
         emit NewPendingImplementation(oldPendingImplementation, pendingXVSVaultImplementation);
 
         return uint(Error.NO_ERROR);
@@ -130,7 +130,7 @@ contract XVSVaultProxy is XVSVaultAdminStorage, XVSVaultErrorReporter {
      */
     function () external payable {
         // delegate all other functions to current implementation
-        (bool success, ) = xvsVaultImplementation.delegatecall(msg.data);
+        (bool success, ) = implementation.delegatecall(msg.data);
 
         assembly {
               let free_mem_ptr := mload(0x40)

--- a/contracts/XVSVault/XVSVaultStorage.sol
+++ b/contracts/XVSVault/XVSVaultStorage.sol
@@ -16,7 +16,7 @@ contract XVSVaultAdminStorage {
     /**
     * @notice Active brains of XVS Vault
     */
-    address public xvsVaultImplementation;
+    address public implementation;
 
     /**
     * @notice Pending brains of XVS Vault

--- a/tests/XVSVault/xvsVaultProxyTest.js
+++ b/tests/XVSVault/xvsVaultProxyTest.js
@@ -23,7 +23,7 @@ describe('XVSVaultProxy', () => {
       expect(await call(vaultProxy, 'admin')).toEqual(root);
       expect(await call(vaultProxy, 'pendingAdmin')).toBeAddressZero();
       expect(await call(vaultProxy, 'pendingXVSVaultImplementation')).toBeAddressZero();
-      expect(await call(vaultProxy, 'xvsVaultImplementation')).toBeAddressZero();
+      expect(await call(vaultProxy, 'implementation')).toBeAddressZero();
     });
   });
 
@@ -67,7 +67,7 @@ describe('XVSVaultProxy', () => {
       });
 
       it("does not change current implementation address", async () => {
-        expect(await call(vaultProxy, 'xvsVaultImplementation')).not.toEqual(vaultProxy._address);
+        expect(await call(vaultProxy, 'implementation')).not.toEqual(vaultProxy._address);
       });
     });
 
@@ -79,8 +79,8 @@ describe('XVSVaultProxy', () => {
         expect(result).toSucceed();
       });
 
-      it("Store xvsVaultImplementation with value pendingXVSVaultImplementation", async () => {
-        expect(await call(vaultProxy, 'xvsVaultImplementation')).toEqual(vaultImpl._address);
+      it("Store implementation with value pendingXVSVaultImplementation", async () => {
+        expect(await call(vaultProxy, 'implementation')).toEqual(vaultImpl._address);
       });
 
       it("Unset pendingXVSVaultImplementation", async () => {


### PR DESCRIPTION
## Description
   
Problem: bscscan can't infer that the proxy is a proxy due to an unusual name for the implementation storage var. This complicates interacting with the contract via bscscan.
    
Solution: Replace xvsVaultImplementation with just "implementation".

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
