### PR TITLE
Run CI on develop branch

### DIFF
--- a/.github/workflows/venus-protocol.yml
+++ b/.github/workflows/venus-protocol.yml
@@ -10,9 +10,9 @@ name: Venus-Protocol
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 jobs:
   test:


### PR DESCRIPTION
## Description

Currently we don't run CI upon PRs to develop, but we should since it's our new default branch.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
