### PR TITLE
VenusLens with function to get dailyXVS for an account and vToken

### DIFF
--- a/contracts/ComptrollerInterface.sol
+++ b/contracts/ComptrollerInterface.sol
@@ -1,5 +1,8 @@
 pragma solidity ^0.5.16;
 
+import "./VToken.sol";
+import "./PriceOracle.sol";
+
 contract ComptrollerInterfaceG1 {
     /// @notice Indicator that this is a Comptroller contract (for inspection)
     bool public constant isComptroller = true;
@@ -78,6 +81,20 @@ contract ComptrollerInterfaceG2 is ComptrollerInterfaceG1 {
 }
 
 contract ComptrollerInterface is ComptrollerInterfaceG2 {
+
+    function markets(address) external view returns (bool, uint);
+    function oracle() external view returns (PriceOracle);
+    function getAccountLiquidity(address) external view returns (uint, uint, uint);
+    function getAssetsIn(address) external view returns (VToken[] memory);
+    function claimVenus(address) external;
+    function venusAccrued(address) external view returns (uint);
+    function venusSpeeds(address) external view returns (uint);
+    function getAllMarkets() external view returns (VToken[] memory);
+    function venusSupplierIndex(address, address) external view returns (uint);
+    function venusInitialIndex() external view returns (uint224);
+    function venusBorrowerIndex(address, address) external view returns (uint);
+    function venusBorrowState(address) external view returns (uint224, uint32);
+    function venusSupplyState(address) external view returns (uint224, uint32);
 }
 
 interface IVAIVault {

--- a/networks/testnet.json
+++ b/networks/testnet.json
@@ -1,6 +1,6 @@
 {
   "Contracts": {
-    "VenusLens": "0xE1Ea1102Fa5e40c80Ca124aF31462500De93e5d1",
+    "VenusLens": "0x4C97B56d596d5cCc11727c0AD7d171E7F0d5134e",
     "WhitepaperInterestRateModel": "0xdE9beC5102ee897a2c934321309517dD6c0106F4",
     "Comptroller": "0xfd301ad2503b25a7670a45b11a043c20b04ee896",
     "Unitroller": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",

--- a/networks/testnet.json
+++ b/networks/testnet.json
@@ -1,6 +1,6 @@
 {
   "Contracts": {
-    "VenusLens": "0x50198Ee860bB48c5b771EdA676587ca4e15C6e11",
+    "VenusLens": "0xE1Ea1102Fa5e40c80Ca124aF31462500De93e5d1",
     "WhitepaperInterestRateModel": "0xdE9beC5102ee897a2c934321309517dD6c0106F4",
     "Comptroller": "0xfd301ad2503b25a7670a45b11a043c20b04ee896",
     "Unitroller": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",

--- a/scenario/src/Contract/VenusLens.ts
+++ b/scenario/src/Contract/VenusLens.ts
@@ -5,8 +5,8 @@ import { Callable, Sendable } from '../Invokation';
 export interface VenusLensMethods {
   vTokenBalances(vToken: string, account: string): Sendable<[string,number,number,number,number,number]>;
   vTokenBalancesAll(vTokens: string[], account: string): Sendable<[string,number,number,number,number,number][]>;
-  vTokenMetadata(vToken: string): Sendable<[string,number,number,number,number,number,number,number,number,boolean,number,string,number,number]>;
-  vTokenMetadataAll(vTokens: string[]): Sendable<[string,number,number,number,number,number,number,number,number,boolean,number,string,number,number][]>;
+  vTokenMetadata(vToken: string): Sendable<[string,number,number,number,number,number,number,number,number,boolean,number,string,number,number,number,number,number,number]>;
+  vTokenMetadataAll(vTokens: string[]): Sendable<[string,number,number,number,number,number,number,number,number,boolean,number,string,number,number,number,number,number,number][]>;
   vTokenUnderlyingPrice(vToken: string): Sendable<[string,number]>;
   vTokenUnderlyingPriceAll(vTokens: string[]): Sendable<[string,number][]>;
   getAccountLimits(comptroller: string, account: string): Sendable<[string[],number,number]>;

--- a/script/hardhat/lens/deploy-venus-lens.js
+++ b/script/hardhat/lens/deploy-venus-lens.js
@@ -1,0 +1,21 @@
+require("@nomiclabs/hardhat-ethers");
+require("dotenv").config();
+const network = process.env.NETWORK;
+const contractConfigData = require(`../../../networks/${network}.json`);
+const hre = require("hardhat");
+const ethers = hre.ethers;
+const { getDeployer } = require('../../deploy/utils/web3-utils');
+
+const main = async () => {
+    const VenusLensContract = await ethers.getContractFactory("VenusLens");
+    const venuLensContractInstance = await VenusLensContract.deploy({ gasLimit: 10000000 });
+    await venuLensContractInstance.deployed();
+    const deployer = await getDeployer(ethers);
+    console.log(`deployer: ${deployer} has deployed VenusLens at address: ${venuLensContractInstance.address}`);
+};
+
+main().then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/script/hardhat/lens/get-daily-xvs.js
+++ b/script/hardhat/lens/get-daily-xvs.js
@@ -1,0 +1,19 @@
+require("@nomiclabs/hardhat-ethers");
+require("@nomiclabs/hardhat-etherscan");
+require("dotenv").config();
+const network = process.env.NETWORK;
+const contractConfigData = require(`../../../networks/${network}.json`);
+const hre = require("hardhat");
+
+const main = async () => {
+    const venusLensAddress = contractConfigData.Contracts.VenusLens;
+    const comptrollerAddress = contractConfigData.Contracts.Unitroller;
+    const venusLensInstance = await ethers.getContractAt("VenusLens", venusLensAddress);
+    const dailyXVS = await venusLensInstance.getDailyXVS("0x0D29D962Ce3ECc34B41E2885fb0296a1C2fD80fd", comptrollerAddress);
+};
+
+main().then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/script/hardhat/lens/get-vtoken-balance.js
+++ b/script/hardhat/lens/get-vtoken-balance.js
@@ -1,0 +1,19 @@
+require("@nomiclabs/hardhat-ethers");
+require("@nomiclabs/hardhat-etherscan");
+require("dotenv").config();
+const network = process.env.NETWORK;
+const contractConfigData = require(`../../../networks/${network}.json`);
+const hre = require("hardhat");
+
+const main = async () => {
+    const venusLensAddress = contractConfigData.Contracts.VenusLens;
+    const venusLensInstance = await ethers.getContractAt("VenusLens", venusLensAddress);
+    const vTokenBalance = await venusLensInstance.vTokenBalances("0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7", "0x0D29D962Ce3ECc34B41E2885fb0296a1C2fD80fd");
+    console.log(`vTokenBalance is: ${JSON.stringify(vTokenBalance)}`);
+};
+
+main().then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/script/hardhat/lens/verify-venus-lens.js
+++ b/script/hardhat/lens/verify-venus-lens.js
@@ -1,0 +1,19 @@
+require("@nomiclabs/hardhat-ethers");
+require("@nomiclabs/hardhat-etherscan");
+require("dotenv").config();
+const network = process.env.NETWORK;
+const contractConfigData = require(`../../../networks/${network}.json`);
+const hre = require("hardhat");
+
+const main = async () => {
+    const venusLens = contractConfigData.Contracts.VenusLens;
+    await hre.run("verify:verify", {
+        address: venusLens
+    });
+};
+
+main().then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/script/query/lens/get-daily-xvs.js
+++ b/script/query/lens/get-daily-xvs.js
@@ -1,0 +1,10 @@
+const [network, acct] = args;
+const contractConfigData = require(`../../../networks/${network}.json`);
+
+(async () => {  
+  const venusLensAddress = contractConfigData.Contracts.VenusLens;
+  const venusLensContractInstance = await saddle.getContractAt('VenusLens', venusLensAddress);
+  const comptrollerAddress = contractConfigData.Contracts.Unitroller;
+  const dailyXVS = await venusLensContractInstance.methods.getDailyXVS(acct, comptrollerAddress).call();
+  console.log(`dailyXVS of account: ${acct} is: ${dailyXVS}`);
+})();

--- a/script/query/lens/get-underlying-price.js
+++ b/script/query/lens/get-underlying-price.js
@@ -1,0 +1,10 @@
+const [network, symbol] = args;
+const contractConfigData = require(`../../../networks/${network}.json`);
+
+(async () => {  
+  const venusLensAddress = contractConfigData.Contracts.VenusLens;
+  const venusLensContractInstance = await saddle.getContractAt('VenusLens', venusLensAddress);
+  const vtokenAddress = contractConfigData.Contracts[symbol];
+  const underlyingPriceResponse = await venusLensContractInstance.methods.vTokenUnderlyingPrice(vtokenAddress).call();
+  console.log(`underlyingPriceResponse of symbol: ${symbol} is: ${JSON.stringify(underlyingPriceResponse)}`);
+})();

--- a/script/query/lens/get-vtoken-balance.js
+++ b/script/query/lens/get-vtoken-balance.js
@@ -1,0 +1,10 @@
+const [network, acct, symbol] = args;
+const contractConfigData = require(`../../../networks/${network}.json`);
+
+(async () => {  
+  const venusLensAddress = contractConfigData.Contracts.VenusLens;
+  const venusLensContractInstance = await saddle.getContractAt('VenusLens', venusLensAddress);
+  const vtokenAddress = contractConfigData.Contracts[symbol];
+  const vTokenBalance = await venusLensContractInstance.methods.vTokenBalances(vtokenAddress, acct).call();
+  console.log(`vTokenBalance of symbol: ${symbol} of account: ${acct} is: ${JSON.stringify(vTokenBalance)}`);
+})();

--- a/tests/Lens/VenusLensTest.js
+++ b/tests/Lens/VenusLensTest.js
@@ -49,7 +49,11 @@ describe('VenusLens', () => {
           collateralFactorMantissa: "0",
           underlyingAssetAddress: await call(vBep20, 'underlying', []),
           vTokenDecimals: "8",
-          underlyingDecimals: "18"
+          underlyingDecimals: "18",
+          venusSupplySpeed: "0",
+          venusBorrowSpeed: "0",
+          dailySupplyXvs: "0",
+          dailyBorrowXvs: "0"
         }
       );
     });
@@ -73,6 +77,10 @@ describe('VenusLens', () => {
         totalSupply: "0",
         underlyingAssetAddress: "0x0000000000000000000000000000000000000000",
         underlyingDecimals: "18",
+        venusSupplySpeed: "0",
+        venusBorrowSpeed: "0",
+        dailySupplyXvs: "0",
+        dailyBorrowXvs: "0"
       });
     });
   });
@@ -98,7 +106,11 @@ describe('VenusLens', () => {
           collateralFactorMantissa: "0",
           underlyingAssetAddress: await call(vBep20, 'underlying', []),
           vTokenDecimals: "8",
-          underlyingDecimals: "18"
+          underlyingDecimals: "18",
+          venusSupplySpeed: "0",
+          venusBorrowSpeed: "0",
+          dailySupplyXvs: "0",
+          dailyBorrowXvs: "0",
         },
         {
           borrowRatePerBlock: "0",
@@ -115,6 +127,10 @@ describe('VenusLens', () => {
           totalSupply: "0",
           underlyingAssetAddress: "0x0000000000000000000000000000000000000000",
           underlyingDecimals: "18",
+          venusSupplySpeed: "0",
+          venusBorrowSpeed: "0",
+          dailySupplyXvs: "0",
+          dailyBorrowXvs: "0",
         }
       ]);
     });
@@ -363,4 +379,15 @@ describe('VenusLens', () => {
       });
     });
   });
+
+  describe('dailyXVS', () => {
+    it('can get dailyXVS for an account', async () => {
+      let vBep20 = await makeVToken();
+      let comptrollerAddress = await vBep20.comptroller._address;
+      expect(
+        await call(VenusLens, 'getDailyXVS', [acct, comptrollerAddress])
+      ).toEqual("0");
+    });
+  });
+
 });


### PR DESCRIPTION
## Requirement:

**Clickup with details:** https://app.clickup.com/t/2d92per

1. vTokenMetadata of a vTokenAddress to get dailySupplyXvs, dailyBorrowXvs, venusSupplySpeed, venusBorrowSpeed

   enhance Existing function vTokenMetadata to return the 4 new properties in response (struct)
   VenusSpeedPerBlock is accessed from Comptroller for a vTokenAddress
   venusSpeedPerBlock to be multiplied by blockPerDay to get dailySupplyXvs and dailyBorrowXvs

2. a new function to compute dailyXvs of an account across all markets

   Function to get all vTokens from comptroller
   compute dailyXvs for each vToken/market
   aggregate the dailyXvs across all markets


```
   dailyXvsForUser =
    sum for all user's supply markets (market.dailyXvsForSuppliers * supplyInUsd(market, user) / market.totalSupplyInUsd)
    +
    sum for all user's borrow markets (market.dailyXvsForBorrowers * borrowsInUsd(market, user) / market.totalBorrowsInUsd)
```
