### PR TITLE
merge liquidator branch without disabling liquidating interface on Comptroller

### DIFF
--- a/contracts/ComptrollerInterface.sol
+++ b/contracts/ComptrollerInterface.sol
@@ -85,6 +85,7 @@ interface IVAIVault {
 }
 
 interface IComptroller {
+    function liquidationIncentiveMantissa() external view returns (uint);
     /*** Treasury Data ***/
     function treasuryAddress() external view returns (address);
     function treasuryPercent() external view returns (uint);

--- a/contracts/Liquidator.sol
+++ b/contracts/Liquidator.sol
@@ -32,12 +32,15 @@ contract Liquidator is WithAdmin, ReentrancyGuard {
     using SafeMath for uint256;
 
     constructor(
+        address admin_,
         address payable vBnb_,
         address comptroller_,
         address treasury_,
         uint256 treasuryPercentMantissa_
     )
         public
+        WithAdmin(admin_)
+        ReentrancyGuard()
     {
         vBnb = VBNB(vBnb_);
         comptroller = IComptroller(comptroller_);

--- a/contracts/Liquidator.sol
+++ b/contracts/Liquidator.sol
@@ -1,0 +1,128 @@
+pragma solidity ^0.5.16;
+
+import "./ComptrollerInterface.sol";
+import "./EIP20Interface.sol";
+import "./SafeMath.sol";
+import "./VBNB.sol";
+import "./VBep20.sol";
+import "./Utils/ReentrancyGuard.sol";
+import "./Utils/WithAdmin.sol";
+
+contract Liquidator is WithAdmin, ReentrancyGuard {
+
+    /// @notice Address of vBNB contract.
+    VBNB public vBnb;
+
+    /// @notice Address of Venus Unitroller contract.
+    IComptroller comptroller;
+
+    /// @notice Address of Venus Treasury.
+    address public treasury;
+
+    /// @notice Percent of seized amount that goes to treasury.
+    uint256 public treasuryPercentMantissa;
+
+    /// @notice Emitted when once changes the percent of the seized amount
+    ///         that goes to treasury.
+    event NewLiquidationTreasuryPercent(uint256 oldPercent, uint256 newPercent);
+
+    using SafeMath for uint256;
+
+    constructor(
+        address payable vBnb_,
+        address comptroller_,
+        address treasury_,
+        uint256 treasuryPercentMantissa_
+    )
+        public
+    {
+        vBnb = VBNB(vBnb_);
+        comptroller = IComptroller(comptroller_);
+        treasury = treasury_;
+        treasuryPercentMantissa = treasuryPercentMantissa_;
+    }
+
+    /// @notice Liquidates a borrow and splits the seized amount between treasury and
+    ///         liquidator. The liquidators should use this interface instead of calling
+    ///         vToken.liquidateBorrow(...) directly.
+    /// @dev For BNB borrows msg.value should be equal to repayAmount; otherwise msg.value
+    ///      should be zero.
+    /// @param vToken Borrowed vToken
+    /// @param borrower The address of the borrower
+    /// @param repayAmount The amount to repay on behalf of the borrower
+    /// @param vTokenCollateral The collateral to seize
+    function liquidateBorrow(
+        address vToken,
+        address borrower,
+        uint256 repayAmount,
+        VToken vTokenCollateral
+    )
+        external
+        payable
+        nonReentrant
+    {
+        uint256 ourBalanceBefore = vTokenCollateral.balanceOf(address(this));
+        if (vToken == address(vBnb)) {
+            require(repayAmount == msg.value, "wrong amount");
+            vBnb.liquidateBorrow.value(msg.value)(borrower, vTokenCollateral);
+        } else {
+            require(msg.value == 0, "you shouldn't pay for this");
+            _liquidateBep20(VBep20(vToken), borrower, repayAmount, vTokenCollateral);
+        }
+        uint256 ourBalanceAfter = vTokenCollateral.balanceOf(address(this));
+        uint256 seizedAmount = ourBalanceAfter.sub(ourBalanceBefore);
+        _distributeLiquidationIncentive(vTokenCollateral, seizedAmount);
+    }
+
+    /// @notice Sets the new percent of the seized amount that goes to treasury. Should
+    ///         be less than or equal to comptroller.liquidationIncentiveMantissa().
+    /// @param newTreasuryPercentMantissa New treasury percent (scaled by 10^18).
+    function setTreasuryPercent(uint256 newTreasuryPercentMantissa) external onlyAdmin {
+        require(
+            newTreasuryPercentMantissa <= comptroller.liquidationIncentiveMantissa(),
+            "appetite too big"
+        );
+        emit NewLiquidationTreasuryPercent(treasuryPercentMantissa, newTreasuryPercentMantissa);
+        treasuryPercentMantissa = newTreasuryPercentMantissa;
+    }
+
+    /// @dev Transfers BEP20 tokens to self, then approves vToken to take these tokens.
+    function _liquidateBep20(
+        VBep20 vToken,
+        address borrower,
+        uint256 repayAmount,
+        VToken vTokenCollateral
+    )
+        internal
+    {
+        EIP20Interface borrowedToken = EIP20Interface(vToken.underlying());
+        borrowedToken.transferFrom(msg.sender, address(this), repayAmount);
+        borrowedToken.approve(address(vToken), repayAmount);
+        require(
+            vToken.liquidateBorrow(borrower, repayAmount, vTokenCollateral) == 0,
+            "failed to liquidate"
+        );
+    }
+
+    /// @dev Splits the received vTokens between the liquidator and treasury.
+    function _distributeLiquidationIncentive(VToken vTokenCollateral, uint256 siezedAmount)
+        internal
+    {
+        (uint256 ours, uint256 theirs) = _splitLiquidationIncentive(siezedAmount);
+        vTokenCollateral.transfer(msg.sender, theirs);
+        vTokenCollateral.transfer(treasury, ours);
+    }
+
+    /// @dev Computes the amounts that would go to treasury and to the liquidator.
+    function _splitLiquidationIncentive(uint256 seizedAmount)
+        internal
+        view
+        returns (uint256 ours, uint256 theirs)
+    {
+        uint256 totalIncentive = comptroller.liquidationIncentiveMantissa();
+        uint256 seizedForRepayment = seizedAmount.mul(1e18).div(totalIncentive);
+        ours = seizedForRepayment.mul(treasuryPercentMantissa).div(1e18);
+        theirs = seizedForRepayment.sub(ours);
+        return (ours, theirs);
+    }
+}

--- a/contracts/Utils/ReentrancyGuard.sol
+++ b/contracts/Utils/ReentrancyGuard.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.5.16;
+
+
+contract ReentrancyGuard {
+    bool public _notEntered;
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     */
+    modifier nonReentrant() {
+        require(_notEntered, "re-entered");
+        _notEntered = false;
+        _;
+        _notEntered = true; // get a gas-refund post-Istanbul
+    }
+
+    constructor() internal {
+        _notEntered = true;
+    }
+}

--- a/contracts/Utils/WithAdmin.sol
+++ b/contracts/Utils/WithAdmin.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.5.16;
+
+
+contract WithAdmin {
+    /// @notice Current admin address
+    address public admin;
+
+    /// @notice The one who can become admin by calling _acceptAdmin
+    address public pendingAdmin;
+
+    /// @notice Emitted when pendingAdmin is changed
+    event NewPendingAdmin(address oldPendingAdmin, address newPendingAdmin);
+
+    /// @notice Emitted when pendingAdmin is accepted, which means admin is updated
+    event NewAdmin(address oldAdmin, address newAdmin);
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     */
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "only admin allowed");
+        _;
+    }
+
+    constructor(address admin_) internal {
+        admin = admin_;
+        pendingAdmin = address(0);
+    }
+
+    /**
+      * @notice Begins transfer of admin rights. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer.
+      * @dev Admin function to begin change of admin. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer.
+      * @param newPendingAdmin New pending admin.
+      */
+    function _setPendingAdmin(address newPendingAdmin) external onlyAdmin {
+        emit NewPendingAdmin(pendingAdmin, newPendingAdmin);
+        pendingAdmin = newPendingAdmin;
+    }
+
+    /**
+      * @notice Accepts transfer of admin rights. msg.sender must be pendingAdmin
+      * @dev Admin function for pending admin to accept role and update admin
+      */
+    function _acceptAdmin() external {
+        require(msg.sender == pendingAdmin, "only pending admin allowed");
+
+        emit NewPendingAdmin(pendingAdmin, address(0));
+        emit NewAdmin(admin, pendingAdmin);
+
+        admin = pendingAdmin;
+        pendingAdmin = address(0);
+    }
+}

--- a/tests/Contracts/ComptrollerHarness.sol
+++ b/tests/Contracts/ComptrollerHarness.sol
@@ -195,7 +195,7 @@ contract BoolComptroller is ComptrollerInterface {
     bool verifyLiquidateBorrow = true;
     bool verifySeize = true;
     bool verifyTransfer = true;
-
+    uint public liquidationIncentiveMantissa = 11e17;
     bool failCalculateSeizeTokens;
     uint calculatedSeizeTokens;
 
@@ -459,6 +459,11 @@ contract BoolComptroller is ComptrollerInterface {
 
     function setTransferVerify(bool verifyTransfer_) public {
         verifyTransfer = verifyTransfer_;
+    }
+
+    /*** Liquidity/Liquidation Calculations ***/
+    function setAnnouncedLiquidationIncentiveMantissa(uint mantissa_) external {
+        liquidationIncentiveMantissa = mantissa_;
     }
 
     /*** Liquidity/Liquidation Calculations ***/

--- a/tests/Contracts/LiquidatorHarness.sol
+++ b/tests/Contracts/LiquidatorHarness.sol
@@ -1,0 +1,46 @@
+pragma solidity ^0.5.16;
+
+import "../../contracts/Liquidator.sol";
+import "./ComptrollerScenario.sol";
+
+contract LiquidatorHarness is Liquidator {
+
+    constructor(
+        address admin_,
+        address payable vBnb_,
+        address comptroller_,
+        address treasury_,
+        uint256 treasuryPercentMantissa_
+    )
+        public
+        Liquidator(
+            admin_,
+            vBnb_,
+            comptroller_,
+            treasury_,
+            treasuryPercentMantissa_
+        )
+    {}
+
+    event DistributeLiquidationIncentive(uint256 seizeTokensForTreasury, uint256 seizeTokensForLiquidator);
+
+
+    /// @dev Splits the received vTokens between the liquidator and treasury.
+    function distributeLiquidationIncentive(
+        VToken vTokenCollateral,
+        uint256 siezedAmount
+    ) public returns (uint256 ours, uint256 theirs) {
+        (ours, theirs) = super._distributeLiquidationIncentive(vTokenCollateral, siezedAmount);
+        emit DistributeLiquidationIncentive(ours, theirs);
+        return (ours, theirs);
+    }
+
+    /// @dev Computes the amounts that would go to treasury and to the liquidator.
+    function splitLiquidationIncentive(uint256 seizedAmount)
+        public
+        view
+        returns (uint256 ours, uint256 theirs)
+    {
+       return super._splitLiquidationIncentive(seizedAmount);
+    }
+}

--- a/tests/Liquidator/liquidatorHarnessTest.js
+++ b/tests/Liquidator/liquidatorHarnessTest.js
@@ -1,0 +1,89 @@
+const {
+  bnbUnsigned,
+  bnbMantissa,
+} = require('../Utils/BSC');
+const {
+  makeVToken,
+  setBalance,
+} = require('../Utils/Venus');
+
+const repayAmount = bnbUnsigned(10e2);
+const seizeAmount = repayAmount;
+const seizeTokens = seizeAmount.mul(4); // forced
+const announcedIncentive = bnbMantissa('1.10');
+const treasuryPercent = bnbMantissa('0.05');
+
+function calculateSplitSeizedTokens(amount) {
+  const treasuryDelta =
+    amount
+      .mul(bnbMantissa('1')).div(announcedIncentive) // / 1.1
+      .mul(treasuryPercent).div(bnbMantissa('1'));   // * 0.05
+  const liquidatorDelta = amount.sub(treasuryDelta);
+  return { treasuryDelta, liquidatorDelta };
+}
+
+describe('Liquidator', function () {
+  let root, liquidator, borrower, treasury, accounts;
+  let vToken, vTokenCollateral, liquidatorContract, vBnb;
+
+  beforeEach(async () => {
+    [root, liquidator, borrower, treasury, ...accounts] = saddle.accounts;
+    vToken = await makeVToken({ comptrollerOpts: { kind: 'bool' } });
+    vTokenCollateral = await makeVToken({ comptroller: vToken.comptroller });
+    vBnb = await makeVToken({ kind: 'vbnb', comptroller: vToken.comptroller });
+    liquidatorContract = await deploy(
+      'LiquidatorHarness', [
+      root,
+      vBnb._address,
+      vToken.comptroller._address,
+      treasury,
+      treasuryPercent
+    ]
+    );
+  });
+
+  describe('splitLiquidationIncentive', () => {
+
+    it('split liquidationIncentive between Treasury and Liquidator with correct amounts', async () => {
+      const splitResponse = await call(liquidatorContract, 'splitLiquidationIncentive', [seizeTokens]);
+      const expectedData = calculateSplitSeizedTokens(seizeTokens);
+      expect(splitResponse["ours"]).toEqual(expectedData.treasuryDelta.toString());
+      expect(splitResponse["theirs"]).toEqual(expectedData.liquidatorDelta.toString());
+    });
+  });
+
+  describe('distributeLiquidationIncentive', () => {
+    
+    it('distribute the liquidationIncentive between Treasury and Liquidator with correct amounts', async () => {
+      await setBalance(vTokenCollateral, liquidatorContract._address, seizeTokens.add(4e5));
+      const distributeLiquidationIncentiveResponse = 
+      await send(liquidatorContract, 'distributeLiquidationIncentive', [vTokenCollateral._address, seizeTokens]);
+      const expectedData = calculateSplitSeizedTokens(seizeTokens);
+      expect(distributeLiquidationIncentiveResponse).toHaveLog('DistributeLiquidationIncentive', {
+        seizeTokensForTreasury: expectedData.treasuryDelta.toString(),
+        seizeTokensForLiquidator: expectedData.liquidatorDelta.toString()
+      });
+    });
+
+  });
+
+  describe('Fails to distribute LiquidationIncentive', () => {
+    
+    it('Insufficient Collateral in LiquidatorContract - Error for transfer to Liquidator', async () => {
+
+      await expect(send(liquidatorContract, 'distributeLiquidationIncentive', [vTokenCollateral._address, seizeTokens]))
+      .rejects.toRevert("revert failed to transfer to liquidator");
+
+    });
+
+    it('Insufficient Collateral in LiquidatorContract - Error for transfer to Treasury', async () => {
+      const expectedData = calculateSplitSeizedTokens(seizeTokens);
+      await setBalance(vTokenCollateral, liquidatorContract._address, expectedData.liquidatorDelta);
+      await expect(send(liquidatorContract, 'distributeLiquidationIncentive', [vTokenCollateral._address, seizeTokens]))
+      .rejects.toRevert("revert failed to transfer to treasury");
+
+    });
+
+  });
+
+});

--- a/tests/Liquidator/liquidatorTest.js
+++ b/tests/Liquidator/liquidatorTest.js
@@ -1,0 +1,124 @@
+const {
+  bnbGasCost,
+  bnbUnsigned,
+  bnbMantissa
+} = require('../Utils/BSC');
+
+
+const { dfn } = require('../Utils/JS');
+const {
+  makeVToken,
+  fastForward,
+  setBalance,
+  getBalances,
+  adjustBalances,
+  pretendBorrow
+} = require('../Utils/Venus');
+
+const repayAmount = bnbUnsigned(10e2);
+const seizeAmount = repayAmount;
+const seizeTokens = seizeAmount.mul(4); // forced
+const announcedIncentive = bnbMantissa('1.10');
+const treasuryPercent = bnbMantissa('0.05');
+
+async function preApprove(vToken, from, spender, amount, opts = {}) {
+  if (dfn(opts.faucet, true)) {
+    expect(await send(vToken.underlying, 'harnessSetBalance', [from, amount], { from })).toSucceed();
+  }
+
+  return send(vToken.underlying, 'approve', [spender, amount], { from });
+}
+
+async function preLiquidate(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral) {
+  // setup for success in liquidating
+  await send(vToken.comptroller, 'setLiquidateBorrowAllowed', [true]);
+  await send(vToken.comptroller, 'setLiquidateBorrowVerify', [true]);
+  await send(vToken.comptroller, 'setRepayBorrowAllowed', [true]);
+  await send(vToken.comptroller, 'setRepayBorrowVerify', [true]);
+  await send(vToken.comptroller, 'setSeizeAllowed', [true]);
+  await send(vToken.comptroller, 'setSeizeVerify', [true]);
+  await send(vToken.comptroller, 'setFailCalculateSeizeTokens', [false]);
+  await send(vToken.comptroller, 'setAnnouncedLiquidationIncentiveMantissa', [announcedIncentive]);
+  await send(vToken.underlying, 'harnessSetFailTransferFromAddress', [liquidator, false]);
+  await send(vToken.interestRateModel, 'setFailBorrowRate', [false]);
+  await send(vTokenCollateral.interestRateModel, 'setFailBorrowRate', [false]);
+  await send(vTokenCollateral.comptroller, 'setCalculatedSeizeTokens', [seizeTokens]);
+  await setBalance(vTokenCollateral, liquidator, 0);
+  await setBalance(vTokenCollateral, borrower, seizeTokens);
+  await pretendBorrow(vTokenCollateral, borrower, 0, 1, 0);
+  await pretendBorrow(vToken, borrower, 1, 1, repayAmount);
+  await preApprove(vToken, liquidator, liquidatorContract._address, repayAmount);
+}
+
+async function liquidate(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral) {
+  // make sure to have a block delta so we accrue interest
+  await fastForward(vToken, 1);
+  await fastForward(vTokenCollateral, 1);
+  return send(
+    liquidatorContract,
+    'liquidateBorrow',
+    [vToken._address, borrower, repayAmount, vTokenCollateral._address],
+    { from: liquidator }
+  );
+}
+
+function calculateSplitSeizedTokens(amount) {
+  const treasuryDelta =
+      amount
+        .mul(bnbMantissa('1')).div(announcedIncentive) // / 1.1
+        .mul(treasuryPercent).div(bnbMantissa('1'));   // * 0.05
+  const liquidatorDelta = amount.sub(treasuryDelta);
+  return { treasuryDelta, liquidatorDelta };
+}
+
+describe('Liquidator', function () {
+  let root, liquidator, borrower, treasury, accounts;
+  let vToken, vTokenCollateral, liquidatorContract;
+
+  beforeEach(async () => {
+    [root, liquidator, borrower, treasury, ...accounts] = saddle.accounts;
+    vToken = await makeVToken({ comptrollerOpts: { kind: 'bool' } });
+    vTokenCollateral = await makeVToken({ comptroller: vToken.comptroller });
+    vBnb = await makeVToken({ kind: 'vbnb', comptroller: vToken.comptroller });
+    liquidatorContract = await deploy(
+      'Liquidator', [
+        root,
+        vBnb._address,
+        vToken.comptroller._address,
+        treasury,
+        treasuryPercent
+      ]
+    );
+    await preLiquidate(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral);
+  });
+
+  describe('liquidateBorrow', () => {
+    it('returns success from liquidateBorrow and transfers the correct amounts', async () => {
+      const beforeBalances = await getBalances([vToken, vTokenCollateral], [treasury, liquidator, borrower]);
+      const result = await liquidate(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral);
+      const gasCost = await bnbGasCost(result);
+      const afterBalances = await getBalances([vToken, vTokenCollateral], [treasury, liquidator, borrower]);
+
+      const { treasuryDelta, liquidatorDelta } = calculateSplitSeizedTokens(seizeTokens);
+      expect(result).toHaveLog('LiquidateBorrowedTokens', {
+        liquidator,
+        borrower,
+        repayAmount: repayAmount.toString(),
+        vTokenCollateral: vTokenCollateral._address,
+        seizeTokensForTreasury: treasuryDelta.toString(),
+        seizeTokensForLiquidator: liquidatorDelta.toString()
+      });
+      expect(afterBalances).toEqual(await adjustBalances(beforeBalances, [
+        [vToken, 'cash', repayAmount],
+        [vToken, 'borrows', -repayAmount],
+        [vToken, liquidator, 'bnb', -gasCost],
+        [vToken, liquidator, 'cash', -repayAmount],
+        [vTokenCollateral, liquidator, 'bnb', -gasCost],
+        [vTokenCollateral, liquidator, 'tokens', liquidatorDelta],
+        [vTokenCollateral, treasury, 'tokens', treasuryDelta],
+        [vToken, borrower, 'borrows', -repayAmount],
+        [vTokenCollateral, borrower, 'tokens', -seizeTokens]
+      ]));
+    });
+  });
+});

--- a/tests/Liquidator/liquidatorTest.js
+++ b/tests/Liquidator/liquidatorTest.js
@@ -22,6 +22,7 @@ const announcedIncentive = bnbMantissa('1.10');
 const treasuryPercent = bnbMantissa('0.05');
 
 async function preApprove(vToken, from, spender, amount, opts = {}) {
+
   if (dfn(opts.faucet, true)) {
     expect(await send(vToken.underlying, 'harnessSetBalance', [from, amount], { from })).toSucceed();
   }
@@ -39,7 +40,10 @@ async function preLiquidate(liquidatorContract, vToken, liquidator, borrower, re
   await send(vToken.comptroller, 'setSeizeVerify', [true]);
   await send(vToken.comptroller, 'setFailCalculateSeizeTokens', [false]);
   await send(vToken.comptroller, 'setAnnouncedLiquidationIncentiveMantissa', [announcedIncentive]);
-  await send(vToken.underlying, 'harnessSetFailTransferFromAddress', [liquidator, false]);
+
+  if (vToken.underlying) {
+    await send(vToken.underlying, 'harnessSetFailTransferFromAddress', [liquidator, false]);
+  }
   await send(vToken.interestRateModel, 'setFailBorrowRate', [false]);
   await send(vTokenCollateral.interestRateModel, 'setFailBorrowRate', [false]);
   await send(vTokenCollateral.comptroller, 'setCalculatedSeizeTokens', [seizeTokens]);
@@ -47,7 +51,9 @@ async function preLiquidate(liquidatorContract, vToken, liquidator, borrower, re
   await setBalance(vTokenCollateral, borrower, seizeTokens);
   await pretendBorrow(vTokenCollateral, borrower, 0, 1, 0);
   await pretendBorrow(vToken, borrower, 1, 1, repayAmount);
-  await preApprove(vToken, liquidator, liquidatorContract._address, repayAmount);
+  if (vToken.underlying) {
+    await preApprove(vToken, liquidator, liquidatorContract._address, repayAmount);
+  }
 }
 
 async function liquidate(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral) {
@@ -62,18 +68,30 @@ async function liquidate(liquidatorContract, vToken, liquidator, borrower, repay
   );
 }
 
+async function liquidatevBnb(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral) {
+  // make sure to have a block delta so we accrue interest
+  await fastForward(vToken, 1);
+  await fastForward(vTokenCollateral, 1);
+  return send(
+    liquidatorContract,
+    'liquidateBorrow',
+    [vToken._address, borrower, repayAmount, vTokenCollateral._address],
+    { from: liquidator, value: repayAmount }
+  );
+}
+
 function calculateSplitSeizedTokens(amount) {
   const treasuryDelta =
-      amount
-        .mul(bnbMantissa('1')).div(announcedIncentive) // / 1.1
-        .mul(treasuryPercent).div(bnbMantissa('1'));   // * 0.05
+    amount
+      .mul(bnbMantissa('1')).div(announcedIncentive) // / 1.1
+      .mul(treasuryPercent).div(bnbMantissa('1'));   // * 0.05
   const liquidatorDelta = amount.sub(treasuryDelta);
   return { treasuryDelta, liquidatorDelta };
 }
 
 describe('Liquidator', function () {
   let root, liquidator, borrower, treasury, accounts;
-  let vToken, vTokenCollateral, liquidatorContract;
+  let vToken, vTokenCollateral, liquidatorContract, vBnb;
 
   beforeEach(async () => {
     [root, liquidator, borrower, treasury, ...accounts] = saddle.accounts;
@@ -82,17 +100,21 @@ describe('Liquidator', function () {
     vBnb = await makeVToken({ kind: 'vbnb', comptroller: vToken.comptroller });
     liquidatorContract = await deploy(
       'Liquidator', [
-        root,
-        vBnb._address,
-        vToken.comptroller._address,
-        treasury,
-        treasuryPercent
-      ]
+      root,
+      vBnb._address,
+      vToken.comptroller._address,
+      treasury,
+      treasuryPercent
+    ]
     );
-    await preLiquidate(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral);
   });
 
   describe('liquidateBorrow', () => {
+
+    beforeEach(async () => {
+      await preLiquidate(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral);
+    });
+
     it('returns success from liquidateBorrow and transfers the correct amounts', async () => {
       const beforeBalances = await getBalances([vToken, vTokenCollateral], [treasury, liquidator, borrower]);
       const result = await liquidate(liquidatorContract, vToken, liquidator, borrower, repayAmount, vTokenCollateral);
@@ -108,6 +130,7 @@ describe('Liquidator', function () {
         seizeTokensForTreasury: treasuryDelta.toString(),
         seizeTokensForLiquidator: liquidatorDelta.toString()
       });
+
       expect(afterBalances).toEqual(await adjustBalances(beforeBalances, [
         [vToken, 'cash', repayAmount],
         [vToken, 'borrows', -repayAmount],
@@ -120,5 +143,42 @@ describe('Liquidator', function () {
         [vTokenCollateral, borrower, 'tokens', -seizeTokens]
       ]));
     });
+
   });
+
+  describe('liquidate vBNB-Borrow', () => {
+
+    beforeEach(async () => {
+      await preLiquidate(liquidatorContract, vBnb, liquidator, borrower, repayAmount, vTokenCollateral);
+    });
+
+    it('liquidate-vBNB and returns success from liquidateBorrow and transfers the correct amounts', async () => {
+      const beforeBalances = await getBalances([vBnb, vTokenCollateral], [treasury, liquidator, borrower]);
+      const result = await liquidatevBnb(liquidatorContract, vBnb, liquidator, borrower, repayAmount, vTokenCollateral);
+      const gasCost = await bnbGasCost(result);
+      const afterBalances = await getBalances([vBnb, vTokenCollateral], [treasury, liquidator, borrower]);
+
+      const { treasuryDelta, liquidatorDelta } = calculateSplitSeizedTokens(seizeTokens);
+      expect(result).toHaveLog('LiquidateBorrowedTokens', {
+        liquidator,
+        borrower,
+        repayAmount: repayAmount.toString(),
+        vTokenCollateral: vTokenCollateral._address,
+        seizeTokensForTreasury: treasuryDelta.toString(),
+        seizeTokensForLiquidator: liquidatorDelta.toString()
+      });
+
+      expect(afterBalances).toEqual(await adjustBalances(beforeBalances, [
+        [vBnb, 'bnb', repayAmount],
+        [vBnb, 'borrows', -repayAmount],
+        [vBnb, liquidator, 'bnb', -(gasCost.add(repayAmount))],
+        [vTokenCollateral, liquidator, 'bnb', -(gasCost.add(repayAmount))],
+        [vTokenCollateral, liquidator, 'tokens', liquidatorDelta],
+        [vTokenCollateral, treasury, 'tokens', treasuryDelta],
+        [vBnb, borrower, 'borrows', -repayAmount],
+        [vTokenCollateral, borrower, 'tokens', -seizeTokens]
+      ]));
+    });
+  });
+
 });


### PR DESCRIPTION
## Description

merge the liquidator branch, but since our liquidators should have time switch to new liquidator interface, we won't disable the original liquidating interface for now.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
