### PR TITLE
Add Liquidator contract

### DIFF
--- a/contracts/ComptrollerInterface.sol
+++ b/contracts/ComptrollerInterface.sol
@@ -85,6 +85,7 @@ interface IVAIVault {
 }
 
 interface IComptroller {
+    function liquidationIncentiveMantissa() external view returns (uint);
     /*** Treasury Data ***/
     function treasuryAddress() external view returns (address);
     function treasuryPercent() external view returns (uint);

--- a/contracts/Liquidator.sol
+++ b/contracts/Liquidator.sol
@@ -1,0 +1,128 @@
+pragma solidity ^0.5.16;
+
+import "./ComptrollerInterface.sol";
+import "./EIP20Interface.sol";
+import "./SafeMath.sol";
+import "./VBNB.sol";
+import "./VBep20.sol";
+import "./Utils/ReentrancyGuard.sol";
+import "./Utils/WithAdmin.sol";
+
+contract Liquidator is WithAdmin, ReentrancyGuard {
+
+    /// @notice Address of vBNB contract.
+    VBNB public vBnb;
+
+    /// @notice Address of Venus Unitroller contract.
+    IComptroller comptroller;
+
+    /// @notice Address of Venus Treasury.
+    address public treasury;
+
+    /// @notice Percent of seized amount that goes to treasury.
+    uint256 public treasuryPercentMantissa;
+
+    /// @notice Emitted when once changes the percent of the seized amount
+    ///         that goes to treasury.
+    event NewLiquidationTreasuryPercent(uint256 oldPercent, uint256 newPercent);
+
+    using SafeMath for uint256;
+
+    constructor(
+        address payable vBnb_,
+        address comptroller_,
+        address treasury_,
+        uint256 treasuryPercentMantissa_
+    )
+        public
+    {
+        vBnb = VBNB(vBnb_);
+        comptroller = IComptroller(comptroller_);
+        treasury = treasury_;
+        treasuryPercentMantissa = treasuryPercentMantissa_;
+    }
+
+    /// @notice Liquidates a borrow and splits the seized amount between treasury and
+    ///         liquidator. The liquidators should use this interface instead of calling
+    ///         vToken.liquidateBorrow(...) directly.
+    /// @dev For BNB borrows msg.value should be equal to repayAmount; otherwise msg.value
+    ///      should be zero.
+    /// @param vToken Borrowed vToken
+    /// @param borrower The address of the borrower
+    /// @param repayAmount The amount to repay on behalf of the borrower
+    /// @param vTokenCollateral The collateral to seize
+    function liquidateBorrow(
+        address vToken,
+        address borrower,
+        uint256 repayAmount,
+        VToken vTokenCollateral
+    )
+        external
+        payable
+        nonReentrant
+    {
+        uint256 ourBalanceBefore = vTokenCollateral.balanceOf(address(this));
+        if (vToken == address(vBnb)) {
+            require(repayAmount == msg.value, "wrong amount");
+            vBnb.liquidateBorrow.value(msg.value)(borrower, vTokenCollateral);
+        } else {
+            require(msg.value == 0, "you shouldn't pay for this");
+            _liquidateBep20(VBep20(vToken), borrower, repayAmount, vTokenCollateral);
+        }
+        uint256 ourBalanceAfter = vTokenCollateral.balanceOf(address(this));
+        uint256 seizedAmount = ourBalanceAfter.sub(ourBalanceBefore);
+        _distributeLiquidationIncentive(vTokenCollateral, seizedAmount);
+    }
+
+    /// @notice Sets the new percent of the seized amount that goes to treasury. Should
+    ///         be less than or equal to comptroller.liquidationIncentiveMantissa().
+    /// @param newTreasuryPercentMantissa New treasury percent (scaled by 10^18).
+    function setTreasuryPercent(uint256 newTreasuryPercentMantissa) external onlyAdmin {
+        require(
+            newTreasuryPercentMantissa <= comptroller.liquidationIncentiveMantissa(),
+            "appetite too big"
+        );
+        emit NewLiquidationTreasuryPercent(treasuryPercentMantissa, newTreasuryPercentMantissa);
+        treasuryPercentMantissa = newTreasuryPercentMantissa;
+    }
+
+    /// @dev Transfers BEP20 tokens to self, then approves vToken to take these tokens.
+    function _liquidateBep20(
+        VBep20 vToken,
+        address borrower,
+        uint256 repayAmount,
+        VToken vTokenCollateral
+    )
+        internal
+    {
+        EIP20Interface borrowedToken = EIP20Interface(vToken.underlying());
+        borrowedToken.transferFrom(msg.sender, address(this), repayAmount);
+        borrowedToken.approve(address(vToken), repayAmount);
+        require(
+            vToken.liquidateBorrow(borrower, repayAmount, vTokenCollateral) == 0,
+            "failed to liquidate"
+        );
+    }
+
+    /// @dev Splits the received vTokens between the liquidator and treasury.
+    function _distributeLiquidationIncentive(VToken vTokenCollateral, uint256 siezedAmount)
+        internal
+    {
+        (uint256 ours, uint256 theirs) = _splitLiquidationIncentive(siezedAmount);
+        vTokenCollateral.transfer(msg.sender, theirs);
+        vTokenCollateral.transfer(treasury, ours);
+    }
+
+    /// @dev Computes the amounts that would go to treasury and to the liquidator.
+    function _splitLiquidationIncentive(uint256 seizedAmount)
+        internal
+        view
+        returns (uint256 ours, uint256 theirs)
+    {
+        uint256 totalIncentive = comptroller.liquidationIncentiveMantissa();
+        uint256 seizedForRepayment = seizedAmount.mul(1e18).div(totalIncentive);
+        ours = seizedForRepayment.mul(treasuryPercentMantissa).div(1e18);
+        theirs = seizedForRepayment.sub(ours);
+        return (ours, theirs);
+    }
+}

--- a/contracts/Utils/ReentrancyGuard.sol
+++ b/contracts/Utils/ReentrancyGuard.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.5.16;
+
+
+contract ReentrancyGuard {
+    bool public _notEntered;
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     */
+    modifier nonReentrant() {
+        require(_notEntered, "re-entered");
+        _notEntered = false;
+        _;
+        _notEntered = true; // get a gas-refund post-Istanbul
+    }
+
+    constructor() internal {
+        _notEntered = true;
+    }
+}

--- a/contracts/Utils/WithAdmin.sol
+++ b/contracts/Utils/WithAdmin.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.5.16;
+
+
+contract WithAdmin {
+    /// @notice Current admin address
+    address public admin;
+
+    /// @notice The one who can become admin by calling _acceptAdmin
+    address public pendingAdmin;
+
+    /// @notice Emitted when pendingAdmin is changed
+    event NewPendingAdmin(address oldPendingAdmin, address newPendingAdmin);
+
+    /// @notice Emitted when pendingAdmin is accepted, which means admin is updated
+    event NewAdmin(address oldAdmin, address newAdmin);
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     */
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "only admin allowed");
+        _;
+    }
+
+    constructor(address admin_) internal {
+        admin = admin_;
+        pendingAdmin = address(0);
+    }
+
+    /**
+      * @notice Begins transfer of admin rights. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer.
+      * @dev Admin function to begin change of admin. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer.
+      * @param newPendingAdmin New pending admin.
+      */
+    function _setPendingAdmin(address newPendingAdmin) external onlyAdmin {
+        emit NewPendingAdmin(pendingAdmin, newPendingAdmin);
+        pendingAdmin = newPendingAdmin;
+    }
+
+    /**
+      * @notice Accepts transfer of admin rights. msg.sender must be pendingAdmin
+      * @dev Admin function for pending admin to accept role and update admin
+      */
+    function _acceptAdmin() external {
+        require(msg.sender == pendingAdmin, "only pending admin allowed");
+
+        emit NewPendingAdmin(pendingAdmin, address(0));
+        emit NewAdmin(admin, pendingAdmin);
+
+        admin = pendingAdmin;
+        pendingAdmin = address(0);
+    }
+}


### PR DESCRIPTION
## Description

Problem: We should split the liquidation incentive between liquidators and treasury. To do this, we need to either upgrade all vTokens (which is not possible due to vBNB), or come up with an intermediary contract that pretends to be a liquidator, and then splits the received vTokens in the right proportion.

Solution: This commit implements the second approach. Liquidator contract is supposed to be the only address allowed to liquidate borrows.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
