### PR TITLE
Fine grained pause control

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -1184,6 +1184,10 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @param paused The new paused state (true=paused, false=unpaused)
      */
     function setActionPausedInternal(address market, Action action, bool paused) internal {
+        require(
+            markets[market].isListed,
+            "cannot pause a market that is not listed"
+        );
         _actionPaused[market][uint(action)] = paused;
         emit ActionPausedMarket(VToken(market), action, paused);
     }

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -125,7 +125,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
     }
 
     /// @notice Reverts if a certain action is paused on a market
-    function checkActionPauseState(Action action, address market) private view {
+    function checkActionPauseState(address market, Action action) private view {
         require(!actionPaused(market, action), "action is paused");
     }
 
@@ -196,7 +196,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @return Success indicator for whether the market was entered
      */
     function addToMarketInternal(VToken vToken, address borrower) internal returns (Error) {
-        checkActionPauseState(Action.ENTER_MARKET, address(vToken));
+        checkActionPauseState(address(vToken), Action.ENTER_MARKET);
 
         Market storage marketToJoin = markets[address(vToken)];
         ensureListed(marketToJoin);
@@ -227,7 +227,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @return Whether or not the account successfully exited the market
      */
     function exitMarket(address vTokenAddress) external returns (uint) {
-        checkActionPauseState(Action.EXIT_MARKET, vTokenAddress);
+        checkActionPauseState(vTokenAddress, Action.EXIT_MARKET);
 
         VToken vToken = VToken(vTokenAddress);
         /* Get sender tokensHeld and amountOwed underlying from the vToken */
@@ -289,7 +289,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
     function mintAllowed(address vToken, address minter, uint mintAmount) external returns (uint) {
         // Pausing is a very serious situation - we revert to sound the alarms
         checkProtocolPauseState();
-        checkActionPauseState(Action.MINT, vToken);
+        checkActionPauseState(vToken, Action.MINT);
 
         // Shh - currently unused
         mintAmount;
@@ -336,7 +336,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      */
     function redeemAllowed(address vToken, address redeemer, uint redeemTokens) external returns (uint) {
         checkProtocolPauseState();
-        checkActionPauseState(Action.REDEEM, vToken);
+        checkActionPauseState(vToken, Action.REDEEM);
 
         uint allowed = redeemAllowedInternal(vToken, redeemer, redeemTokens);
         if (allowed != uint(Error.NO_ERROR)) {
@@ -396,7 +396,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
     function borrowAllowed(address vToken, address borrower, uint borrowAmount) external returns (uint) {
         // Pausing is a very serious situation - we revert to sound the alarms
         checkProtocolPauseState();
-        checkActionPauseState(Action.BORROW, vToken);
+        checkActionPauseState(vToken, Action.BORROW);
 
         ensureListed(markets[vToken]);
 
@@ -475,7 +475,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
         returns (uint)
     {
         checkProtocolPauseState();
-        checkActionPauseState(Action.REPAY, vToken);
+        checkActionPauseState(vToken, Action.REPAY);
         // Shh - currently unused
         payer;
         borrower;
@@ -541,7 +541,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
         checkProtocolPauseState();
 
         // if we want to pause liquidating to vTokenCollateral, we should pause seizing
-        checkActionPauseState(Action.LIQUIDATE, vTokenBorrowed);
+        checkActionPauseState(vTokenBorrowed, Action.LIQUIDATE);
 
         if (liquidatorContract != address(0) && liquidator != liquidatorContract) {
             return uint(Error.UNAUTHORIZED);
@@ -629,7 +629,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
     {
         // Pausing is a very serious situation - we revert to sound the alarms
         checkProtocolPauseState();
-        checkActionPauseState(Action.SEIZE, vTokenCollateral);
+        checkActionPauseState(vTokenCollateral, Action.SEIZE);
 
         // Shh - currently unused
         seizeTokens;
@@ -693,7 +693,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
     function transferAllowed(address vToken, address src, address dst, uint transferTokens) external returns (uint) {
         // Pausing is a very serious situation - we revert to sound the alarms
         checkProtocolPauseState();
-        checkActionPauseState(Action.TRANSFER, vToken);
+        checkActionPauseState(vToken, Action.TRANSFER);
 
         // Currently the only consideration is whether or not
         //  the src is allowed to redeem this many tokens

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -47,7 +47,7 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
     event ActionPaused(string action, bool pauseState);
 
     /// @notice Emitted when an action is paused on a market
-    event ActionPausedMarket(VToken vToken, string action, bool pauseState);
+    event ActionPausedMarket(VToken vToken, Action action, bool pauseState);
 
     /// @notice Emitted when Venus VAI Vault rate is changed
     event NewVenusVAIVaultRate(uint oldVenusVAIVaultRate, uint newVenusVAIVaultRate);
@@ -119,9 +119,14 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
         admin = msg.sender;
     }
 
-    modifier onlyProtocolAllowed {
+    /// @notice Reverts if the protocol is paused
+    function checkProtocolPauseState() private view {
         require(!protocolPaused, "protocol is paused");
-        _;
+    }
+
+    /// @notice Reverts if a certain action is paused on a market
+    function checkActionPauseState(Action action, address market) private view {
+        require(!actionPaused(market, action), "action is paused");
     }
 
     /// @notice Reverts if the caller is not admin
@@ -191,6 +196,8 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @return Success indicator for whether the market was entered
      */
     function addToMarketInternal(VToken vToken, address borrower) internal returns (Error) {
+        checkActionPauseState(Action.ENTER_MARKET, address(vToken));
+
         Market storage marketToJoin = markets[address(vToken)];
         ensureListed(marketToJoin);
 
@@ -220,6 +227,8 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @return Whether or not the account successfully exited the market
      */
     function exitMarket(address vTokenAddress) external returns (uint) {
+        checkActionPauseState(Action.EXIT_MARKET, vTokenAddress);
+
         VToken vToken = VToken(vTokenAddress);
         /* Get sender tokensHeld and amountOwed underlying from the vToken */
         (uint oErr, uint tokensHeld, uint amountOwed, ) = vToken.getAccountSnapshot(msg.sender);
@@ -277,9 +286,10 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @param mintAmount The amount of underlying being supplied to the market in exchange for tokens
      * @return 0 if the mint is allowed, otherwise a semi-opaque error code (See ErrorReporter.sol)
      */
-    function mintAllowed(address vToken, address minter, uint mintAmount) external onlyProtocolAllowed returns (uint) {
+    function mintAllowed(address vToken, address minter, uint mintAmount) external returns (uint) {
         // Pausing is a very serious situation - we revert to sound the alarms
-        require(!mintGuardianPaused[vToken], "mint is paused");
+        checkProtocolPauseState();
+        checkActionPauseState(Action.MINT, vToken);
 
         // Shh - currently unused
         mintAmount;
@@ -324,7 +334,10 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @param redeemTokens The number of vTokens to exchange for the underlying asset in the market
      * @return 0 if the redeem is allowed, otherwise a semi-opaque error code (See ErrorReporter.sol)
      */
-    function redeemAllowed(address vToken, address redeemer, uint redeemTokens) external onlyProtocolAllowed returns (uint) {
+    function redeemAllowed(address vToken, address redeemer, uint redeemTokens) external returns (uint) {
+        checkProtocolPauseState();
+        checkActionPauseState(Action.REDEEM, vToken);
+
         uint allowed = redeemAllowedInternal(vToken, redeemer, redeemTokens);
         if (allowed != uint(Error.NO_ERROR)) {
             return allowed;
@@ -380,11 +393,11 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @param borrowAmount The amount of underlying the account would borrow
      * @return 0 if the borrow is allowed, otherwise a semi-opaque error code (See ErrorReporter.sol)
      */
-    function borrowAllowed(address vToken, address borrower, uint borrowAmount) external onlyProtocolAllowed returns (uint) {
+    function borrowAllowed(address vToken, address borrower, uint borrowAmount) external returns (uint) {
         // Pausing is a very serious situation - we revert to sound the alarms
-        require(!borrowGuardianPaused[vToken], "borrow is paused");
+        checkProtocolPauseState();
+        checkActionPauseState(Action.BORROW, vToken);
 
-        // Pausing is a very serious situation - we revert to sound the alarms
         ensureListed(markets[vToken]);
 
         if (!markets[vToken].accountMembership[borrower]) {
@@ -459,9 +472,10 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
         uint repayAmount
     )
         external
-        onlyProtocolAllowed
         returns (uint)
     {
+        checkProtocolPauseState();
+        checkActionPauseState(Action.REPAY, vToken);
         // Shh - currently unused
         payer;
         borrower;
@@ -522,9 +536,13 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
         uint repayAmount
     )
         external
-        onlyProtocolAllowed
         returns (uint)
     {
+        checkProtocolPauseState();
+
+        // if we want to pause liquidating to vTokenCollateral, we should pause seizing
+        checkActionPauseState(Action.LIQUIDATE, vTokenBorrowed);
+
         if (liquidatorContract != address(0) && liquidator != liquidatorContract) {
             return uint(Error.UNAUTHORIZED);
         }
@@ -607,11 +625,11 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
         uint seizeTokens
     )
         external
-        onlyProtocolAllowed
         returns (uint)
     {
         // Pausing is a very serious situation - we revert to sound the alarms
-        require(!seizeGuardianPaused, "seize is paused");
+        checkProtocolPauseState();
+        checkActionPauseState(Action.SEIZE, vTokenCollateral);
 
         // Shh - currently unused
         seizeTokens;
@@ -672,9 +690,10 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @param transferTokens The number of vTokens to transfer
      * @return 0 if the transfer is allowed, otherwise a semi-opaque error code (See ErrorReporter.sol)
      */
-    function transferAllowed(address vToken, address src, address dst, uint transferTokens) external onlyProtocolAllowed returns (uint) {
+    function transferAllowed(address vToken, address src, address dst, uint transferTokens) external returns (uint) {
         // Pausing is a very serious situation - we revert to sound the alarms
-        require(!transferGuardianPaused, "transfer is paused");
+        checkProtocolPauseState();
+        checkActionPauseState(Action.TRANSFER, vToken);
 
         // Currently the only consideration is whether or not
         //  the src is allowed to redeem this many tokens
@@ -1138,6 +1157,38 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
     }
 
     /**
+     * @notice Pause/unpause certain actions
+     * @param markets Markets to pause/unpause the actions on
+     * @param actions List of action ids to pause/unpause
+     * @param paused The new paused state (true=paused, false=unpaused)
+     */
+    function _setActionsPaused(
+        address[] calldata markets,
+        Action[] calldata actions,
+        bool paused
+    )
+        external
+    {
+        ensureAdminOr(pauseGuardian);
+        for (uint market_idx = 0; market_idx < markets.length; ++market_idx) {
+            for (uint action_idx = 0; action_idx < actions.length; ++action_idx) {
+                setActionPausedInternal(markets[market_idx], actions[action_idx], paused);
+            }
+        }
+    }
+
+    /**
+     * @dev Pause/unpause an action on a market
+     * @param market Market to pause/unpause the action on
+     * @param action Action id to pause/unpause
+     * @param paused The new paused state (true=paused, false=unpaused)
+     */
+    function setActionPausedInternal(address market, Action action, bool paused) internal {
+        _actionPaused[market][uint(action)] = paused;
+        emit ActionPausedMarket(VToken(market), action, paused);
+    }
+
+    /**
       * @notice Sets a new VAI controller
       * @dev Admin function to set a new VAI controller
       * @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)
@@ -1543,6 +1594,16 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
         return 0x151B1e2635A717bcDc836ECd6FbB62B674FE3E1D;
     }
 
+    /**
+     * @notice Checks if a certain action is paused on a market
+     * @param action Action id
+     * @param market vToken address
+     */
+    function actionPaused(address market, Action action) public view returns (bool) {
+        return _actionPaused[market][uint(action)];
+    }
+
+
     /*** VAI functions ***/
 
     /**
@@ -1551,7 +1612,9 @@ contract Comptroller is ComptrollerV9Storage, ComptrollerInterfaceG2, Comptrolle
      * @param amount The amount of VAI to set to the account
      * @return The number of minted VAI by `owner`
      */
-    function setMintedVAIOf(address owner, uint amount) external onlyProtocolAllowed returns (uint) {
+    function setMintedVAIOf(address owner, uint amount) external returns (uint) {
+        checkProtocolPauseState();
+
         // Pausing is a very serious situation - we revert to sound the alarms
         require(!mintVAIGuardianPaused && !repayVAIGuardianPaused, "VAI is paused");
         // Check caller is vaiController

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -204,7 +204,22 @@ contract ComptrollerV8Storage is ComptrollerV7Storage {
     mapping(address => uint256) public supplyCaps;
 }
     
-    contract ComptrollerV9Storage is ComptrollerV8Storage {
+contract ComptrollerV9Storage is ComptrollerV8Storage {
     /// @notice AccessControlManager address
     address accessControl;
+
+    enum Action {
+        MINT,
+        REDEEM,
+        BORROW,
+        REPAY,
+        SEIZE,
+        LIQUIDATE,
+        TRANSFER,
+        ENTER_MARKET,
+        EXIT_MARKET
+    }
+
+    /// @notice True if a certain action is paused on a certain market
+    mapping (address => mapping(uint => bool)) internal _actionPaused;
 }

--- a/tests/hardhat/Comptroller/pauseTest.ts
+++ b/tests/hardhat/Comptroller/pauseTest.ts
@@ -1,0 +1,139 @@
+import { Signer } from "ethers";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { smock, MockContract, FakeContract } from "@defi-wonderland/smock";
+import chai from "chai";
+const { expect } = chai;
+chai.use(smock.matchers);
+
+import {
+  Comptroller, PriceOracle, Comptroller__factory, VBep20Immutable, IAccessControlManager
+} from "../../../typechain";
+
+
+type PauseFixture = {
+  accessControl: FakeContract<IAccessControlManager>;
+  comptroller: MockContract<Comptroller>;
+  oracle: FakeContract<PriceOracle>;
+  OMG: FakeContract<VBep20Immutable>;
+  ZRX: FakeContract<VBep20Immutable>;
+  BAT: FakeContract<VBep20Immutable>;
+  SKT: FakeContract<VBep20Immutable>;
+  allTokens: FakeContract<VBep20Immutable>[];
+  names: string[];
+};
+
+async function pauseFixture(): Promise<PauseFixture> {
+  const accessControl = await smock.fake<IAccessControlManager>("AccessControlManager");
+  const ComptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
+  const comptroller = await ComptrollerFactory.deploy();
+  await comptroller._setAccessControl(accessControl.address);
+  const oracle = await smock.fake<PriceOracle>("PriceOracle");
+
+  accessControl.isAllowedToCall.returns(true);
+  await comptroller._setPriceOracle(oracle.address);
+  const names = ["OMG", "ZRX", "BAT", "sketch"];
+  const [OMG, ZRX, BAT, SKT] = await Promise.all(
+    names.map(async (name) => {
+      const vToken = await smock.fake<VBep20Immutable>("VBep20Immutable");
+      if (name !== "sketch") {
+        await comptroller._supportMarket(vToken.address);
+      }
+      return vToken;
+    })
+  );
+  const allTokens = [OMG, ZRX, BAT];
+  return { accessControl, comptroller, oracle, OMG, ZRX, BAT, SKT, allTokens, names };
+}
+
+function configure({ accessControl, oracle, allTokens, names }: PauseFixture) {
+  accessControl.isAllowedToCall.reset();
+  accessControl.isAllowedToCall.returns(true);
+  allTokens.map((vToken, i) => {
+    vToken.isVToken.returns(true);
+    vToken.symbol.returns(names[i]);
+    vToken.name.returns(names[i]);
+    vToken.getAccountSnapshot.returns([0, 0, 0, 0]);
+  });
+}
+
+
+describe("Comptroller", () => {
+  let root: Signer;
+  let rootAddress: string;
+  let customer: Signer;
+  let accounts: Signer[];
+  let accessControl: FakeContract<IAccessControlManager>;
+  let comptroller: MockContract<Comptroller>;
+  let OMG: FakeContract<VBep20Immutable>;
+  let ZRX: FakeContract<VBep20Immutable>;
+  let BAT: FakeContract<VBep20Immutable>;
+  let SKT: FakeContract<VBep20Immutable>;
+
+  beforeEach(async () => {
+    [root, customer, ...accounts] = await ethers.getSigners();
+    const contracts = await loadFixture(pauseFixture);
+    configure(contracts);
+    ({ accessControl, comptroller, OMG, ZRX, BAT, SKT } = contracts);
+    rootAddress = await root.getAddress();
+  });
+
+  describe("_setActionsPaused", () => {
+    it("reverts if AccessControlManager does not allow it", async () => {
+      accessControl.isAllowedToCall
+        .whenCalledWith(rootAddress, "_setActionsPaused(address[],uint256[],bool)")
+        .returns(false);
+      await expect(comptroller._setActionsPaused([OMG.address], [1], true))
+        .to.be.revertedWith("access denied");
+    });
+
+    it("reverts if the market is not listed", async () => {
+      await expect(comptroller._setActionsPaused([SKT.address], [1], true))
+        .to.be.revertedWith("cannot pause a market that is not listed");
+    });
+
+    it("does nothing if the actions list is empty", async () => {
+      await comptroller._setActionsPaused([OMG.address, ZRX.address], [], true);
+      expect(await comptroller.actionPaused(OMG.address, 1)).to.equal(false);
+      expect(await comptroller.actionPaused(ZRX.address, 2)).to.equal(false);
+    });
+
+    it("does nothing if the markets list is empty", async () => {
+      await comptroller._setActionsPaused([], [1, 2, 3, 4, 5], true);
+      expect(await comptroller.actionPaused(OMG.address, 1)).to.equal(false);
+      expect(await comptroller.actionPaused(ZRX.address, 2)).to.equal(false);
+    });
+
+    it("can pause one action on several markets", async () => {
+      await comptroller._setActionsPaused([OMG.address, BAT.address], [1], true);
+      expect(await comptroller.actionPaused(OMG.address, 1)).to.equal(true);
+      expect(await comptroller.actionPaused(ZRX.address, 1)).to.equal(false);
+      expect(await comptroller.actionPaused(BAT.address, 1)).to.equal(true);
+    });
+
+    it("can pause several actions on one market", async () => {
+      await comptroller._setActionsPaused([OMG.address], [3, 5, 6], true);
+      expect(await comptroller.actionPaused(OMG.address, 3)).to.equal(true);
+      expect(await comptroller.actionPaused(OMG.address, 4)).to.equal(false);
+      expect(await comptroller.actionPaused(OMG.address, 5)).to.equal(true);
+      expect(await comptroller.actionPaused(OMG.address, 6)).to.equal(true);
+    });
+
+    it("can pause and unpause several actions on several markets", async () => {
+      await comptroller._setActionsPaused([OMG.address, BAT.address, ZRX.address], [3, 4, 5, 6], true);
+      await comptroller._setActionsPaused([ZRX.address, BAT.address], [3, 5], false);
+      expect(await comptroller.actionPaused(OMG.address, 3)).to.equal(true);
+      expect(await comptroller.actionPaused(OMG.address, 4)).to.equal(true);
+      expect(await comptroller.actionPaused(OMG.address, 5)).to.equal(true);
+      expect(await comptroller.actionPaused(OMG.address, 6)).to.equal(true);
+      expect(await comptroller.actionPaused(ZRX.address, 3)).to.equal(false);
+      expect(await comptroller.actionPaused(ZRX.address, 4)).to.equal(true);
+      expect(await comptroller.actionPaused(ZRX.address, 5)).to.equal(false);
+      expect(await comptroller.actionPaused(ZRX.address, 6)).to.equal(true);
+      expect(await comptroller.actionPaused(BAT.address, 3)).to.equal(false);
+      expect(await comptroller.actionPaused(BAT.address, 4)).to.equal(true);
+      expect(await comptroller.actionPaused(BAT.address, 5)).to.equal(false);
+      expect(await comptroller.actionPaused(BAT.address, 6)).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
## Description

**Problem:** In case of any incident, we would like to be able to just pause certain actions rather than the whole protocol.

**Solution:** Add _setActionsPaused function that accepts a list of markets and actions to pause on these markets. Refactor the current approach to pausing to save some Comptroller space.

**Note:** This change is a bit controversial since it does allow pause guardians to temporarily disable repayBorrow and redeem. This might be worrisome for the community, so I propose we discuss this change publicly before upgrading.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
