### PR TITLE
SupplyCap for VToken

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -14,7 +14,7 @@ import "./ComptrollerLensInterface.sol";
  * @title Venus's Comptroller Contract
  * @author Venus
  */
-contract Comptroller is ComptrollerV7Storage, ComptrollerInterfaceG2, ComptrollerErrorReporter, ExponentialNoError {
+contract Comptroller is ComptrollerV8Storage, ComptrollerInterfaceG2, ComptrollerErrorReporter, ExponentialNoError {
     /// @notice Emitted when an admin supports a market
     event MarketListed(VToken vToken);
 
@@ -95,6 +95,12 @@ contract Comptroller is ComptrollerV7Storage, ComptrollerInterfaceG2, Comptrolle
 
     /// @notice Emitted whe ComptrollerLens address is changed
     event NewComptrollerLens(address oldComptrollerLens, address newComptrollerLens);
+
+    /// @notice Emitted when supply cap for a vToken is changed
+    event NewSupplyCap(VToken indexed vToken, uint newSupplyCap);
+
+    /// @notice Emitted when supply cap guardian is changed
+    event NewSupplyCapGuardian(address oldSupplyCapGuardian, address newSupplyCapGuardian);
 
     /// @notice The initial Venus index for a market
     uint224 public constant venusInitialIndex = 1e36;
@@ -278,6 +284,15 @@ contract Comptroller is ComptrollerV7Storage, ComptrollerInterfaceG2, Comptrolle
         mintAmount;
 
         ensureListed(markets[vToken]);
+
+        uint supplyCap = supplyCaps[vToken];
+
+        // Supply cap of 0 corresponds to Minting notAllowed 
+        require(supplyCap > 0, "market supply cap is 0");
+
+        uint totalSupply = VToken(vToken).totalSupply();
+        uint nextTotalSupply = add_(totalSupply, mintAmount);
+        require(nextTotalSupply <= supplyCap, "market supply cap reached");
 
         // Keep the flywheel moving
         updateVenusSupplyIndex(vToken);
@@ -1020,6 +1035,44 @@ contract Comptroller is ComptrollerV7Storage, ComptrollerInterfaceG2, Comptrolle
 
         // Emit NewBorrowCapGuardian(OldBorrowCapGuardian, NewBorrowCapGuardian)
         emit NewBorrowCapGuardian(oldBorrowCapGuardian, newBorrowCapGuardian);
+    }
+
+    /**
+      * @notice Set the given supply caps for the given vToken markets. Supply that brings total Supply to or above supply cap will revert.
+      * @dev Admin or supplyCapGuardian function to set the supply caps. A supply cap of 0 corresponds to Minting NotAllowed.
+      * @param vTokens The addresses of the markets (tokens) to change the supply caps for
+      * @param newSupplyCaps The new supply cap values in underlying to be set. A value of 0 corresponds to Minting NotAllowed.
+      */
+    function _setMarketSupplyCaps(VToken[] calldata vTokens, uint[] calldata newSupplyCaps) external {
+        require(msg.sender == admin || msg.sender == supplyCapGuardian, "only admin or supply cap guardian can set supply caps");
+
+        uint numMarkets = vTokens.length;
+        uint numSupplyCaps = newSupplyCaps.length;
+
+        require(numMarkets != 0 && numMarkets == numSupplyCaps, "invalid input");
+
+        for(uint i = 0; i < numMarkets; i++) {
+            supplyCaps[address(vTokens[i])] = newSupplyCaps[i];
+            emit NewSupplyCap(vTokens[i], newSupplyCaps[i]);
+        }
+    }
+
+    /**
+     * @notice Admin function to change the Supply Cap Guardian
+     * @param newSupplyCapGuardian The address of the new Supply Cap Guardian
+     */
+    function _setSupplyCapGuardian(address newSupplyCapGuardian) external {
+        ensureAdmin();
+        ensureNonzeroAddress(newSupplyCapGuardian);
+
+        // Save current value for inclusion in log
+        address oldSupplyCapGuardian = supplyCapGuardian;
+
+        // Store supplyCapGuardian with value newSupplyCapGuardian
+        supplyCapGuardian = newSupplyCapGuardian;
+
+        // Emit NewSupplyCapGuardian(OldSupplyCapGuardian, NewSupplyCapGuardian)
+        emit NewSupplyCapGuardian(oldSupplyCapGuardian, newSupplyCapGuardian);
     }
 
     /**

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -199,10 +199,7 @@ contract ComptrollerV7Storage is ComptrollerV6Storage {
 }
 
 contract ComptrollerV8Storage is ComptrollerV7Storage {
-
-    /// @notice The supplyCapGuardian can set supplyCaps to any number for any market. Lowering the supply cap could disable Supply on the given market.
-    address public supplyCapGuardian;
     
     /// @notice Supply caps enforced by mintAllowed for each vToken address. Defaults to zero which corresponds to minting notAllowed
-    mapping(address => uint) public supplyCaps;
+    mapping(address => uint256) public supplyCaps;
 }

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -197,3 +197,12 @@ contract ComptrollerV6Storage is ComptrollerV5Storage {
 contract ComptrollerV7Storage is ComptrollerV6Storage {
     ComptrollerLensInterface public comptrollerLens;
 }
+
+contract ComptrollerV8Storage is ComptrollerV7Storage {
+
+    /// @notice The supplyCapGuardian can set supplyCaps to any number for any market. Lowering the supply cap could disable Supply on the given market.
+    address public supplyCapGuardian;
+    
+    /// @notice Supply caps enforced by mintAllowed for each vToken address. Defaults to zero which corresponds to minting notAllowed
+    mapping(address => uint) public supplyCaps;
+}

--- a/contracts/test/ComptrollerHarness.sol
+++ b/contracts/test/ComptrollerHarness.sol
@@ -526,6 +526,10 @@ contract BoolComptroller is ComptrollerInterface {
         treasuryPercent = treasuryPercent_;
     }
 
+    function _setMarketSupplyCaps(VToken[] calldata vTokens, uint[] calldata newSupplyCaps) external {
+
+    }
+
     /*** Functions from ComptrollerInterface not implemented by BoolComptroller ***/
 
     function markets(address) external view returns (bool, uint) { revert(); }

--- a/contracts/test/ComptrollerScenarioG1.sol
+++ b/contracts/test/ComptrollerScenarioG1.sol
@@ -6,6 +6,8 @@ contract ComptrollerScenarioG1 is ComptrollerG1 {
     uint public blockNumber;
     address public xvsAddress;
     address public vaiAddress;
+    /// @notice Supply caps enforced by mintAllowed for each vToken address. Defaults to zero which corresponds to minting notAllowed
+    mapping(address => uint) public supplyCaps;
 
     constructor() ComptrollerG1() public {}
 
@@ -64,5 +66,24 @@ contract ComptrollerScenarioG1 is ComptrollerG1 {
 
     function unlist(VToken vToken) public {
         markets[address(vToken)].isListed = false;
+    }
+
+    /**
+    * @notice Set the given supply caps for the given vToken markets. Supply that brings total Supply to or above supply cap will revert.
+    * @dev Admin function to set the supply caps. A supply cap of 0 corresponds to Minting NotAllowed.
+    * @param vTokens The addresses of the markets (tokens) to change the supply caps for
+    * @param newSupplyCaps The new supply cap values in underlying to be set. A value of 0 corresponds to Minting NotAllowed.
+    */
+    function _setMarketSupplyCaps(VToken[] calldata vTokens, uint[] calldata newSupplyCaps) external {
+        require(msg.sender == admin , "only admin can set supply caps");
+
+        uint numMarkets = vTokens.length;
+        uint numSupplyCaps = newSupplyCaps.length;
+
+        require(numMarkets != 0 && numMarkets == numSupplyCaps, "invalid input");
+
+        for(uint i = 0; i < numMarkets; i++) {
+            supplyCaps[address(vTokens[i])] = newSupplyCaps[i];
+        }
     }
 }

--- a/contracts/test/ComptrollerScenarioG2.sol
+++ b/contracts/test/ComptrollerScenarioG2.sol
@@ -4,6 +4,8 @@ import "../ComptrollerG2.sol";
 
 contract ComptrollerScenarioG2 is ComptrollerG2 {
     uint public blockNumber;
+    /// @notice Supply caps enforced by mintAllowed for each vToken address. Defaults to zero which corresponds to minting notAllowed
+    mapping(address => uint) public supplyCaps;
 
     constructor() ComptrollerG2() public {}
 
@@ -26,5 +28,24 @@ contract ComptrollerScenarioG2 is ComptrollerG2 {
 
     function setVenusSpeed(address vToken, uint venusSpeed) public {
         venusSpeeds[vToken] = venusSpeed;
+    }
+
+    /**
+    * @notice Set the given supply caps for the given vToken markets. Supply that brings total Supply to or above supply cap will revert.
+    * @dev Admin function to set the supply caps. A supply cap of 0 corresponds to Minting NotAllowed.
+    * @param vTokens The addresses of the markets (tokens) to change the supply caps for
+    * @param newSupplyCaps The new supply cap values in underlying to be set. A value of 0 corresponds to Minting NotAllowed.
+    */
+    function _setMarketSupplyCaps(VToken[] calldata vTokens, uint[] calldata newSupplyCaps) external {
+        require(msg.sender == admin , "only admin can set supply caps");
+
+        uint numMarkets = vTokens.length;
+        uint numSupplyCaps = newSupplyCaps.length;
+
+        require(numMarkets != 0 && numMarkets == numSupplyCaps, "invalid input");
+
+        for(uint i = 0; i < numMarkets; i++) {
+            supplyCaps[address(vTokens[i])] = newSupplyCaps[i];
+        }
     }
 }

--- a/scenario/src/Contract/Comptroller.ts
+++ b/scenario/src/Contract/Comptroller.ts
@@ -57,9 +57,7 @@ interface ComptrollerMethods {
   _setMarketBorrowCaps(vTokens:string[], borrowCaps:encodedNumber[]): Sendable<void>
   _setMarketSupplyCaps(vTokens:string[], supplyCaps:encodedNumber[]): Sendable<void>
   _setBorrowCapGuardian(string): Sendable<void>
-  _setSupplyCapGuardian(string): Sendable<void>
   borrowCapGuardian(): Callable<string>
-  supplyCapGuardian(): Callable<string>
   borrowCaps(string): Callable<string>
   supplyCaps(string): Callable<string>
   _setTreasuryData(guardian, address, percent: encodedNumber): Sendable<number>

--- a/scenario/src/Contract/Comptroller.ts
+++ b/scenario/src/Contract/Comptroller.ts
@@ -55,9 +55,13 @@ interface ComptrollerMethods {
   _setVenusSpeed(vToken: string, encodedNumber): Sendable<void>
   mintedVAIs(string): Callable<number>
   _setMarketBorrowCaps(vTokens:string[], borrowCaps:encodedNumber[]): Sendable<void>
+  _setMarketSupplyCaps(vTokens:string[], supplyCaps:encodedNumber[]): Sendable<void>
   _setBorrowCapGuardian(string): Sendable<void>
+  _setSupplyCapGuardian(string): Sendable<void>
   borrowCapGuardian(): Callable<string>
+  supplyCapGuardian(): Callable<string>
   borrowCaps(string): Callable<string>
+  supplyCaps(string): Callable<string>
   _setTreasuryData(guardian, address, percent: encodedNumber): Sendable<number>
 }
 

--- a/scenario/src/Event/ComptrollerEvent.ts
+++ b/scenario/src/Event/ComptrollerEvent.ts
@@ -1,10 +1,10 @@
-import {Event} from '../Event';
-import {addAction, describeUser, World} from '../World';
-import {decodeCall, getPastEvents} from '../Contract';
-import {Comptroller} from '../Contract/Comptroller';
-import {ComptrollerImpl} from '../Contract/ComptrollerImpl';
-import {VToken} from '../Contract/VToken';
-import {invoke} from '../Invokation';
+import { Event } from '../Event';
+import { addAction, describeUser, World } from '../World';
+import { decodeCall, getPastEvents } from '../Contract';
+import { Comptroller } from '../Contract/Comptroller';
+import { ComptrollerImpl } from '../Contract/ComptrollerImpl';
+import { VToken } from '../Contract/VToken';
+import { invoke } from '../Invokation';
 import {
   getAddressV,
   getBoolV,
@@ -22,17 +22,17 @@ import {
   NumberV,
   StringV
 } from '../Value';
-import {Arg, Command, View, processCommandEvent} from '../Command';
-import {buildComptrollerImpl} from '../Builder/ComptrollerImplBuilder';
-import {ComptrollerErrorReporter} from '../ErrorReporter';
-import {getComptroller, getComptrollerImpl} from '../ContractLookup';
-import {getLiquidity} from '../Value/ComptrollerValue';
-import {getVTokenV} from '../Value/VTokenValue';
-import {encodedNumber} from '../Encoding';
-import {encodeABI, rawValues} from "../Utils";
+import { Arg, Command, View, processCommandEvent } from '../Command';
+import { buildComptrollerImpl } from '../Builder/ComptrollerImplBuilder';
+import { ComptrollerErrorReporter } from '../ErrorReporter';
+import { getComptroller, getComptrollerImpl } from '../ContractLookup';
+import { getLiquidity } from '../Value/ComptrollerValue';
+import { getVTokenV } from '../Value/VTokenValue';
+import { encodedNumber } from '../Encoding';
+import { encodeABI, rawValues } from "../Utils";
 
 async function genComptroller(world: World, from: string, params: Event): Promise<World> {
-  let {world: nextWorld, comptrollerImpl: comptroller, comptrollerImplData: comptrollerData} = await buildComptrollerImpl(world, from, params);
+  let { world: nextWorld, comptrollerImpl: comptroller, comptrollerImplData: comptrollerData } = await buildComptrollerImpl(world, from, params);
   world = nextWorld;
 
   world = addAction(
@@ -218,13 +218,13 @@ async function fastForward(world: World, from: string, comptroller: Comptroller,
   return world;
 }
 
-async function sendAny(world: World, from:string, comptroller: Comptroller, signature: string, callArgs: string[]): Promise<World> {
+async function sendAny(world: World, from: string, comptroller: Comptroller, signature: string, callArgs: string[]): Promise<World> {
   const fnData = encodeABI(world, signature, callArgs);
   await world.web3.eth.sendTransaction({
-      to: comptroller._address,
-      data: fnData,
-      from: from
-    })
+    to: comptroller._address,
+    data: fnData,
+    from: from
+  })
   return world;
 }
 
@@ -380,6 +380,30 @@ async function setBorrowCapGuardian(world: World, from: string, comptroller: Com
   return world;
 }
 
+async function setMarketSupplyCaps(world: World, from: string, comptroller: Comptroller, vTokens: VToken[], supplyCaps: NumberV[]): Promise<World> {
+  let invokation = await invoke(world, comptroller.methods._setMarketSupplyCaps(vTokens.map(c => c._address), supplyCaps.map(c => c.encode())), from, ComptrollerErrorReporter);
+
+  world = addAction(
+    world,
+    `Supply caps on ${vTokens} set to ${supplyCaps}`,
+    invokation
+  );
+
+  return world;
+}
+
+async function setSupplyCapGuardian(world: World, from: string, comptroller: Comptroller, newSupplyCapGuardian: string): Promise<World> {
+  let invokation = await invoke(world, comptroller.methods._setSupplyCapGuardian(newSupplyCapGuardian), from, ComptrollerErrorReporter);
+
+  world = addAction(
+    world,
+    `Comptroller: ${describeUser(world, from)} sets supply cap guardian to ${newSupplyCapGuardian}`,
+    invokation
+  );
+
+  return world;
+}
+
 async function setComptrollerLens(world: World, from: string, comptroller: Comptroller, newComptrollerLens: string): Promise<World> {
   let invokation = await invoke(world, comptroller.methods._setComptrollerLens(newComptrollerLens), from, ComptrollerErrorReporter);
 
@@ -413,17 +437,17 @@ async function setTreasuryData(
 
 export function comptrollerCommands() {
   return [
-    new Command<{comptrollerParams: EventV}>(`
+    new Command<{ comptrollerParams: EventV }>(`
         #### Deploy
 
         * "Comptroller Deploy ...comptrollerParams" - Generates a new Comptroller (not as Impl)
           * E.g. "Comptroller Deploy YesNo"
       `,
       "Deploy",
-      [new Arg("comptrollerParams", getEventV, {variadic: true})],
-      (world, from, {comptrollerParams}) => genComptroller(world, from, comptrollerParams.val)
+      [new Arg("comptrollerParams", getEventV, { variadic: true })],
+      (world, from, { comptrollerParams }) => genComptroller(world, from, comptrollerParams.val)
     ),
-    new Command<{comptroller: Comptroller, isPaused: BoolV}>(`
+    new Command<{ comptroller: Comptroller, isPaused: BoolV }>(`
         #### SetProtocolPaused
 
         * "Comptroller SetProtocolPaused <Bool>" - Pauses or unpaused protocol
@@ -431,12 +455,12 @@ export function comptrollerCommands() {
       `,
       "SetProtocolPaused",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("isPaused", getBoolV)
       ],
-      (world, from, {comptroller, isPaused}) => setProtocolPaused(world, from, comptroller, isPaused.val)
+      (world, from, { comptroller, isPaused }) => setProtocolPaused(world, from, comptroller, isPaused.val)
     ),
-    new Command<{comptroller: Comptroller, vToken: VToken}>(`
+    new Command<{ comptroller: Comptroller, vToken: VToken }>(`
         #### SupportMarket
 
         * "Comptroller SupportMarket <VToken>" - Adds support in the Comptroller for the given vToken
@@ -444,12 +468,12 @@ export function comptrollerCommands() {
       `,
       "SupportMarket",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV)
       ],
-      (world, from, {comptroller, vToken}) => supportMarket(world, from, comptroller, vToken)
+      (world, from, { comptroller, vToken }) => supportMarket(world, from, comptroller, vToken)
     ),
-    new Command<{comptroller: Comptroller, vToken: VToken}>(`
+    new Command<{ comptroller: Comptroller, vToken: VToken }>(`
         #### UnList
 
         * "Comptroller UnList <VToken>" - Mock unlists a given market in tests
@@ -457,12 +481,12 @@ export function comptrollerCommands() {
       `,
       "UnList",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV)
       ],
-      (world, from, {comptroller, vToken}) => unlistMarket(world, from, comptroller, vToken)
+      (world, from, { comptroller, vToken }) => unlistMarket(world, from, comptroller, vToken)
     ),
-    new Command<{comptroller: Comptroller, vTokens: VToken[]}>(`
+    new Command<{ comptroller: Comptroller, vTokens: VToken[] }>(`
         #### EnterMarkets
 
         * "Comptroller EnterMarkets (<VToken> ...)" - User enters the given markets
@@ -470,12 +494,12 @@ export function comptrollerCommands() {
       `,
       "EnterMarkets",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
-        new Arg("vTokens", getVTokenV, {mapped: true})
+        new Arg("comptroller", getComptroller, { implicit: true }),
+        new Arg("vTokens", getVTokenV, { mapped: true })
       ],
-      (world, from, {comptroller, vTokens}) => enterMarkets(world, from, comptroller, vTokens.map((c) => c._address))
+      (world, from, { comptroller, vTokens }) => enterMarkets(world, from, comptroller, vTokens.map((c) => c._address))
     ),
-    new Command<{comptroller: Comptroller, vToken: VToken}>(`
+    new Command<{ comptroller: Comptroller, vToken: VToken }>(`
         #### ExitMarket
 
         * "Comptroller ExitMarket <VToken>" - User exits the given markets
@@ -483,12 +507,12 @@ export function comptrollerCommands() {
       `,
       "ExitMarket",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV)
       ],
-      (world, from, {comptroller, vToken}) => exitMarket(world, from, comptroller, vToken._address)
+      (world, from, { comptroller, vToken }) => exitMarket(world, from, comptroller, vToken._address)
     ),
-    new Command<{comptroller: Comptroller, maxAssets: NumberV}>(`
+    new Command<{ comptroller: Comptroller, maxAssets: NumberV }>(`
         #### SetMaxAssets
 
         * "Comptroller SetMaxAssets <Number>" - Sets (or resets) the max allowed asset count
@@ -496,12 +520,12 @@ export function comptrollerCommands() {
       `,
       "SetMaxAssets",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("maxAssets", getNumberV)
       ],
-      (world, from, {comptroller, maxAssets}) => setMaxAssets(world, from, comptroller, maxAssets)
+      (world, from, { comptroller, maxAssets }) => setMaxAssets(world, from, comptroller, maxAssets)
     ),
-    new Command<{comptroller: Comptroller, liquidationIncentive: NumberV}>(`
+    new Command<{ comptroller: Comptroller, liquidationIncentive: NumberV }>(`
         #### LiquidationIncentive
 
         * "Comptroller LiquidationIncentive <Number>" - Sets the liquidation incentive
@@ -509,12 +533,12 @@ export function comptrollerCommands() {
       `,
       "LiquidationIncentive",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("liquidationIncentive", getExpNumberV)
       ],
-      (world, from, {comptroller, liquidationIncentive}) => setLiquidationIncentive(world, from, comptroller, liquidationIncentive)
+      (world, from, { comptroller, liquidationIncentive }) => setLiquidationIncentive(world, from, comptroller, liquidationIncentive)
     ),
-    new Command<{comptroller: Comptroller, newLiquidatorContract: AddressV}>(`
+    new Command<{ comptroller: Comptroller, newLiquidatorContract: AddressV }>(`
         #### SetLiquidatorContract
 
         * "Comptroller SetLiquidatorContract <Address>" - Sets the liquidator contract address
@@ -522,13 +546,13 @@ export function comptrollerCommands() {
       `,
       "SetLiquidatorContract",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("newLiquidatorContract", getAddressV)
       ],
-      (world, from, {comptroller, newLiquidatorContract}) => setLiquidatorContract(world, from, comptroller, newLiquidatorContract.val)
+      (world, from, { comptroller, newLiquidatorContract }) => setLiquidatorContract(world, from, comptroller, newLiquidatorContract.val)
     ),
 
-    new Command<{comptroller: Comptroller, newComptrollerLens: AddressV}>(`
+    new Command<{ comptroller: Comptroller, newComptrollerLens: AddressV }>(`
         #### SetComptrollerLens
 
         * "Comptroller SetComptrollerLens <Address>" - Sets the comptroller lens contract address
@@ -536,13 +560,13 @@ export function comptrollerCommands() {
       `,
       "SetComptrollerLens",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("newComptrollerLens", getAddressV)
       ],
-      (world, from, {comptroller, newComptrollerLens}) => setComptrollerLens(world, from, comptroller, newComptrollerLens.val)
+      (world, from, { comptroller, newComptrollerLens }) => setComptrollerLens(world, from, comptroller, newComptrollerLens.val)
     ),
 
-    new Command<{comptroller: Comptroller, priceOracle: AddressV}>(`
+    new Command<{ comptroller: Comptroller, priceOracle: AddressV }>(`
         #### SetPriceOracle
 
         * "Comptroller SetPriceOracle oracle:<Address>" - Sets the price oracle address
@@ -550,12 +574,12 @@ export function comptrollerCommands() {
       `,
       "SetPriceOracle",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("priceOracle", getAddressV)
       ],
-      (world, from, {comptroller, priceOracle}) => setPriceOracle(world, from, comptroller, priceOracle.val)
+      (world, from, { comptroller, priceOracle }) => setPriceOracle(world, from, comptroller, priceOracle.val)
     ),
-    new Command<{comptroller: Comptroller, vToken: VToken, collateralFactor: NumberV}>(`
+    new Command<{ comptroller: Comptroller, vToken: VToken, collateralFactor: NumberV }>(`
         #### SetCollateralFactor
 
         * "Comptroller SetCollateralFactor <VToken> <Number>" - Sets the collateral factor for given vToken to number
@@ -563,13 +587,13 @@ export function comptrollerCommands() {
       `,
       "SetCollateralFactor",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV),
         new Arg("collateralFactor", getExpNumberV)
       ],
-      (world, from, {comptroller, vToken, collateralFactor}) => setCollateralFactor(world, from, comptroller, vToken, collateralFactor)
+      (world, from, { comptroller, vToken, collateralFactor }) => setCollateralFactor(world, from, comptroller, vToken, collateralFactor)
     ),
-    new Command<{comptroller: Comptroller, closeFactor: NumberV}>(`
+    new Command<{ comptroller: Comptroller, closeFactor: NumberV }>(`
         #### SetCloseFactor
 
         * "Comptroller SetCloseFactor <Number>" - Sets the close factor to given percentage
@@ -577,12 +601,12 @@ export function comptrollerCommands() {
       `,
       "SetCloseFactor",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("closeFactor", getPercentV)
       ],
-      (world, from, {comptroller, closeFactor}) => setCloseFactor(world, from, comptroller, closeFactor)
+      (world, from, { comptroller, closeFactor }) => setCloseFactor(world, from, comptroller, closeFactor)
     ),
-    new Command<{comptroller: Comptroller, vaiMintRate: NumberV}>(`
+    new Command<{ comptroller: Comptroller, vaiMintRate: NumberV }>(`
         #### SetVAIMintRate
 
         * "Comptroller SetVAIMintRate <Number>" - Sets the vai mint rate to given value
@@ -590,12 +614,12 @@ export function comptrollerCommands() {
       `,
       "SetVAIMintRate",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vaiMintRate", getNumberV)
       ],
-      (world, from, {comptroller, vaiMintRate}) => setVAIMintRate(world, from, comptroller, vaiMintRate)
+      (world, from, { comptroller, vaiMintRate }) => setVAIMintRate(world, from, comptroller, vaiMintRate)
     ),
-    new Command<{comptroller: Comptroller, vaicontroller: AddressV}>(`
+    new Command<{ comptroller: Comptroller, vaicontroller: AddressV }>(`
         #### SetVAIController
 
         * "Comptroller SetVAIController vaicontroller:<Address>" - Sets the vai controller address
@@ -603,12 +627,12 @@ export function comptrollerCommands() {
       `,
       "SetVAIController",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vaicontroller", getAddressV)
       ],
-      (world, from, {comptroller, vaicontroller}) => setVAIController(world, from, comptroller, vaicontroller.val)
+      (world, from, { comptroller, vaicontroller }) => setVAIController(world, from, comptroller, vaicontroller.val)
     ),
-    new Command<{comptroller: Comptroller, newPendingAdmin: AddressV}>(`
+    new Command<{ comptroller: Comptroller, newPendingAdmin: AddressV }>(`
         #### SetPendingAdmin
 
         * "Comptroller SetPendingAdmin newPendingAdmin:<Address>" - Sets the pending admin for the Comptroller
@@ -616,12 +640,12 @@ export function comptrollerCommands() {
       `,
       "SetPendingAdmin",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("newPendingAdmin", getAddressV)
       ],
-      (world, from, {comptroller, newPendingAdmin}) => setPendingAdmin(world, from, comptroller, newPendingAdmin.val)
+      (world, from, { comptroller, newPendingAdmin }) => setPendingAdmin(world, from, comptroller, newPendingAdmin.val)
     ),
-    new Command<{comptroller: Comptroller}>(`
+    new Command<{ comptroller: Comptroller }>(`
         #### AcceptAdmin
 
         * "Comptroller AcceptAdmin" - Accepts admin for the Comptroller
@@ -629,11 +653,11 @@ export function comptrollerCommands() {
       `,
       "AcceptAdmin",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
       ],
-      (world, from, {comptroller}) => acceptAdmin(world, from, comptroller)
+      (world, from, { comptroller }) => acceptAdmin(world, from, comptroller)
     ),
-    new Command<{comptroller: Comptroller, blocks: NumberV, _keyword: StringV}>(`
+    new Command<{ comptroller: Comptroller, blocks: NumberV, _keyword: StringV }>(`
         #### FastForward
 
         * "FastForward n:<Number> Blocks" - Moves the block number forward "n" blocks. Note: in "VTokenScenario" and "ComptrollerScenario" the current block number is mocked (starting at 100000). This is the only way for the protocol to see a higher block number (for accruing interest).
@@ -641,51 +665,51 @@ export function comptrollerCommands() {
       `,
       "FastForward",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("blocks", getNumberV),
         new Arg("_keyword", getStringV)
       ],
-      (world, from, {comptroller, blocks}) => fastForward(world, from, comptroller, blocks)
+      (world, from, { comptroller, blocks }) => fastForward(world, from, comptroller, blocks)
     ),
-    new View<{comptroller: Comptroller}>(`
+    new View<{ comptroller: Comptroller }>(`
         #### Liquidity
 
         * "Comptroller Liquidity" - Prints liquidity of all minters or borrowers
       `,
       "Liquidity",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
       ],
-      (world, {comptroller}) => printLiquidity(world, comptroller)
+      (world, { comptroller }) => printLiquidity(world, comptroller)
     ),
-    new View<{comptroller: Comptroller, input: StringV}>(`
+    new View<{ comptroller: Comptroller, input: StringV }>(`
         #### Decode
 
         * "Decode input:<String>" - Prints information about a call to a Comptroller contract
       `,
       "Decode",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("input", getStringV)
 
       ],
-      (world, {comptroller, input}) => decodeCall(world, comptroller, input.val)
+      (world, { comptroller, input }) => decodeCall(world, comptroller, input.val)
     ),
 
-    new Command<{comptroller: Comptroller, signature: StringV, callArgs: StringV[]}>(`
+    new Command<{ comptroller: Comptroller, signature: StringV, callArgs: StringV[] }>(`
       #### Send
       * Comptroller Send functionSignature:<String> callArgs[] - Sends any transaction to comptroller
       * E.g: Comptroller Send "setXVSAddress(address)" (Address XVS)
       `,
       "Send",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("signature", getStringV),
-        new Arg("callArgs", getCoreValue, {variadic: true, mapped: true})
+        new Arg("callArgs", getCoreValue, { variadic: true, mapped: true })
       ],
-      (world, from, {comptroller, signature, callArgs}) => sendAny(world, from, comptroller, signature.val, rawValues(callArgs))
+      (world, from, { comptroller, signature, callArgs }) => sendAny(world, from, comptroller, signature.val, rawValues(callArgs))
     ),
-    new Command<{comptroller: Comptroller, vTokens: VToken[]}>(`
+    new Command<{ comptroller: Comptroller, vTokens: VToken[] }>(`
       #### AddVenusMarkets
 
       * "Comptroller AddVenusMarkets (<Address> ...)" - Makes a market XVS-enabled
@@ -693,12 +717,12 @@ export function comptrollerCommands() {
       `,
       "AddVenusMarkets",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
-        new Arg("vTokens", getVTokenV, {mapped: true})
+        new Arg("comptroller", getComptroller, { implicit: true }),
+        new Arg("vTokens", getVTokenV, { mapped: true })
       ],
-      (world, from, {comptroller, vTokens}) => addVenusMarkets(world, from, comptroller, vTokens)
-     ),
-    new Command<{comptroller: Comptroller, vToken: VToken}>(`
+      (world, from, { comptroller, vTokens }) => addVenusMarkets(world, from, comptroller, vTokens)
+    ),
+    new Command<{ comptroller: Comptroller, vToken: VToken }>(`
       #### DropVenusMarket
 
       * "Comptroller DropVenusMarket <Address>" - Makes a market XVS
@@ -706,13 +730,13 @@ export function comptrollerCommands() {
       `,
       "DropVenusMarket",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV)
       ],
-      (world, from, {comptroller, vToken}) => dropVenusMarket(world, from, comptroller, vToken)
-     ),
+      (world, from, { comptroller, vToken }) => dropVenusMarket(world, from, comptroller, vToken)
+    ),
 
-    new Command<{comptroller: Comptroller}>(`
+    new Command<{ comptroller: Comptroller }>(`
       #### RefreshVenusSpeeds
 
       * "Comptroller RefreshVenusSpeeds" - Recalculates all the Venus market speeds
@@ -720,11 +744,11 @@ export function comptrollerCommands() {
       `,
       "RefreshVenusSpeeds",
       [
-        new Arg("comptroller", getComptroller, {implicit: true})
+        new Arg("comptroller", getComptroller, { implicit: true })
       ],
-      (world, from, {comptroller}) => refreshVenusSpeeds(world, from, comptroller)
+      (world, from, { comptroller }) => refreshVenusSpeeds(world, from, comptroller)
     ),
-    new Command<{comptroller: Comptroller, holder: AddressV}>(`
+    new Command<{ comptroller: Comptroller, holder: AddressV }>(`
       #### ClaimVenus
 
       * "Comptroller ClaimVenus <holder>" - Claims xvs
@@ -732,25 +756,25 @@ export function comptrollerCommands() {
       `,
       "ClaimVenus",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("holder", getAddressV)
       ],
-      (world, from, {comptroller, holder}) => claimVenus(world, from, comptroller, holder.val)
+      (world, from, { comptroller, holder }) => claimVenus(world, from, comptroller, holder.val)
     ),
-    new Command<{comptroller: Comptroller, recipient: AddressV, amount: NumberV}>(`
+    new Command<{ comptroller: Comptroller, recipient: AddressV, amount: NumberV }>(`
       #### GrantXVS
       * "Comptroller GrantXVS <recipient> <amount>" - Grants XVS to a recipient
       * E.g. "Comptroller GrantXVS Geoff 1e18
       `,
       "GrantXVS",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("recipient", getAddressV),
         new Arg("amount", getNumberV)
       ],
-      (world, from, {comptroller, recipient, amount}) => grantXVS(world, from, comptroller, recipient.val, amount)
+      (world, from, { comptroller, recipient, amount }) => grantXVS(world, from, comptroller, recipient.val, amount)
     ),
-    new Command<{comptroller: Comptroller, rate: NumberV}>(`
+    new Command<{ comptroller: Comptroller, rate: NumberV }>(`
       #### SetVenusRate
 
       * "Comptroller SetVenusRate <rate>" - Sets Venus rate
@@ -758,62 +782,90 @@ export function comptrollerCommands() {
       `,
       "SetVenusRate",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("rate", getNumberV)
       ],
-      (world, from, {comptroller, rate}) => setVenusRate(world, from, comptroller, rate)
+      (world, from, { comptroller, rate }) => setVenusRate(world, from, comptroller, rate)
     ),
-    new Command<{comptroller: Comptroller, vToken: VToken, speed: NumberV}>(`
+    new Command<{ comptroller: Comptroller, vToken: VToken, speed: NumberV }>(`
       #### SetVenusSpeed
       * "Comptroller SetVenusSpeed <vToken> <rate>" - Sets XVS speed for market
       * E.g. "Comptroller SetVenusSpeed vToken 1000
       `,
       "SetVenusSpeed",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV),
         new Arg("speed", getNumberV)
       ],
-      (world, from, {comptroller, vToken, speed}) => setVenusSpeed(world, from, comptroller, vToken, speed)
+      (world, from, { comptroller, vToken, speed }) => setVenusSpeed(world, from, comptroller, vToken, speed)
     ),
-    new Command<{comptroller: Comptroller, vTokens: VToken[], borrowCaps: NumberV[]}>(`
+    new Command<{ comptroller: Comptroller, vTokens: VToken[], borrowCaps: NumberV[] }>(`
       #### SetMarketBorrowCaps
       * "Comptroller SetMarketBorrowCaps (<VToken> ...) (<borrowCap> ...)" - Sets Market Borrow Caps
       * E.g "Comptroller SetMarketBorrowCaps (vZRX vUSDC) (10000.0e18, 1000.0e6)
       `,
       "SetMarketBorrowCaps",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
-        new Arg("vTokens", getVTokenV, {mapped: true}),
-        new Arg("borrowCaps", getNumberV, {mapped: true})
+        new Arg("comptroller", getComptroller, { implicit: true }),
+        new Arg("vTokens", getVTokenV, { mapped: true }),
+        new Arg("borrowCaps", getNumberV, { mapped: true })
       ],
-      (world, from, {comptroller,vTokens,borrowCaps}) => setMarketBorrowCaps(world, from, comptroller, vTokens, borrowCaps)
+      (world, from, { comptroller, vTokens, borrowCaps }) => setMarketBorrowCaps(world, from, comptroller, vTokens, borrowCaps)
     ),
-    new Command<{comptroller: Comptroller, newBorrowCapGuardian: AddressV}>(`
+    new Command<{ comptroller: Comptroller, newBorrowCapGuardian: AddressV }>(`
         #### SetBorrowCapGuardian
         * "Comptroller SetBorrowCapGuardian newBorrowCapGuardian:<Address>" - Sets the Borrow Cap Guardian for the Comptroller
           * E.g. "Comptroller SetBorrowCapGuardian Geoff"
       `,
       "SetBorrowCapGuardian",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("newBorrowCapGuardian", getAddressV)
       ],
-      (world, from, {comptroller, newBorrowCapGuardian}) => setBorrowCapGuardian(world, from, comptroller, newBorrowCapGuardian.val)
+      (world, from, { comptroller, newBorrowCapGuardian }) => setBorrowCapGuardian(world, from, comptroller, newBorrowCapGuardian.val)
     ),
-    new Command<{comptroller: Comptroller, guardian: AddressV, address: AddressV, percent: NumberV}>(`
+
+    new Command<{ comptroller: Comptroller, vTokens: VToken[], supplyCaps: NumberV[] }>(`
+      #### SetMarketSupplyCaps
+      * "Comptroller SetMarketSupplyCaps (<VToken> ...) (<borrowCap> ...)" - Sets Market Supply Caps
+      * E.g "Comptroller SetMarketSupplyCaps (vZRX vUSDC) (10000.0e18, 1000.0e6)
+      `,
+      "SetMarketSupplyCaps",
+      [
+        new Arg("comptroller", getComptroller, { implicit: true }),
+        new Arg("vTokens", getVTokenV, { mapped: true }),
+        new Arg("supplyCaps", getNumberV, { mapped: true })
+      ],
+      (world, from, { comptroller, vTokens, supplyCaps }) => setMarketSupplyCaps(world, from, comptroller, vTokens, supplyCaps)
+    ),
+
+    new Command<{ comptroller: Comptroller, newSupplyCapGuardian: AddressV }>(`
+        #### SetSupplyCapGuardian
+        * "Comptroller SetSupplyCapGuardian newSupplyCapGuardian:<Address>" - Sets the Supply Cap Guardian for the Comptroller
+          * E.g. "Comptroller SetSupplyCapGuardian Geoff"
+      `,
+      "SetSupplyCapGuardian",
+      [
+        new Arg("comptroller", getComptroller, { implicit: true }),
+        new Arg("newSupplyCapGuardian", getAddressV)
+      ],
+      (world, from, { comptroller, newSupplyCapGuardian }) => setSupplyCapGuardian(world, from, comptroller, newSupplyCapGuardian.val)
+    ),
+
+    new Command<{ comptroller: Comptroller, guardian: AddressV, address: AddressV, percent: NumberV }>(`
       #### SetTreasuryData
       * "Comptroller SetTreasuryData <guardian> <address> <rate>" - Sets Treasury Data
       * E.g. "Comptroller SetTreasuryData 0x.. 0x.. 1e18
       `,
       "SetTreasuryData",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("guardian", getAddressV),
         new Arg("address", getAddressV),
         new Arg("percent", getNumberV)
       ],
-      (world, from, {comptroller, guardian, address, percent}) => setTreasuryData(world, from, comptroller, guardian.val, address.val, percent)
+      (world, from, { comptroller, guardian, address, percent }) => setTreasuryData(world, from, comptroller, guardian.val, address.val, percent)
     )
   ];
 }

--- a/scenario/src/Event/ComptrollerEvent.ts
+++ b/scenario/src/Event/ComptrollerEvent.ts
@@ -381,23 +381,11 @@ async function setBorrowCapGuardian(world: World, from: string, comptroller: Com
 }
 
 async function setMarketSupplyCaps(world: World, from: string, comptroller: Comptroller, vTokens: VToken[], supplyCaps: NumberV[]): Promise<World> {
-  let invokation = await invoke(world, comptroller.methods._setMarketSupplyCaps(vTokens.map(c => c._address), supplyCaps.map(c => c.encode())), from, ComptrollerErrorReporter);
+    let invokation = await invoke(world, comptroller.methods._setMarketSupplyCaps(vTokens.map(c => c._address), supplyCaps.map(c => c.encode())), from, ComptrollerErrorReporter);
 
   world = addAction(
     world,
     `Supply caps on ${vTokens} set to ${supplyCaps}`,
-    invokation
-  );
-
-  return world;
-}
-
-async function setSupplyCapGuardian(world: World, from: string, comptroller: Comptroller, newSupplyCapGuardian: string): Promise<World> {
-  let invokation = await invoke(world, comptroller.methods._setSupplyCapGuardian(newSupplyCapGuardian), from, ComptrollerErrorReporter);
-
-  world = addAction(
-    world,
-    `Comptroller: ${describeUser(world, from)} sets supply cap guardian to ${newSupplyCapGuardian}`,
     invokation
   );
 
@@ -838,19 +826,6 @@ export function comptrollerCommands() {
         new Arg("supplyCaps", getNumberV, { mapped: true })
       ],
       (world, from, { comptroller, vTokens, supplyCaps }) => setMarketSupplyCaps(world, from, comptroller, vTokens, supplyCaps)
-    ),
-
-    new Command<{ comptroller: Comptroller, newSupplyCapGuardian: AddressV }>(`
-        #### SetSupplyCapGuardian
-        * "Comptroller SetSupplyCapGuardian newSupplyCapGuardian:<Address>" - Sets the Supply Cap Guardian for the Comptroller
-          * E.g. "Comptroller SetSupplyCapGuardian Geoff"
-      `,
-      "SetSupplyCapGuardian",
-      [
-        new Arg("comptroller", getComptroller, { implicit: true }),
-        new Arg("newSupplyCapGuardian", getAddressV)
-      ],
-      (world, from, { comptroller, newSupplyCapGuardian }) => setSupplyCapGuardian(world, from, comptroller, newSupplyCapGuardian.val)
     ),
 
     new Command<{ comptroller: Comptroller, guardian: AddressV, address: AddressV, percent: NumberV }>(`

--- a/scenario/src/Value/ComptrollerValue.ts
+++ b/scenario/src/Value/ComptrollerValue.ts
@@ -1,7 +1,7 @@
-import {Event} from '../Event';
-import {World} from '../World';
-import {Comptroller} from '../Contract/Comptroller';
-import {VToken} from '../Contract/VToken';
+import { Event } from '../Event';
+import { World } from '../World';
+import { Comptroller } from '../Contract/Comptroller';
+import { VToken } from '../Contract/VToken';
 import {
   getAddressV,
   getCoreValue,
@@ -16,10 +16,10 @@ import {
   StringV,
   Value
 } from '../Value';
-import {Arg, Fetcher, getFetcherValue} from '../Command';
-import {getComptroller} from '../ContractLookup';
-import {encodedNumber} from '../Encoding';
-import {getVTokenV} from '../Value/VTokenValue';
+import { Arg, Fetcher, getFetcherValue } from '../Command';
+import { getComptroller } from '../ContractLookup';
+import { encodedNumber } from '../Encoding';
+import { getVTokenV } from '../Value/VTokenValue';
 import { encodeParameters, encodeABI } from '../Utils';
 
 export async function getComptrollerAddress(world: World, comptroller: Comptroller): Promise<AddressV> {
@@ -27,7 +27,7 @@ export async function getComptrollerAddress(world: World, comptroller: Comptroll
 }
 
 export async function getLiquidity(world: World, comptroller: Comptroller, user: string): Promise<NumberV> {
-  let {0: error, 1: liquidity, 2: shortfall} = await comptroller.methods.getAccountLiquidity(user).call();
+  let { 0: error, 1: liquidity, 2: shortfall } = await comptroller.methods.getAccountLiquidity(user).call();
   if (Number(error) != 0) {
     throw new Error(`Failed to compute account liquidity: error code = ${error}`);
   }
@@ -35,7 +35,7 @@ export async function getLiquidity(world: World, comptroller: Comptroller, user:
 }
 
 export async function getHypotheticalLiquidity(world: World, comptroller: Comptroller, account: string, asset: string, redeemTokens: encodedNumber, borrowAmount: encodedNumber): Promise<NumberV> {
-  let {0: error, 1: liquidity, 2: shortfall} = await comptroller.methods.getHypotheticalAccountLiquidity(account, asset, redeemTokens, borrowAmount).call();
+  let { 0: error, 1: liquidity, 2: shortfall } = await comptroller.methods.getHypotheticalAccountLiquidity(account, asset, redeemTokens, borrowAmount).call();
   if (Number(error) != 0) {
     throw new Error(`Failed to compute account hypothetical liquidity: error code = ${error}`);
   }
@@ -75,7 +75,7 @@ async function getPendingAdmin(world: World, comptroller: Comptroller): Promise<
 }
 
 async function getCollateralFactor(world: World, comptroller: Comptroller, vToken: VToken): Promise<NumberV> {
-  let {0: _isListed, 1: collateralFactorMantissa} = await comptroller.methods.markets(vToken._address).call();
+  let { 0: _isListed, 1: collateralFactorMantissa } = await comptroller.methods.markets(vToken._address).call();
   return new NumberV(collateralFactorMantissa, 1e18);
 }
 
@@ -100,13 +100,13 @@ async function getVenusMarkets(world: World, comptroller: Comptroller): Promise<
 }
 
 async function checkListed(world: World, comptroller: Comptroller, vToken: VToken): Promise<BoolV> {
-  let {0: isListed, 1: _collateralFactorMantissa} = await comptroller.methods.markets(vToken._address).call();
+  let { 0: isListed, 1: _collateralFactorMantissa } = await comptroller.methods.markets(vToken._address).call();
 
   return new BoolV(isListed);
 }
 
 async function checkIsVenus(world: World, comptroller: Comptroller, vToken: VToken): Promise<BoolV> {
-  let {0: isListed, 1: _collateralFactorMantissa, 2: isVenus} = await comptroller.methods.markets(vToken._address).call();
+  let { 0: isListed, 1: _collateralFactorMantissa, 2: isVenus } = await comptroller.methods.markets(vToken._address).call();
   return new BoolV(isVenus);
 }
 
@@ -116,16 +116,16 @@ async function mintedVAIs(world: World, comptroller: Comptroller, user: string):
 
 export function comptrollerFetchers() {
   return [
-    new Fetcher<{comptroller: Comptroller}, AddressV>(`
+    new Fetcher<{ comptroller: Comptroller }, AddressV>(`
         #### Address
 
         * "Comptroller Address" - Returns address of comptroller
       `,
       "Address",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      (world, {comptroller}) => getComptrollerAddress(world, comptroller)
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      (world, { comptroller }) => getComptrollerAddress(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller, account: AddressV}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, account: AddressV }, NumberV>(`
         #### Liquidity
 
         * "Comptroller Liquidity <User>" - Returns a given user's trued up liquidity
@@ -133,12 +133,12 @@ export function comptrollerFetchers() {
       `,
       "Liquidity",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("account", getAddressV)
       ],
-      (world, {comptroller, account}) => getLiquidity(world, comptroller, account.val)
+      (world, { comptroller, account }) => getLiquidity(world, comptroller, account.val)
     ),
-    new Fetcher<{comptroller: Comptroller, account: AddressV, action: StringV, amount: NumberV, vToken: VToken}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, account: AddressV, action: StringV, amount: NumberV, vToken: VToken }, NumberV>(`
         #### Hypothetical
 
         * "Comptroller Hypothetical <User> <Action> <Asset> <Number>" - Returns a given user's trued up liquidity given a hypothetical change in asset with redeeming a certain number of tokens and/or borrowing a given amount.
@@ -147,13 +147,13 @@ export function comptrollerFetchers() {
       `,
       "Hypothetical",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("account", getAddressV),
         new Arg("action", getStringV),
         new Arg("amount", getNumberV),
         new Arg("vToken", getVTokenV)
       ],
-      async (world, {comptroller, account, action, vToken, amount}) => {
+      async (world, { comptroller, account, action, vToken, amount }) => {
         let redeemTokens: NumberV;
         let borrowAmount: NumberV;
 
@@ -173,17 +173,17 @@ export function comptrollerFetchers() {
         return await getHypotheticalLiquidity(world, comptroller, account.val, vToken._address, redeemTokens.encode(), borrowAmount.encode());
       }
     ),
-    new Fetcher<{comptroller: Comptroller}, AddressV>(`
+    new Fetcher<{ comptroller: Comptroller }, AddressV>(`
         #### Admin
 
         * "Comptroller Admin" - Returns the Comptrollers's admin
           * E.g. "Comptroller Admin"
       `,
       "Admin",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      (world, {comptroller}) => getAdmin(world, comptroller)
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      (world, { comptroller }) => getAdmin(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller}, AddressV>(`
+    new Fetcher<{ comptroller: Comptroller }, AddressV>(`
         #### PendingAdmin
 
         * "Comptroller PendingAdmin" - Returns the pending admin of the Comptroller
@@ -191,71 +191,71 @@ export function comptrollerFetchers() {
       `,
       "PendingAdmin",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
       ],
-      (world, {comptroller}) => getPendingAdmin(world, comptroller)
+      (world, { comptroller }) => getPendingAdmin(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller}, AddressV>(`
+    new Fetcher<{ comptroller: Comptroller }, AddressV>(`
         #### PriceOracle
 
         * "Comptroller PriceOracle" - Returns the Comptrollers's price oracle
           * E.g. "Comptroller PriceOracle"
       `,
       "PriceOracle",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      (world, {comptroller}) => getPriceOracle(world, comptroller)
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      (world, { comptroller }) => getPriceOracle(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller }, NumberV>(`
         #### CloseFactor
 
         * "Comptroller CloseFactor" - Returns the Comptrollers's close factor
           * E.g. "Comptroller CloseFactor"
       `,
       "CloseFactor",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      (world, {comptroller}) => getCloseFactor(world, comptroller)
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      (world, { comptroller }) => getCloseFactor(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller }, NumberV>(`
         #### MaxAssets
 
         * "Comptroller MaxAssets" - Returns the Comptrollers's max assets
           * E.g. "Comptroller MaxAssets"
       `,
       "MaxAssets",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      (world, {comptroller}) => getMaxAssets(world, comptroller)
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      (world, { comptroller }) => getMaxAssets(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller }, NumberV>(`
         #### LiquidationIncentive
 
         * "Comptroller LiquidationIncentive" - Returns the Comptrollers's liquidation incentive
           * E.g. "Comptroller LiquidationIncentive"
       `,
       "LiquidationIncentive",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      (world, {comptroller}) => getLiquidationIncentive(world, comptroller)
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      (world, { comptroller }) => getLiquidationIncentive(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller}, AddressV>(`
+    new Fetcher<{ comptroller: Comptroller }, AddressV>(`
         #### Implementation
 
         * "Comptroller Implementation" - Returns the Comptrollers's implementation
           * E.g. "Comptroller Implementation"
       `,
       "Implementation",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      (world, {comptroller}) => getImplementation(world, comptroller)
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      (world, { comptroller }) => getImplementation(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller }, NumberV>(`
         #### BlockNumber
 
         * "Comptroller BlockNumber" - Returns the Comptrollers's mocked block number (for scenario runner)
           * E.g. "Comptroller BlockNumber"
       `,
       "BlockNumber",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      (world, {comptroller}) => getBlockNumber(world, comptroller)
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      (world, { comptroller }) => getBlockNumber(world, comptroller)
     ),
-    new Fetcher<{comptroller: Comptroller, vToken: VToken}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, vToken: VToken }, NumberV>(`
         #### CollateralFactor
 
         * "Comptroller CollateralFactor <VToken>" - Returns the collateralFactor associated with a given asset
@@ -263,12 +263,12 @@ export function comptrollerFetchers() {
       `,
       "CollateralFactor",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV)
       ],
-      (world, {comptroller, vToken}) => getCollateralFactor(world, comptroller, vToken)
+      (world, { comptroller, vToken }) => getCollateralFactor(world, comptroller, vToken)
     ),
-    new Fetcher<{comptroller: Comptroller, account: AddressV}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, account: AddressV }, NumberV>(`
         #### MembershipLength
 
         * "Comptroller MembershipLength <User>" - Returns a given user's length of membership
@@ -276,12 +276,12 @@ export function comptrollerFetchers() {
       `,
       "MembershipLength",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("account", getAddressV)
       ],
-      (world, {comptroller, account}) => membershipLength(world, comptroller, account.val)
+      (world, { comptroller, account }) => membershipLength(world, comptroller, account.val)
     ),
-    new Fetcher<{comptroller: Comptroller, account: AddressV, vToken: VToken}, BoolV>(`
+    new Fetcher<{ comptroller: Comptroller, account: AddressV, vToken: VToken }, BoolV>(`
         #### CheckMembership
 
         * "Comptroller CheckMembership <User> <VToken>" - Returns one if user is in asset, zero otherwise.
@@ -289,13 +289,13 @@ export function comptrollerFetchers() {
       `,
       "CheckMembership",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("account", getAddressV),
         new Arg("vToken", getVTokenV)
       ],
-      (world, {comptroller, account, vToken}) => checkMembership(world, comptroller, account.val, vToken)
+      (world, { comptroller, account, vToken }) => checkMembership(world, comptroller, account.val, vToken)
     ),
-    new Fetcher<{comptroller: Comptroller, account: AddressV}, ListV>(`
+    new Fetcher<{ comptroller: Comptroller, account: AddressV }, ListV>(`
         #### AssetsIn
 
         * "Comptroller AssetsIn <User>" - Returns the assets a user is in
@@ -303,12 +303,12 @@ export function comptrollerFetchers() {
       `,
       "AssetsIn",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("account", getAddressV)
       ],
-      (world, {comptroller, account}) => getAssetsIn(world, comptroller, account.val)
+      (world, { comptroller, account }) => getAssetsIn(world, comptroller, account.val)
     ),
-    new Fetcher<{comptroller: Comptroller, vToken: VToken}, BoolV>(`
+    new Fetcher<{ comptroller: Comptroller, vToken: VToken }, BoolV>(`
         #### CheckListed
 
         * "Comptroller CheckListed <VToken>" - Returns true if market is listed, false otherwise.
@@ -316,12 +316,12 @@ export function comptrollerFetchers() {
       `,
       "CheckListed",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV)
       ],
-      (world, {comptroller, vToken}) => checkListed(world, comptroller, vToken)
+      (world, { comptroller, vToken }) => checkListed(world, comptroller, vToken)
     ),
-    new Fetcher<{comptroller: Comptroller, vToken: VToken}, BoolV>(`
+    new Fetcher<{ comptroller: Comptroller, vToken: VToken }, BoolV>(`
         #### CheckIsVenus
 
         * "Comptroller CheckIsVenus <VToken>" - Returns true if market is listed, false otherwise.
@@ -329,45 +329,45 @@ export function comptrollerFetchers() {
       `,
       "CheckIsVenus",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("vToken", getVTokenV)
       ],
-      (world, {comptroller, vToken}) => checkIsVenus(world, comptroller, vToken)
+      (world, { comptroller, vToken }) => checkIsVenus(world, comptroller, vToken)
     ),
 
-    new Fetcher<{comptroller: Comptroller}, BoolV>(`
+    new Fetcher<{ comptroller: Comptroller }, BoolV>(`
         #### _ProtocolPaused
 
         * "_ProtocolPaused" - Returns the Comptrollers's original protocol paused status
         * E.g. "Comptroller _ProtocolPaused"
         `,
-        "_ProtocolPaused",
-        [new Arg("comptroller", getComptroller, {implicit: true})],
-        async (world, {comptroller}) => new BoolV(await comptroller.methods.protocolPaused().call())
+      "_ProtocolPaused",
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      async (world, { comptroller }) => new BoolV(await comptroller.methods.protocolPaused().call())
     ),
-    new Fetcher<{comptroller: Comptroller}, ListV>(`
+    new Fetcher<{ comptroller: Comptroller }, ListV>(`
       #### GetVenusMarkets
 
       * "GetVenusMarkets" - Returns an array of the currently enabled Venus markets. To use the auto-gen array getter venusMarkets(uint), use VenusMarkets
       * E.g. "Comptroller GetVenusMarkets"
       `,
       "GetVenusMarkets",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      async(world, {comptroller}) => await getVenusMarkets(world, comptroller)
-     ),
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      async (world, { comptroller }) => await getVenusMarkets(world, comptroller)
+    ),
 
-    new Fetcher<{comptroller: Comptroller}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller }, NumberV>(`
       #### VenusRate
 
       * "VenusRate" - Returns the current xvs rate.
       * E.g. "Comptroller VenusRate"
       `,
       "VenusRate",
-      [new Arg("comptroller", getComptroller, {implicit: true})],
-      async(world, {comptroller}) => new NumberV(await comptroller.methods.venusRate().call())
+      [new Arg("comptroller", getComptroller, { implicit: true })],
+      async (world, { comptroller }) => new NumberV(await comptroller.methods.venusRate().call())
     ),
 
-    new Fetcher<{comptroller: Comptroller, signature: StringV, callArgs: StringV[]}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, signature: StringV, callArgs: StringV[] }, NumberV>(`
         #### CallNum
 
         * "CallNum signature:<String> ...callArgs<CoreValue>" - Simple direct call method
@@ -375,108 +375,108 @@ export function comptrollerFetchers() {
       `,
       "CallNum",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("signature", getStringV),
-        new Arg("callArgs", getCoreValue, {variadic: true, mapped: true})
+        new Arg("callArgs", getCoreValue, { variadic: true, mapped: true })
       ],
-      async (world, {comptroller, signature, callArgs}) => {
+      async (world, { comptroller, signature, callArgs }) => {
         const fnData = encodeABI(world, signature.val, callArgs.map(a => a.val));
         const res = await world.web3.eth.call({
-            to: comptroller._address,
-            data: fnData
-          })
-        const resNum : any = world.web3.eth.abi.decodeParameter('uint256',res);
+          to: comptroller._address,
+          data: fnData
+        })
+        const resNum: any = world.web3.eth.abi.decodeParameter('uint256', res);
         return new NumberV(resNum);
       }
     ),
-    new Fetcher<{comptroller: Comptroller, VToken: VToken, key: StringV}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, VToken: VToken, key: StringV }, NumberV>(`
         #### VenusSupplyState(address)
 
         * "Comptroller VenusBorrowState vZRX "index"
       `,
       "VenusSupplyState",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("VToken", getVTokenV),
         new Arg("key", getStringV),
       ],
-      async (world, {comptroller, VToken, key}) => {
+      async (world, { comptroller, VToken, key }) => {
         const result = await comptroller.methods.venusSupplyState(VToken._address).call();
         return new NumberV(result[key.val]);
       }
     ),
-    new Fetcher<{comptroller: Comptroller, VToken: VToken, key: StringV}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, VToken: VToken, key: StringV }, NumberV>(`
         #### VenusBorrowState(address)
 
         * "Comptroller VenusBorrowState vZRX "index"
       `,
       "VenusBorrowState",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("VToken", getVTokenV),
         new Arg("key", getStringV),
       ],
-      async (world, {comptroller, VToken, key}) => {
+      async (world, { comptroller, VToken, key }) => {
         const result = await comptroller.methods.venusBorrowState(VToken._address).call();
         return new NumberV(result[key.val]);
       }
     ),
-    new Fetcher<{comptroller: Comptroller, account: AddressV, key: StringV}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, account: AddressV, key: StringV }, NumberV>(`
         #### VenusAccrued(address)
 
         * "Comptroller VenusAccrued Coburn
       `,
       "VenusAccrued",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("account", getAddressV),
       ],
-      async (world, {comptroller,account}) => {
+      async (world, { comptroller, account }) => {
         const result = await comptroller.methods.venusAccrued(account.val).call();
         return new NumberV(result);
       }
     ),
-    new Fetcher<{comptroller: Comptroller, VToken: VToken, account: AddressV}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, VToken: VToken, account: AddressV }, NumberV>(`
         #### venusSupplierIndex
 
         * "Comptroller VenusSupplierIndex vZRX Coburn
       `,
       "VenusSupplierIndex",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("VToken", getVTokenV),
         new Arg("account", getAddressV),
       ],
-      async (world, {comptroller, VToken, account}) => {
+      async (world, { comptroller, VToken, account }) => {
         return new NumberV(await comptroller.methods.venusSupplierIndex(VToken._address, account.val).call());
       }
     ),
-    new Fetcher<{comptroller: Comptroller, VToken: VToken, account: AddressV}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, VToken: VToken, account: AddressV }, NumberV>(`
         #### VenusBorrowerIndex
 
         * "Comptroller VenusBorrowerIndex vZRX Coburn
       `,
       "VenusBorrowerIndex",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("VToken", getVTokenV),
         new Arg("account", getAddressV),
       ],
-      async (world, {comptroller, VToken, account}) => {
+      async (world, { comptroller, VToken, account }) => {
         return new NumberV(await comptroller.methods.venusBorrowerIndex(VToken._address, account.val).call());
       }
     ),
-    new Fetcher<{comptroller: Comptroller, VToken: VToken}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller, VToken: VToken }, NumberV>(`
         #### VenusSpeed
 
         * "Comptroller VenusSpeed vZRX
       `,
       "VenusSpeed",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("VToken", getVTokenV),
       ],
-      async (world, {comptroller, VToken}) => {
+      async (world, { comptroller, VToken }) => {
         return new NumberV(await comptroller.methods.venusSpeeds(VToken._address).call());
       }
     ),
@@ -488,33 +488,57 @@ export function comptrollerFetchers() {
       `,
       "MintedVAI",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg<AddressV>("address", getAddressV)
       ],
       (world, { comptroller, address }) => mintedVAIs(world, comptroller, address.val),
     ),
-    new Fetcher<{comptroller: Comptroller}, AddressV>(`
+    new Fetcher<{ comptroller: Comptroller }, AddressV>(`
         #### BorrowCapGuardian
         * "BorrowCapGuardian" - Returns the Comptrollers's BorrowCapGuardian
         * E.g. "Comptroller BorrowCapGuardian"
         `,
-        "BorrowCapGuardian",
-        [
-          new Arg("comptroller", getComptroller, {implicit: true})
-        ],
-        async (world, {comptroller}) => new AddressV(await comptroller.methods.borrowCapGuardian().call())
+      "BorrowCapGuardian",
+      [
+        new Arg("comptroller", getComptroller, { implicit: true })
+      ],
+      async (world, { comptroller }) => new AddressV(await comptroller.methods.borrowCapGuardian().call())
     ),
-    new Fetcher<{comptroller: Comptroller, VToken: VToken}, NumberV>(`
+    new Fetcher<{ comptroller: Comptroller }, AddressV>(`
+    #### SupplyCapGuardian
+    * "SupplyCapGuardian" - Returns the Comptrollers's SupplyCapGuardian
+    * E.g. "Comptroller SupplyCapGuardian"
+    `,
+      "SupplyCapGuardian",
+      [
+        new Arg("comptroller", getComptroller, { implicit: true })
+      ],
+      async (world, { comptroller }) => new AddressV(await comptroller.methods.supplyCapGuardian().call())
+    ),
+    new Fetcher<{ comptroller: Comptroller, VToken: VToken }, NumberV>(`
         #### BorrowCaps
         * "Comptroller BorrowCaps vZRX
       `,
       "BorrowCaps",
       [
-        new Arg("comptroller", getComptroller, {implicit: true}),
+        new Arg("comptroller", getComptroller, { implicit: true }),
         new Arg("VToken", getVTokenV),
       ],
-      async (world, {comptroller, VToken}) => {
+      async (world, { comptroller, VToken }) => {
         return new NumberV(await comptroller.methods.borrowCaps(VToken._address).call());
+      }
+    ),
+    new Fetcher<{ comptroller: Comptroller, VToken: VToken }, NumberV>(`
+    #### SupplyCaps
+    * "Comptroller SupplyCaps vZRX
+  `,
+      "SupplyCaps",
+      [
+        new Arg("comptroller", getComptroller, { implicit: true }),
+        new Arg("VToken", getVTokenV),
+      ],
+      async (world, { comptroller, VToken }) => {
+        return new NumberV(await comptroller.methods.supplyCaps(VToken._address).call());
       }
     )
   ];

--- a/scenario/src/Value/ComptrollerValue.ts
+++ b/scenario/src/Value/ComptrollerValue.ts
@@ -504,17 +504,6 @@ export function comptrollerFetchers() {
       ],
       async (world, { comptroller }) => new AddressV(await comptroller.methods.borrowCapGuardian().call())
     ),
-    new Fetcher<{ comptroller: Comptroller }, AddressV>(`
-    #### SupplyCapGuardian
-    * "SupplyCapGuardian" - Returns the Comptrollers's SupplyCapGuardian
-    * E.g. "Comptroller SupplyCapGuardian"
-    `,
-      "SupplyCapGuardian",
-      [
-        new Arg("comptroller", getComptroller, { implicit: true })
-      ],
-      async (world, { comptroller }) => new AddressV(await comptroller.methods.supplyCapGuardian().call())
-    ),
     new Fetcher<{ comptroller: Comptroller, VToken: VToken }, NumberV>(`
         #### BorrowCaps
         * "Comptroller BorrowCaps vZRX

--- a/spec/scenario/AddReserves.scen
+++ b/spec/scenario/AddReserves.scen
@@ -1,6 +1,7 @@
 Test "Add all reserves and verify effects"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 500e8) -- 50e18 / 1e9
@@ -36,6 +37,7 @@ Test "Add all reserves and verify effects"
 Test "Remove and re add reserves and remove again"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 500e8)
@@ -78,6 +80,7 @@ Test "Remove and re add reserves and remove again"
 Test "add reserves to empty contract"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Assert Equal (VToken vZRX ExchangeRate) (Exactly 1e9)
     Bep20 ZRX Faucet Root 3e18
     From Root (Bep20 ZRX Approve vZRX 6e18)
@@ -91,6 +94,7 @@ Test "add reserves to empty contract"
 Test "add reserves failures"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (1000000e18)
     Assert Equal (VToken vZRX ExchangeRate) (Exactly 1e9)
     Assert Equal (VToken vZRX Reserves) (Exactly 0e18)
     Bep20 ZRX Faucet Root 2e18
@@ -106,6 +110,7 @@ Test "add reserves failures"
 Test "Add reserves WBTC when paused"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:1e9 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 50e18 WBTC vWBTC
     Mint Geoff 50e18 vWBTC
     Assert Equal (Bep20 vWBTC TokenBalance Geoff) (Exactly 500e8)

--- a/spec/scenario/Borrow.scen
+++ b/spec/scenario/Borrow.scen
@@ -3,6 +3,8 @@ Test "Borrow some BAT and enters BAT if BAT not entered"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken BAT vBAT
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5
@@ -23,6 +25,8 @@ Test "Borrow some BAT fails, but user still entered"
     NewVToken BAT vBAT
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 100e18 vZRX
     EnterMarkets Geoff vZRX
@@ -41,6 +45,8 @@ Test "Borrow some BAT fails when no BAT available"
     NewVToken BAT vBAT
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 100e18 vZRX
     EnterMarkets Geoff vZRX vBAT
@@ -53,6 +59,8 @@ Test "Borrow fails if market not listed"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken BAT vBAT
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
     Prep Geoff Some ZRX vZRX
@@ -67,6 +75,8 @@ Test "Borrow some BAT from Excess Cash"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken BAT vBAT
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5
@@ -82,6 +92,8 @@ Test "Borrow some BAT reverts if borrow is paused"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken BAT vBAT
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5

--- a/spec/scenario/BorrowBalance.scen
+++ b/spec/scenario/BorrowBalance.scen
@@ -4,6 +4,8 @@ Macro NewBorrow borrowAmount borrowRate user=Geoff
     NewComptroller price:1.0 -- TODO: This should really be a price for a specific asset
     NewVToken ZRX vZRX
     NewVToken BAT vBAT borrowRate -- note: cannot use macros with named args right now
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5
@@ -52,6 +54,7 @@ Test "Borrow Balance after accrual then changed interest rate"
     -- Note: this should accrue interest
     InterestRateModel Deploy Fixed Std 0.000004
     VToken vBAT SetInterestRateModel (InterestRateModel Std Address)
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
     -- Check borrow balance still based on old figure (with previous interest accrual)
     Assert Equal (vToken vBAT BorrowBalance Geoff) (Exactly 2.5e18)
     Assert Equal (vToken vBAT TotalBorrowsCurrent) (Exactly 2.5e18)

--- a/spec/scenario/BorrowBnb.scen
+++ b/spec/scenario/BorrowBnb.scen
@@ -5,6 +5,7 @@ Test "Borrow some BNB enters BNB and succeeds when BNB not entered"
     ListedBNBToken vBNB initialExchangeRate:0.005e9
     SetCollateralFactor vZRX collateralFactor:0.5
     SetCollateralFactor vBNB collateralFactor:0.5
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Donate vBNB 0.003e18
     Prep Geoff Some ZRX vZRX
     Mint Geoff 1e18 vZRX
@@ -22,6 +23,7 @@ Test "Borrow some BNB fails when no BNB available"
     ListedBNBToken vBNB initialExchangeRate:0.005e9
     SetCollateralFactor vZRX collateralFactor:0.5
     SetCollateralFactor vBNB collateralFactor:0.5
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 100e18 vZRX
     EnterMarkets Geoff vZRX vBNB
@@ -39,6 +41,7 @@ Test "Borrow some BNB from excess cash"
     ListedBNBToken vBNB initialExchangeRate:0.005e9
     SetCollateralFactor vZRX collateralFactor:0.5
     SetCollateralFactor vBNB collateralFactor:0.5
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Donate vBNB 0.003e18
     Prep Geoff Some ZRX vZRX
     Mint Geoff 1e18 vZRX

--- a/spec/scenario/BorrowCap.scen
+++ b/spec/scenario/BorrowCap.scen
@@ -4,6 +4,8 @@ Test "Attempt to borrow over set cap BEP20"
     NewVToken ZRX vZRX
     NewVToken BAT vBAT
     Comptroller SetMarketBorrowCaps (vBAT) (0.5e18)
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Assert Equal (Comptroller BorrowCaps vBAT) (Exactly 0.5e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
@@ -23,6 +25,8 @@ Test "Attempt to borrow at set cap BEP20"
     NewVToken ZRX vZRX
     NewVToken BAT vBAT
     Comptroller SetMarketBorrowCaps (vBAT) (1000000000000000001)
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5
@@ -41,6 +45,8 @@ Test "Attempt to borrow below set cap BEP20"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken BAT vBAT
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Comptroller SetMarketBorrowCaps (vBAT) (10e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
@@ -62,6 +68,8 @@ Test "Borrow some Bnb over cap"
     ListedBNBToken vBNB initialExchangeRate:0.005e9
     SetCollateralFactor vZRX collateralFactor:0.5
     SetCollateralFactor vBNB collateralFactor:0.5
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
+    Comptroller SetMarketSupplyCaps (vBNB) (0.01e18)
     Comptroller SetMarketBorrowCaps (vBNB) (0.0001e18)
     Donate vBNB 0.003e18
     Prep Geoff Some ZRX vZRX
@@ -78,6 +86,9 @@ Test "Borrow some Bnb enters Bnb and succeeds when Bnb not entered. At borrow ca
     ListedBNBToken vBNB initialExchangeRate:0.005e9
     SetCollateralFactor vZRX collateralFactor:0.5
     SetCollateralFactor vBNB collateralFactor:0.5
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
+    Comptroller SetMarketBorrowCaps (vBNB) (0.01e18)
+    Comptroller SetMarketSupplyCaps (vBNB) (1000e18)
     Comptroller SetMarketBorrowCaps (vBNB) (1000000000000001)
     Donate vBNB 0.003e18
     Prep Geoff Some ZRX vZRX
@@ -97,6 +108,8 @@ Test "Borrow some Bnb enters Bnb and succeeds when Bnb not entered. At under bor
     SetCollateralFactor vZRX collateralFactor:0.5
     SetCollateralFactor vBNB collateralFactor:0.5
     Comptroller SetMarketBorrowCaps (vBNB) (0.01e18)
+    Comptroller SetMarketSupplyCaps (vBNB) (0.01e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Donate vBNB 0.003e18
     Prep Geoff Some ZRX vZRX
     Mint Geoff 1e18 vZRX
@@ -146,6 +159,8 @@ Test "SetBorrowCaps works correctly too"
     NewVToken BAT vBAT
     NewVToken USDC vUSDC
     Comptroller SetMarketBorrowCaps (vBAT vUSDC) (0.5e18 1000001)
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Assert Equal (Comptroller BorrowCaps vBAT) (Exactly 0.5e18)
     Assert Equal (Comptroller BorrowCaps vUSDC) (Exactly 1000001)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow

--- a/spec/scenario/BorrowWBTC.scen
+++ b/spec/scenario/BorrowWBTC.scen
@@ -4,6 +4,8 @@ Test "Borrow some WBTC enters WBTC and succeeds when not entered"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken WBTC vWBTC tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vWBTC 10e8 WBTC -- Faucet some WBTC to borrow
     Support vZRX collateralFactor:0.5
     Support vWBTC collateralFactor:0.5
@@ -19,6 +21,8 @@ Test "Borrow some WBTC fails when no WBTC available"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken WBTC vWBTC tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Support vZRX collateralFactor:0.5
     Support vWBTC collateralFactor:0.5
     Prep Geoff Some ZRX vZRX
@@ -33,6 +37,8 @@ Test "Borrow some WBTC fails when WBTC paused"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken WBTC vWBTC tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vWBTC 10e8 WBTC -- Faucet some WBTC to borrow
     Support vZRX collateralFactor:0.5
     Support vWBTC collateralFactor:0.5
@@ -50,6 +56,8 @@ Test "Borrow some WBTC from Excess Cash"
     NewComptroller price:1.0
     NewVToken ZRX vZRX
     NewVToken WBTC vWBTC tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vWBTC 10e8 WBTC -- Faucet some WBTC to borrow
     Support vZRX collateralFactor:0.5
     Support vWBTC collateralFactor:0.5

--- a/spec/scenario/BreakLiquidate.scen
+++ b/spec/scenario/BreakLiquidate.scen
@@ -4,6 +4,8 @@ Macro NewBorrow borrowAmount mintAmount borrowRate=0.000005 user=Geoff collatera
     Comptroller LiquidationIncentive liquidationIncentive
     NewVToken ZRX vZRX
     NewVToken BAT vBAT borrowRate
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     PriceOracle SetPrice vZRX collateralPrice
     Support vZRX collateralFactor:0.7

--- a/spec/scenario/BreakLiquidateVAI.scen
+++ b/spec/scenario/BreakLiquidateVAI.scen
@@ -5,6 +5,7 @@ Macro NewMintVAI mintVAIAmount mintAmount user=Geoff collateralPrice=1.0 borrowP
     Comptroller SetLiquidatorContract (Address Liquidator)
     Comptroller LiquidationIncentive liquidationIncentive
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
     PriceOracle SetPrice vZRX collateralPrice
     Support vZRX collateralFactor:0.7
     Comptroller SetVAIMintRate 7e3

--- a/spec/scenario/ChangeDelegate.scen
+++ b/spec/scenario/ChangeDelegate.scen
@@ -3,6 +3,7 @@
 Test "Change the delegate"
     NewComptroller
     NewVToken DEL vDEL
+    Comptroller SetMarketSupplyCaps (vDEL) (1000e18)
     Support vDEL collateralFactor:0.5
     Prep Jared Some DEL vDEL
     Mint Jared 100e18 vDEL

--- a/spec/scenario/CoreMacros
+++ b/spec/scenario/CoreMacros
@@ -87,6 +87,7 @@ Macro NewVTokenBringBEP20 bep20 vToken borrowRate=0.000005 initialExchangeRate=2
     InterestRateModel Deploy Fixed StdInterest borrowRate -- Note: interest rate model probably shouldn't be global
     VTokenDelegate Deploy vTokenType vBep20Delegate
     VToken Deploy delegatorType vToken vToken (Bep20 bep20 Address) (Comptroller Address) (InterestRateModel StdInterest Address) initialExchangeRate decimals admin (VTokenDelegate vBep20Delegate Address) becomeImplementationData
+    Comptroller SetMarketSupplyCaps (vToken) (2000e18)
 
 Macro NewVTokenImmutable bep20 vToken borrowRate=0.000005 initialExchangeRate=2e9 decimals=8 tokenType=Standard vTokenType=Scenario admin=Admin
     Bep20 Deploy tokenType bep20 bep20
@@ -108,12 +109,14 @@ Macro ListedVTokenImmutable bep20 vToken borrowRate=0.000005 initialExchangeRate
 Macro ListedBNBToken vToken borrowRate=0.000005 initialExchangeRate=2e9 decimals=8 admin=Admin
     NewBNBToken vToken borrowRate initialExchangeRate decimals admin
     Comptroller SupportMarket vToken
+    Comptroller SetMarketSupplyCaps (vToken) (2000e18)
     PriceOracleProxy Deploy Admin (PriceOracle Address) (Address vBNB) (Address Zero) (Address Zero) (Address Zero) (Address Zero)
     Comptroller SetPriceOracle (PriceOracleProxy Address)
 
 Macro ListedBNBTokenMinted vToken borrowRate=0.000005 initialExchangeRate=2e9 decimals=8 admin=Admin
     NewBNBToken vToken borrowRate initialExchangeRate decimals admin
     Comptroller SupportMarket vToken
+    Comptroller SetMarketSupplyCaps (vToken) (2000e18)
     CallMintBnb Root 1e18 vToken
 
 Macro SetPriceCF vToken price collateralFactor
@@ -263,6 +266,7 @@ Macro BorrowAndRepayWithInterest bep20 vToken amount interestAmount interestRate
     VToken vToken SetReserveFactor reserveRate
     ListedVToken COLLAT cCOLLAT
     Comptroller SetCollateralFactor cCOLLAT 0.9
+    Comptroller SetMarketSupplyCaps (cCOLLAT) (2e30)
     Prep Torrey 1e30 COLLAT cCOLLAT
     Mint Torrey 1e30 cCOLLAT
     EnterMarkets Torrey cCOLLAT vToken
@@ -289,6 +293,7 @@ Macro BorrowAndRepayBnbWithInterest vBnb amount interestAmount interestRate bloc
     VToken vBnb SetReserveFactor reserveRate
     ListedVToken COLLAT cCOLLAT
     Comptroller SetCollateralFactor cCOLLAT 0.9
+    Comptroller SetMarketSupplyCaps (cCOLLAT) (2e30)
     Prep Torrey 1e30 COLLAT cCOLLAT
     Mint Torrey 1e30 cCOLLAT
     EnterMarkets Torrey cCOLLAT vBnb

--- a/spec/scenario/EnterExitMarkets.scen
+++ b/spec/scenario/EnterExitMarkets.scen
@@ -92,6 +92,8 @@ Test "Realistic Market Scenario"
 	ListedVToken ZRX vZRX
 	SetPriceCF vZRX 0.002 0.4
 	ListedBNBToken vBNB
+	Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
+	Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
 	Comptroller SetCollateralFactor vBnb 0.8
 	ListedVToken BAT vBAT
 	SetPriceCF vBAT 0.0015 0.3

--- a/spec/scenario/ExchangeRate.scen
+++ b/spec/scenario/ExchangeRate.scen
@@ -7,6 +7,7 @@ Test "Initial Exchange Rate"
 Test "Initial Exchange Rate with Mint"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:5e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     -- Check initial exchange holds
     Invariant Remains (VToken vZRX ExchangeRateStored) (Exp 5e9)
     -- Mint some tokens and verify invariant still holds
@@ -26,6 +27,7 @@ Test "ZRX: Exch. Rate:2e9, Cash(51e18) + Borrows(2.0e18) - Reserves(0.5e18) / To
     NewComptroller
     -- Decimals You=18, Decimals Us=8 -> 2e9 Exchange Rate
     ListedVToken ZRX vZRX initialExchangeRate:2e9 decimals:8
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Assert Equal (VToken vZRX ExchangeRateStored) (Exp 2e9)
     -- Mint 50.0 ZRX at given exchange rate
     Prep Geoff Some ZRX vZRX
@@ -51,6 +53,7 @@ Test "USDC: Exch. Rate:2e-3, Cash(51e18) + Borrows(2.0e18) - Reserves(0.5e18) / 
     NewComptroller
     -- Decimals You=6, Decimals Us=8 -> 2e-3 Exchange Rate
     ListedVToken USDC vUSDC initialExchangeRate:2e-3 decimals:8
+    Comptroller SetMarketSupplyCaps (vUSDC) (2000e18)
     Assert Equal (VToken vUSDC ExchangeRateStored) (Exp 2e-3)
     -- Mint 50.0 USDC at given exchange rate
     Prep Geoff Little USDC vUSDC

--- a/spec/scenario/Fee.scen
+++ b/spec/scenario/Fee.scen
@@ -21,7 +21,9 @@ Test "Repay borrow should work and not change exchange rate"
     PricedComptroller
     Bep20 Deploy Fee USDT USDT 18 100 Admin
     NewVTokenBringBEP20 USDT vUSDT
+    Comptroller SetMarketSupplyCaps (vUSDT) (2000e18)
     NewVToken ZRX vZRX 0.000005 2e9 8 Standard
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     PriceOracle SetPrice vZRX 1.0
     PriceOracle SetPrice vUSDT 1.0
     Support vZRX 0.5
@@ -47,7 +49,9 @@ Test "Should be able to liquidate fee token borrow"
     Comptroller LiquidationIncentive 1.1
     Bep20 Deploy Fee USDT USDT 18 100 Admin
     NewVTokenBringBEP20 USDT vUSDT
+    Comptroller SetMarketSupplyCaps (vUSDT) (2000e18)
     NewVToken ZRX vZRX 0.000005 2e9 8 Standard
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     PriceOracle SetPrice vZRX 1.0
     PriceOracle SetPrice vUSDT 1.0
     Support vZRX 0.5
@@ -78,6 +82,7 @@ Test "Should be able to redeem a fee VToken, exchange Rate should not change"
     NewComptroller price:1.0
     Bep20 Deploy Fee USDT USDT 18 100 Admin
     NewVTokenBringBEP20 USDT vUSDT
+    Comptroller SetMarketSupplyCaps (vUSDT) (2000e18)
     Support vUSDT collateralFactor:0.5
     Invariant Static (VToken vUSDT ExchangeRate)
     Prep Torrey 1e18 USDT vUSDT
@@ -88,6 +93,7 @@ Test "Order of redeems should not matter if no interest accrued"
     NewComptroller price:1.0
     Bep20 Deploy Fee USDT USDT 18 100 Admin
     NewVTokenBringBEP20 USDT vUSDT
+    Comptroller SetMarketSupplyCaps (vUSDT) (2000e18)
     Support vUSDT collateralFactor:0.5
     Invariant Static (VToken vUSDT ExchangeRate)
     Prep Torrey 1e18 USDT vUSDT

--- a/spec/scenario/Flywheel/Flywheel.scen
+++ b/spec/scenario/Flywheel/Flywheel.scen
@@ -15,6 +15,8 @@ Macro FlywheelComptroller price=1.0 borrowRate=0.000005 venusInitAmount=5000000e
     Comptroller SetVenusRate 1e18
     NewVToken ZRX vZRX
     NewVToken BAT vBAT
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5
     Comptroller AddVenusMarkets (vZRX vBAT)

--- a/spec/scenario/Flywheel/Grants.scen
+++ b/spec/scenario/Flywheel/Grants.scen
@@ -47,6 +47,8 @@ Macro GrantsComptroller
     ComptrollerImpl ComptrollerScen Become
     ComptrollerLens Deploy
     Comptroller SetComptrollerLens (Address ComptrollerLens)
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
 
 Macro InitSpeeds
     Prep Geoff 100e18 ZRX vZRX

--- a/spec/scenario/Flywheel/VenusSpeed.scen
+++ b/spec/scenario/Flywheel/VenusSpeed.scen
@@ -38,6 +38,8 @@ Macro GrantsComptroller
     ComptrollerImpl ComptrollerScen Become
     ComptrollerLens Deploy
     Comptroller SetComptrollerLens (Address ComptrollerLens)
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
+    Comptroller SetMarketSupplyCaps (vBAT) (1000e18)
 
 Macro InitSpeeds
     Prep Geoff 100e18 ZRX vZRX

--- a/spec/scenario/HypotheticalAccountLiquidity.scen
+++ b/spec/scenario/HypotheticalAccountLiquidity.scen
@@ -3,14 +3,18 @@ Test "Calculates hypothetical account liquidity"
     -- Note, this comes a bit from `EnterExitMarkets` Scenario
     PricedComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     SetPriceCF vZRX 0.002 0.4
     ListedBNBToken vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Comptroller SetCollateralFactor vBnb 0.8
     ListedVToken BAT vBAT initialExchangeRate:1e9
     SetPriceCF vBAT 0.0015 0.3
     ListedVToken OMG vOMG initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vOMG) (2000e18)
     NewVToken REP vREP
     -- Mint some vZRX and vBNB
+    Comptroller SetMarketSupplyCaps (vREP) (2000e18)
     Prep Geoff 1250e18 ZRX vZRX
     Mint Geoff 1250e18 vZRX -- Liquidity -> 0.4 * 0.002 * 1250e18 = 1.0e18
     SendMintBnb Geoff 2.5e18 vBNB -- Liqiuidity -> 0.8 * 1.0 * 2.5e18 = 2.0e18

--- a/spec/scenario/InKindLiquidation.scen
+++ b/spec/scenario/InKindLiquidation.scen
@@ -3,6 +3,7 @@ Macro InKindBorrow borrowAmount borrowRate user=Geoff borrowPrice=1.0 mintAmount
     PricedComptrollerWithLiquidator Bank
     Comptroller LiquidationIncentive 1.1
     NewVToken BAT vBAT borrowRate 2e9 8 borrowTokenType -- note: cannot use macros with named args right now
+    Comptroller SetMarketSupplyCaps (vBAT) (2000e18)
     Give vBAT giveAmount BAT -- Faucet some bat
     PriceOracle SetPrice vBAT borrowPrice
     Support vBAT collateralFactor:0.5
@@ -15,6 +16,7 @@ Test "Insufficient in-kind shortfall"
     InKindBorrow borrowAmount:1e18 borrowRate:0.000005
     Assert Equal (VToken vBAT BorrowBalance Geoff) 1e18
     Assert Equal (VToken vBAT TotalBorrows) 1e18
+    Comptroller SetMarketSupplyCaps (vBAT) (2000e18)
     Assert Equal (Bep20 BAT TokenBalance Geoff) 1e18
     Assert Equal (Bep20 BAT TokenBalance vBAT) 99e18
     Assert Equal (Comptroller Liquidity Geoff) 49e18 -- ( ( 1.0 * 100e18 * 0.5 ) - ( 1.0 * 51e18 ) ) / 1e18

--- a/spec/scenario/Mint.scen
+++ b/spec/scenario/Mint.scen
@@ -3,6 +3,7 @@
 Test "Mint 1 vZRX"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 50e9)
@@ -11,6 +12,7 @@ Test "Mint 1 vZRX"
 Test "MintBehalf 1 vZRX"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Assert Equal (Bep20 ZRX TokenBalance Geoff) (Exactly 100e18)
     Assert Equal (Bep20 ZRX TokenBalance Torrey) (Exactly 0)
@@ -24,6 +26,7 @@ Test "MintBehalf 1 vZRX"
 Test "Mint with insufficient allowance"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 50e18 ZRX vZRX allowanceAmount:49e18
     AllowFailures
     Mint Geoff 50e18 vZRX
@@ -33,6 +36,7 @@ Test "Mint with insufficient allowance"
 Test "Mint with insufficient balance"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 49e18 ZRX vZRX allowanceAmount:50e18
     AllowFailures
     Mint Geoff 50e18 vZRX
@@ -42,6 +46,7 @@ Test "Mint with insufficient balance"
 Test "Mint two ZRX after minting two ZRX, and then I mint two more"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 2e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 2e9)
@@ -56,6 +61,7 @@ Test "Mint two ZRX after minting two ZRX, and then I mint two more"
 Test "Two users Mint"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Prep Torrey Some ZRX vZRX
     Mint Geoff 2e18 vZRX
@@ -69,6 +75,7 @@ Test "Two users Mint"
 Test "Mint accrues no interest without borrows"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Prep Torrey Some ZRX vZRX
     Mint Geoff 2e18 vZRX
@@ -81,6 +88,7 @@ Test "Mint accrues no interest without borrows"
 Test "Mint transfer in fails"
     NewComptroller
     ListedVToken EVL vEVL tokenType:Evil
+    Comptroller SetMarketSupplyCaps (vEVL) (2000e18)
     Prep Geoff Some EVL vEVL
     Prep Torrey Some EVL vEVL
     Invariant Static (Bep20 vEVL TokenBalance Geoff)
@@ -93,6 +101,7 @@ Test "Mint transfer in fails"
 Test "Denied by comptroller because unlisted"
     NewComptroller
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Prep Torrey Some ZRX vZRX
     Invariant Static (Bep20 vZRX TokenBalance Geoff)
@@ -105,6 +114,7 @@ Test "Denied by comptroller because unlisted"
 Test "mint reverts if mint is paused"
     NewComptroller
     ListedVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Prep Torrey Some ZRX vZRX
     Invariant Static (Bep20 vZRX TokenBalance Geoff)

--- a/spec/scenario/MintBnb.scen
+++ b/spec/scenario/MintBnb.scen
@@ -3,6 +3,7 @@
 GasTest "Send Mint 1 vBNB"
     NewComptroller
     ListedBNBTokenMinted vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Expect Changes (BNBBalance Geoff) -0.005e18
     Expect Changes (VToken vBNB UnderlyingBalance Geoff) +0.005e18
     SendMintBnb Geoff 0.005e18 vBNB
@@ -12,6 +13,7 @@ GasTest "Send Mint 1 vBNB"
 GasTest "Call Mint 1 vBNB"
     NewComptroller
     ListedBNBTokenMinted vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Expect Changes (BNBBalance Geoff) -0.005e18
     Expect Changes (VToken vBNB UnderlyingBalance Geoff) +0.005e18
     CallMintBnb Geoff 0.005e18 vBNB
@@ -21,6 +23,7 @@ GasTest "Call Mint 1 vBNB"
 Test "Mint with insufficient bnb balance"
     NewComptroller
     ListedBNBTokenMinted vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     AllowFailures
     Invariant Remains (VToken vBNB UnderlyingBalance Geoff) 0e18
     Invariant Remains (Bep20 vBNB TokenBalance Geoff) 0e8
@@ -31,6 +34,7 @@ Test "Mint with insufficient bnb balance"
 Test "Mint two Bnb after minting two Bnb, and then I mint two more"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Expect Changes (BNBBalance Geoff) -0.002e18
     CallMintBnb Geoff 0.002e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 4e8
@@ -47,6 +51,7 @@ Test "Mint two Bnb after minting two Bnb, and then I mint two more"
 Test "Two users Mint"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.002e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 4e8
     Assert Equal (Bep20 vBNB TotalSupply) 4e8
@@ -58,6 +63,7 @@ Test "Two users Mint"
 Test "Mint accrues no interest without borrows"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.002e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 4e8
     Assert Equal (Bep20 vBNB TotalSupply) 4e8

--- a/spec/scenario/MintWBTC.scen
+++ b/spec/scenario/MintWBTC.scen
@@ -3,6 +3,7 @@
 Test "Mint 1 vWBTC"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.2 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2000e18)
     Prep Geoff Some WBTC vWBTC
     Mint Geoff 10e8 vWBTC
     Assert Equal (Bep20 vWBTC TokenBalance Geoff) (Exactly 50e8)
@@ -11,6 +12,7 @@ Test "Mint 1 vWBTC"
 Test "Mint WBTC with insufficient allowance"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.2 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2000e18)
     Prep Geoff 5e8 WBTC vWBTC allowanceAmount:4.9e8
     AllowFailures
     Mint Geoff 5e8 vWBTC
@@ -21,6 +23,7 @@ Test "Mint WBTC with insufficient allowance"
 Test "Mint WBTC with insufficient balance"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.2 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2000e18)
     Prep Geoff 4.9e8 WBTC vWBTC allowanceAmount:5e8
     AllowFailures
     Mint Geoff 5e8 vWBTC
@@ -31,6 +34,7 @@ Test "Mint WBTC with insufficient balance"
 Test "Mint two WBTC after minting two WBTC, and then I mint two more"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.2 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2000e18)
     Prep Geoff Some WBTC vWBTC
     Mint Geoff 2e8 vWBTC
     Assert Equal (Bep20 vWBTC TokenBalance Geoff) (Exactly 10e8)
@@ -45,6 +49,7 @@ Test "Mint two WBTC after minting two WBTC, and then I mint two more"
 Test "Two users Mint WBTC"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.2 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2000e18)
     Prep Geoff Some WBTC vWBTC
     Prep Torrey Some WBTC vWBTC
     Mint Geoff 2e8 vWBTC
@@ -58,6 +63,7 @@ Test "Two users Mint WBTC"
 Test "Mint WBTC accrues no interest without borrows"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.2 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2000e18)
     Prep Geoff Some WBTC vWBTC
     Prep Torrey Some WBTC vWBTC
     Mint Geoff 2e8 vWBTC
@@ -70,6 +76,7 @@ Test "Mint WBTC accrues no interest without borrows"
 Test "Mint WBTC transfer in fails due to paused"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.2 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2000e18)
     Prep Geoff Some WBTC vWBTC
     Prep Torrey Some WBTC vWBTC
     Invariant Static (Bep20 vWBTC TokenBalance Geoff)
@@ -83,6 +90,7 @@ Test "Mint WBTC transfer in fails due to paused"
 Test "Denied by comptroller because WBTC unlisted"
     NewComptroller
     NewVToken WBTC vWBTC tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2000e18)
     Prep Geoff Some WBTC vWBTC
     Prep Torrey Some WBTC vWBTC
     Invariant Static (Bep20 vWBTC TokenBalance Geoff)

--- a/spec/scenario/ReEntry.scen
+++ b/spec/scenario/ReEntry.scen
@@ -5,6 +5,7 @@ Test "ReEntry Mint @no-cov"
     InterestRateModel Deploy Fixed Std 0.000001
     VToken Deploy Scenario cPHREAK cPHREAK (Bep20 PHREAK Address) (Comptroller Address) (InterestRateModel Std Address) 1e9 8 Admin
     Comptroller SupportMarket cPHREAK
+    Comptroller SetMarketSupplyCaps (cPHREAK) (2e30)
     Prep Geoff Some PHREAK cPHREAK
     AllowFailures
     Mint Geoff 50e18 cPHREAK

--- a/spec/scenario/Redeem.scen
+++ b/spec/scenario/Redeem.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -19,6 +20,7 @@ Test "Mint then Redeem All"
 Test "Mint, Enter and then Redeem All"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -36,6 +38,7 @@ Test "Mint, Enter and then Redeem All"
 Test "Mint then Redeem Part"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -52,6 +55,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check and hold static
@@ -67,6 +71,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -83,6 +88,7 @@ Test "Mint then Redeem Zero"
 Test "Mint then redeem with interest - no reserves"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Invariant Remains (VToken vZRX Reserves) Zero
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
@@ -109,6 +115,7 @@ Test "Mint then redeem with interest - no reserves"
 Test "Mint then redeem part with interest - no reserves"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Invariant Remains (VToken vZRX Reserves) Zero
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
@@ -133,6 +140,7 @@ Test "Mint then redeem part with interest - no reserves"
 Test "Mint then redeem with reserves and interest"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) 500e8
@@ -162,6 +170,7 @@ Test "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Prep Torrey Some ZRX vZRX
     Mint Geoff 2e18 vZRX
@@ -179,6 +188,7 @@ Test "Two users Mint, one redeems"
 Test "Redeem transfer out fails"
     NewComptroller
     ListedVToken EVL vEVL initialExchangeRate:1e9 tokenType:Evil
+    Comptroller SetMarketSupplyCaps (vEVL) (2000e18)
     Bep20 EVL SetFail False
     Prep Geoff 70e18 EVL vEVL
     Mint Geoff 50e18 vEVL
@@ -196,6 +206,7 @@ Test "Redeem transfer out fails"
 Test "Mint, Enter, then Redeem Too Much (collateral factor: 0)"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check and hold static
@@ -212,6 +223,7 @@ Test "Mint, Enter, then Redeem Too Much (collateral factor: 0)"
 Test "Mint, Enter, then Redeem Too Much (collateral factor: 0.1)"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Comptroller SetCollateralFactor vZRX 0.1
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX

--- a/spec/scenario/RedeemBnb.scen
+++ b/spec/scenario/RedeemBnb.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check current affairs
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
@@ -18,6 +19,7 @@ Test "Mint then Redeem All"
 Test "Mint then Redeem Part"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check current affairs
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
@@ -33,6 +35,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     AllowFailures
     -- Check and hold static
@@ -49,6 +52,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check and hold static
     Invariant Static (VToken vBNB ExchangeRateStored)
@@ -62,6 +66,7 @@ Pending "Mint then redeem with interest - no reserves"
     Invariant Success
     NewComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Invariant Remains (VToken vBNB Reserves) Zero
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
@@ -89,6 +94,7 @@ Pending "Mint then redeem part with interest - no reserves"
     Invariant Success
     NewComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Invariant Remains (VToken vBNB Reserves) Zero
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
@@ -114,6 +120,7 @@ Pending "Mint then redeem with reserves and interest"
     Invariant Success
     NewComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 500e8
@@ -143,6 +150,7 @@ Pending "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.002e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 4e8
     Assert Equal (Bep20 vBNB TotalSupply) 4e8

--- a/spec/scenario/RedeemBnbFee.scen
+++ b/spec/scenario/RedeemBnbFee.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check current affairs
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
@@ -19,6 +20,7 @@ Test "Mint then Redeem All"
 Test "Mint then Redeem Part"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check current affairs
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
@@ -34,6 +36,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     AllowFailures
     -- Check and hold static
@@ -50,6 +53,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check and hold static
     Invariant Static (VToken vBNB ExchangeRateStored)
@@ -63,6 +67,7 @@ Pending "Mint then redeem with interest - no reserves"
     Invariant Success
     NewFeeComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Invariant Remains (VToken vBNB Reserves) Zero
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
@@ -90,6 +95,7 @@ Pending "Mint then redeem part with interest - no reserves"
     Invariant Success
     NewFeeComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Invariant Remains (VToken vBNB Reserves) Zero
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
@@ -115,6 +121,7 @@ Pending "Mint then redeem with reserves and interest"
     Invariant Success
     NewFeeComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 500e8
@@ -144,6 +151,7 @@ Pending "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.002e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 4e8
     Assert Equal (Bep20 vBNB TotalSupply) 4e8

--- a/spec/scenario/RedeemFee.scen
+++ b/spec/scenario/RedeemFee.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -20,6 +21,7 @@ Test "Mint then Redeem All"
 Test "Mint, Enter and then Redeem All"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -37,6 +39,7 @@ Test "Mint, Enter and then Redeem All"
 Test "Mint then Redeem Part"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -53,6 +56,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check and hold static
@@ -68,6 +72,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -84,6 +89,7 @@ Test "Mint then Redeem Zero"
 Test "Mint then redeem with interest - no reserves"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Invariant Remains (VToken vZRX Reserves) Zero
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
@@ -110,6 +116,7 @@ Test "Mint then redeem with interest - no reserves"
 Test "Mint then redeem part with interest - no reserves"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Invariant Remains (VToken vZRX Reserves) Zero
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
@@ -134,6 +141,7 @@ Test "Mint then redeem part with interest - no reserves"
 Test "Mint then redeem with reserves and interest"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) 500e8
@@ -163,6 +171,7 @@ Test "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Prep Torrey Some ZRX vZRX
     Mint Geoff 2e18 vZRX
@@ -180,6 +189,7 @@ Test "Two users Mint, one redeems"
 Test "Redeem transfer out fails"
     NewFeeComptroller
     ListedVToken EVL vEVL initialExchangeRate:1e9 tokenType:Evil
+    Comptroller SetMarketSupplyCaps (vEVL) (2000e18)
     Bep20 EVL SetFail False
     Prep Geoff 70e18 EVL vEVL
     Mint Geoff 50e18 vEVL
@@ -197,6 +207,7 @@ Test "Redeem transfer out fails"
 Test "Mint, Enter, then Redeem Too Much (collateral factor: 0)"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check and hold static
@@ -213,6 +224,7 @@ Test "Mint, Enter, then Redeem Too Much (collateral factor: 0)"
 Test "Mint, Enter, then Redeem Too Much (collateral factor: 0.1)"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Comptroller SetCollateralFactor vZRX 0.1
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX

--- a/spec/scenario/RedeemUnderlying.scen
+++ b/spec/scenario/RedeemUnderlying.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -19,6 +20,7 @@ Test "Mint then Redeem All"
 Test "Mint then Redeem Part"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -35,6 +37,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check and hold static
@@ -50,6 +53,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -66,6 +70,7 @@ Test "Mint then Redeem Zero"
 Test "Mint then redeem with interest - no reserves"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Invariant Remains (VToken vZRX Reserves) Zero
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
@@ -94,6 +99,7 @@ Test "Mint then redeem with interest - no reserves"
 Test "Mint then redeem part with interest - no reserves"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Invariant Remains (VToken vZRX Reserves) Zero
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
@@ -120,6 +126,7 @@ Test "Mint then redeem part with interest - no reserves"
 Test "Mint then redeem with reserves and interest"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) 500e8
@@ -151,6 +158,7 @@ Test "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff Some ZRX vZRX
     Prep Torrey Some ZRX vZRX
     Mint Geoff 2e18 vZRX
@@ -168,6 +176,7 @@ Test "Two users Mint, one redeems"
 Test "Mint then Redeem 1 wei of underlying"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2000e18)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     AllowFailures

--- a/spec/scenario/RedeemUnderlyingBnb.scen
+++ b/spec/scenario/RedeemUnderlyingBnb.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check current affairs
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
@@ -18,6 +19,7 @@ Test "Mint then Redeem All"
 Test "Mint then Redeem Part"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check current affairs
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
@@ -33,6 +35,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     AllowFailures
     -- Check and hold static
@@ -49,6 +52,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check and hold static
     Invariant Static (VToken vBNB ExchangeRateStored)
@@ -88,6 +92,7 @@ Pending "Mint then redeem part with interest - no reserves"
     Invariant Success
     NewComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Invariant Remains (VToken vBNB Reserves) Zero
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
@@ -113,6 +118,7 @@ Pending "Mint then redeem with reserves and interest"
     Invariant Success
     NewComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 500e8
@@ -142,6 +148,7 @@ Pending "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.002e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 4e8
     Assert Equal (Bep20 vBNB TotalSupply) 4e8
@@ -157,6 +164,7 @@ Test "Two users Mint, one redeems"
 Test "Mint then redeem 1 wei"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     AllowFailures
     -- Check current affairs

--- a/spec/scenario/RedeemUnderlyingBnbFee.scen
+++ b/spec/scenario/RedeemUnderlyingBnbFee.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check current affairs
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
@@ -18,6 +19,7 @@ Test "Mint then Redeem All"
 Test "Mint then Redeem Part"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check current affairs
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 10e8
@@ -33,6 +35,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     AllowFailures
     -- Check and hold static
@@ -49,6 +52,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     -- Check and hold static
     Invariant Static (VToken vBNB ExchangeRateStored)
@@ -62,6 +66,7 @@ Test "Mint then redeem with interest - no reserves"
     Invariant Success
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Invariant Remains (VToken vBNB Reserves) Zero
     CallMintBnb Geoff 50e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 500e8
@@ -88,6 +93,7 @@ Pending "Mint then redeem part with interest - no reserves"
     Invariant Success
     NewFeeComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Invariant Remains (VToken vBNB Reserves) Zero
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
@@ -113,6 +119,7 @@ Pending "Mint then redeem with reserves and interest"
     Invariant Success
     NewFeeComptroller
     ListedVToken ZRX vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     Prep Geoff 50e18 ZRX vBNB
     Mint Geoff 50e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 500e8
@@ -142,6 +149,7 @@ Pending "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.002e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) 4e8
     Assert Equal (Bep20 vBNB TotalSupply) 4e8
@@ -157,6 +165,7 @@ Test "Two users Mint, one redeems"
 Test "Mint then redeem 1 wei"
     NewFeeComptroller
     ListedBNBToken vBNB initialExchangeRate:0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2000e18)
     CallMintBnb Geoff 0.005e18 vBNB
     AllowFailures
     -- Check current affairs

--- a/spec/scenario/RedeemUnderlyingFee.scen
+++ b/spec/scenario/RedeemUnderlyingFee.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -20,6 +21,7 @@ Test "Mint then Redeem All"
 Test "Mint then Redeem Part"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -36,6 +38,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check and hold static
@@ -51,6 +54,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Check current affairs
@@ -67,6 +71,7 @@ Test "Mint then Redeem Zero"
 Test "Mint then redeem with interest - no reserves"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Invariant Remains (VToken vZRX Reserves) Zero
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
@@ -95,6 +100,7 @@ Test "Mint then redeem with interest - no reserves"
 Test "Mint then redeem part with interest - no reserves"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Invariant Remains (VToken vZRX Reserves) Zero
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
@@ -121,6 +127,7 @@ Test "Mint then redeem part with interest - no reserves"
 Test "Mint then redeem with reserves and interest"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) 500e8
@@ -152,6 +159,7 @@ Test "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff Some ZRX vZRX
     Prep Torrey Some ZRX vZRX
     Mint Geoff 2e18 vZRX
@@ -169,6 +177,7 @@ Test "Two users Mint, one redeems"
 Test "Mint then Redeem 1 wei of underlying"
     NewFeeComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 70e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     AllowFailures

--- a/spec/scenario/RedeemUnderlyingWBTC.scen
+++ b/spec/scenario/RedeemUnderlyingWBTC.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs
@@ -19,6 +20,7 @@ Test "Mint then Redeem All"
 Test "Mint then Redeem Part"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs
@@ -35,6 +37,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check and hold static
@@ -50,6 +53,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs
@@ -66,6 +70,7 @@ Test "Mint then Redeem Zero"
 Test "Mint then redeem with interest - no reserves"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Invariant Remains (VToken vWBTC Reserves) Zero
     Prep Geoff 50e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
@@ -94,6 +99,7 @@ Test "Mint then redeem with interest - no reserves"
 Test "Mint then redeem part with interest - no reserves"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Invariant Remains (VToken vWBTC Reserves) Zero
     Prep Geoff 50e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
@@ -120,6 +126,7 @@ Test "Mint then redeem part with interest - no reserves"
 Test "Mint then redeem with reserves and interest"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 50e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     Assert Equal (Bep20 vWBTC TokenBalance Geoff) 500e8
@@ -151,6 +158,7 @@ Test "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff Some WBTC vWBTC
     Prep Torrey Some WBTC vWBTC
     Mint Geoff 2e8 vWBTC
@@ -168,6 +176,7 @@ Test "Two users Mint, one redeems"
 Test "Mint then Redeem 1 wei of underlying is allowed for 1:1 assets"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs

--- a/spec/scenario/RedeemUnderlyingWBTCFee.scen
+++ b/spec/scenario/RedeemUnderlyingWBTCFee.scen
@@ -3,6 +3,7 @@
 Test "Mint then Redeem All"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs
@@ -19,6 +20,7 @@ Test "Mint then Redeem All"
 Test "Mint then Redeem Part"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs
@@ -35,6 +37,7 @@ Test "Mint then Redeem Part"
 Test "Mint then Redeem Too Much"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check and hold static
@@ -50,6 +53,7 @@ Test "Mint then Redeem Too Much"
 Test "Mint then Redeem Zero"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs
@@ -66,6 +70,7 @@ Test "Mint then Redeem Zero"
 Test "Mint then redeem with interest - no reserves"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Invariant Remains (VToken fWBTC Reserves) Zero
     Prep Geoff 50e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
@@ -94,6 +99,7 @@ Test "Mint then redeem with interest - no reserves"
 Test "Mint then redeem part with interest - no reserves"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Invariant Remains (VToken fWBTC Reserves) Zero
     Prep Geoff 50e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
@@ -120,6 +126,7 @@ Test "Mint then redeem part with interest - no reserves"
 Test "Mint then redeem with reserves and interest"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 50e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     Assert Equal (Bep20 fWBTC TokenBalance Geoff) 500e8
@@ -151,6 +158,7 @@ Test "Mint then redeem with reserves and interest"
 Test "Two users Mint, one redeems"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff Some WBTC fWBTC
     Prep Torrey Some WBTC fWBTC
     Mint Geoff 2e8 fWBTC
@@ -168,6 +176,7 @@ Test "Two users Mint, one redeems"
 Test "Mint then Redeem 1 wei of underlying is allowed for 1:1 assets"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs

--- a/spec/scenario/RedeemWBTC.scen
+++ b/spec/scenario/RedeemWBTC.scen
@@ -3,6 +3,7 @@
 Test "Mint WBTC then Redeem All"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs
@@ -19,6 +20,7 @@ Test "Mint WBTC then Redeem All"
 Test "Mint WBTC, Enter and then Redeem All"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs
@@ -36,6 +38,7 @@ Test "Mint WBTC, Enter and then Redeem All"
 Test "Mint WBTC then Redeem Part"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs
@@ -52,6 +55,7 @@ Test "Mint WBTC then Redeem Part"
 Test "Mint WBTC then Redeem Too Much"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check and hold static
@@ -67,6 +71,7 @@ Test "Mint WBTC then Redeem Too Much"
 Test "Mint WBTC then Redeem Zero"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs
@@ -83,6 +88,7 @@ Test "Mint WBTC then Redeem Zero"
 Test "Mint WBTC then redeem with interest - no reserves"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Invariant Remains (VToken vWBTC Reserves) Zero
     Prep Geoff 50e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
@@ -109,6 +115,7 @@ Test "Mint WBTC then redeem with interest - no reserves"
 Test "Mint WBTC then redeem part with interest - no reserves"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Invariant Remains (VToken vWBTC Reserves) Zero
     Prep Geoff 50e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
@@ -133,6 +140,7 @@ Test "Mint WBTC then redeem part with interest - no reserves"
 Test "Mint WBTC then redeem with reserves and interest"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 50e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     Assert Equal (Bep20 vWBTC TokenBalance Geoff) 500e8
@@ -162,6 +170,7 @@ Test "Mint WBTC then redeem with reserves and interest"
 Test "Two users Mint WBTC, one redeems"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff Some WBTC vWBTC
     Prep Torrey Some WBTC vWBTC
     Mint Geoff 2e8 vWBTC
@@ -179,6 +188,7 @@ Test "Two users Mint WBTC, one redeems"
 Test "Redeem WBTC transfer out fails"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check current affairs
@@ -195,6 +205,7 @@ Test "Redeem WBTC transfer out fails"
 Test "Mint WBTC, Enter, then Redeem Too Much (collateral factor: 0)"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Check and hold static
@@ -211,6 +222,7 @@ Test "Mint WBTC, Enter, then Redeem Too Much (collateral factor: 0)"
 Test "Mint WBTC, Enter, then Redeem Too Much (collateral factor: 0.1)"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Comptroller SetCollateralFactor vWBTC 0.1
     Prep Geoff 70e8 WBTC vWBTC
     Mint Geoff 50e8 vWBTC

--- a/spec/scenario/RedeemWBTCFee.scen
+++ b/spec/scenario/RedeemWBTCFee.scen
@@ -3,6 +3,7 @@
 Test "Mint WBTC then Redeem All"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs
@@ -19,6 +20,7 @@ Test "Mint WBTC then Redeem All"
 Test "Mint WBTC, Enter and then Redeem All"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs
@@ -36,6 +38,7 @@ Test "Mint WBTC, Enter and then Redeem All"
 Test "Mint WBTC then Redeem Part"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs
@@ -52,6 +55,7 @@ Test "Mint WBTC then Redeem Part"
 Test "Mint WBTC then Redeem Too Much"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check and hold static
@@ -67,6 +71,7 @@ Test "Mint WBTC then Redeem Too Much"
 Test "Mint WBTC then Redeem Zero"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs
@@ -83,6 +88,7 @@ Test "Mint WBTC then Redeem Zero"
 Test "Mint WBTC then redeem with interest - no reserves"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Invariant Remains (VToken fWBTC Reserves) Zero
     Prep Geoff 50e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
@@ -109,6 +115,7 @@ Test "Mint WBTC then redeem with interest - no reserves"
 Test "Mint WBTC then redeem part with interest - no reserves"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Invariant Remains (VToken fWBTC Reserves) Zero
     Prep Geoff 50e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
@@ -133,6 +140,7 @@ Test "Mint WBTC then redeem part with interest - no reserves"
 Test "Mint WBTC then redeem with reserves and interest"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 50e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     Assert Equal (Bep20 fWBTC TokenBalance Geoff) 500e8
@@ -162,6 +170,7 @@ Test "Mint WBTC then redeem with reserves and interest"
 Test "Two users Mint WBTC, one redeems"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff Some WBTC fWBTC
     Prep Torrey Some WBTC fWBTC
     Mint Geoff 2e8 fWBTC
@@ -179,6 +188,7 @@ Test "Two users Mint WBTC, one redeems"
 Test "Redeem WBTC transfer out fails"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check current affairs
@@ -195,6 +205,7 @@ Test "Redeem WBTC transfer out fails"
 Test "Mint WBTC, Enter, then Redeem Too Much (collateral factor: 0)"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC
     -- Check and hold static
@@ -211,6 +222,7 @@ Test "Mint WBTC, Enter, then Redeem Too Much (collateral factor: 0)"
 Test "Mint WBTC, Enter, then Redeem Too Much (collateral factor: 0.1)"
     NewFeeComptroller
     ListedVToken WBTC fWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (fWBTC) (2e30)
     Comptroller SetCollateralFactor fWBTC 0.1
     Prep Geoff 70e8 WBTC fWBTC
     Mint Geoff 50e8 fWBTC

--- a/spec/scenario/ReduceReserves.scen
+++ b/spec/scenario/ReduceReserves.scen
@@ -2,6 +2,7 @@
 Test "Reduce all reserves and verify effects"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 500e8) -- 50e18 / 1e9
@@ -34,6 +35,7 @@ Test "Reduce all reserves and verify effects"
 Test "Reduce partial reserves and verify effects"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 500e8)
@@ -66,6 +68,7 @@ Test "Reduce partial reserves and verify effects"
 Test "Redeem all and then reduce all reserves"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 500e8)
@@ -110,6 +113,7 @@ Test "Redeem all and then reduce all reserves"
 Test "Reduce reserves WBTC when paused"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:1e9 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff 50e18 WBTC vWBTC
     Mint Geoff 50e18 vWBTC
     Assert Equal (Bep20 vWBTC TokenBalance Geoff) (Exactly 500e8)

--- a/spec/scenario/RepayBorrow.scen
+++ b/spec/scenario/RepayBorrow.scen
@@ -3,7 +3,9 @@
 Macro NewBorrow borrowAmount borrowRate
     NewComptroller price:1.0 -- TODO: This should really be a price for a specific asset
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     NewVToken BAT vBAT borrowRate -- note: cannot use macros with named args right now
+    Comptroller SetMarketSupplyCaps (vBAT) (2e30)
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.5

--- a/spec/scenario/RepayBorrowBnb.scen
+++ b/spec/scenario/RepayBorrowBnb.scen
@@ -3,7 +3,9 @@
 Macro SetupBorrow borrowRate
     NewComptroller price:1.0 -- TODO: This should really be a price for a specific asset
     ListedVToken ZRX vZRX borrowRate
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     ListedBNBToken vBNB borrowRate 0.005e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2e30)
     SetCollateralFactor vZRX collateralFactor:0.5
     SetCollateralFactor vBNB collateralFactor:0.5
     Donate vBNB 0.003e18

--- a/spec/scenario/RepayBorrowWBTC.scen
+++ b/spec/scenario/RepayBorrowWBTC.scen
@@ -3,7 +3,9 @@
 Macro NewBorrow borrowAmount borrowRate
     NewComptroller price:1.0 -- TODO: This should really be a price for a specific asset
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     NewVToken WBTC vWBTC borrowRate 0.1 8 WBTC -- note: cannot use macros with named args right now
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Give vWBTC 10e8 WBTC -- Faucet some WBTC to borrow
     Support vZRX collateralFactor:0.5
     Support vWBTC collateralFactor:0.5

--- a/spec/scenario/Seize.scen
+++ b/spec/scenario/Seize.scen
@@ -2,7 +2,9 @@
 Test "Fail to seize calling directly"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     ListedVToken BAT vBAT initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBAT) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     Invariant Remains (Bep20 vZRX TokenBalance Geoff) 50e9
@@ -14,7 +16,9 @@ Test "Fail to seize calling directly"
 Test "Seize tokens with a paused WBTC vToken-- like normal"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     Bep20 WBTC Pause
@@ -27,7 +31,9 @@ Test "Seize tokens with a paused WBTC vToken-- like normal"
 Test "Not able to seize tokens with a malicious unlisted vToken"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     NewVTokenImmutable EVL vEVL initialExchangeRate:1e9 vTokenType:VEvil
+    Comptroller SetMarketSupplyCaps (vEVL) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     Invariant Remains (Bep20 vZRX TokenBalance Geoff) 50e9
@@ -41,7 +47,9 @@ Test "Not able to seize tokens with a malicious unlisted vToken"
 Test "Able to seize tokens with a malicious listed vToken"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     ListedVTokenImmutable EVL vEVL initialExchangeRate:1e9 vTokenType:VEvil
+    Comptroller SetMarketSupplyCaps (vEVL) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) 50e9

--- a/spec/scenario/SetComptroller.scen
+++ b/spec/scenario/SetComptroller.scen
@@ -3,6 +3,7 @@
 Test "Set Comptroller"
     NewComptroller
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Assert Equal (VToken vZRX Comptroller) (Unitroller Address)
     ComptrollerImpl Deploy Scenario NewComptroller
     From Root (VToken vZRX SetComptroller (ComptrollerImpl NewComptroller Address))
@@ -13,6 +14,7 @@ Test "Set Comptroller"
 Test "Fail when is not a comptroller"
     NewComptroller
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Invariant Remains (VToken vZRX Comptroller) (Unitroller Address)
     AllowFailures
     From Root (VToken vZRX SetComptroller (PriceOracle Address))
@@ -21,6 +23,7 @@ Test "Fail when is not a comptroller"
 Test "Fail to set comptroller as not admin"
     NewComptroller
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     AllowFailures
     From Geoff (VToken vZRX SetComptroller (PriceOracle Address))
     Assert Failure UNAUTHORIZED SET_COMPTROLLER_OWNER_CHECK

--- a/spec/scenario/Supply.scen.old
+++ b/spec/scenario/Supply.scen.old
@@ -1,0 +1,59 @@
+-- Supply Tests
+
+Test "Geoff supplies BNB and we check 2 future balances and then supply again"
+	AddToken BNB
+	SupportMarket BNB (FixedPrice 1.0) (FixedRate 0.5 0.75) SimplePolicyHook
+	Approve Geoff BNB "10.0e18"
+	Faucet Geoff BNB "10.0e18"
+	Supply Geoff BNB "3e18"
+	Assert Success
+	FastForward 2 Blocks
+	Assert Equal (SupplyBalance Geoff BNB) (Exactly "6.0e18") -- 3 * ( 1 + 2 * .5 )
+	FastForward 2 Blocks
+	Assert Equal (SupplyBalance Geoff BNB) (Exactly "9.0e18") -- 3 * ( 1 + 4 * .5 )
+	Supply Geoff BNB "1e18"
+	Assert Equal (SupplyBalance Geoff BNB) (Exactly "10.0e18") -- 3 * ( 1 + 4 * .5 ) + 1
+	FastForward 2 Blocks
+	Assert Equal (SupplyBalance Geoff BNB) (Exactly "20.0e18") -- 10 * ( 1 + 2 * .5 )
+
+Test "Geoff supplies BNB, Torrey supplies BNB and then Geoff supplies more BNB"
+	AddToken BNB
+	SupportMarket BNB (FixedPrice 1.0) (FixedRate 0.5 0.75) SimplePolicyHook
+	Approve Geoff BNB "10.0e18"
+	Faucet Geoff BNB "10.0e18"
+	Approve Torrey BNB "5.0e18"
+	Faucet Torrey BNB "5.0e18"
+	Supply Geoff BNB "1e18"
+	Assert Success
+	FastForward 2 Blocks
+	Assert Equal (SupplyBalance Geoff BNB) (Exactly "2.0e18")
+	Supply Torrey BNB "3e18"
+	Assert Success
+	FastForward 2 Blocks
+	Assert Equal (SupplyBalance Torrey BNB) (Exactly "6.0e18")
+	Assert Equal (SupplyBalance Geoff BNB) (Exactly "4.0e18")
+	Supply Geoff BNB "1e18"
+	Assert Equal (SupplyBalance Geoff BNB) (Exactly "5.0e18")
+
+Test "Can't supply an 'initial' asset"
+	AddToken Dragon
+	Approve Geoff Dragon "10.0e18"
+	Faucet Geoff Dragon "10.0e18"
+	Supply Geoff Dragon "1e18"
+	Assert Failure MARKET_NOT_LISTED SUPPLY_MARKET_NOT_LISTED
+
+Test "Can't supply when contract is paused"
+	AddToken BNB
+	SupportMarket BNB (FixedPrice 1.0) (FixedRate 0.5 0.75) SimplePolicyHook
+	Approve Geoff BNB 1.0e18
+	Faucet Geoff BNB 0.4e18
+	PolicyHook BNB (SetProtocolPaused True)
+	Supply Geoff BNB 0.3e18
+	Assert Failure COMPTROLLER_REJECTION SUPPLY_COMPTROLLER_REJECTION 1
+	Assert Equal (SupplyBalance Geoff BNB) (Exactly "0e18")
+
+Test "With always paused policy hook, can't supply when contract is paused"
+	AddToken BNB
+	SupportMarket BNB (FixedPrice 1.0) (FixedRate 0.5 0.75) AlwaysPausedPolicyHook
+	Supply Geoff BNB 0.3e18
+	Assert Failure COMPTROLLER_REJECTION SUPPLY_COMPTROLLER_REJECTION 99

--- a/spec/scenario/SupplyCap.scen
+++ b/spec/scenario/SupplyCap.scen
@@ -53,40 +53,21 @@ Test "Setting supply cap restricted to admin"
     ListedBNBToken vBNB initialExchangeRate:0.005e9
     AllowFailures
     From Robert (Comptroller SetMarketSupplyCaps (vBNB) (0.01e18))
-    Assert Revert "revert only admin or supply cap guardian can set supply caps"
-
-Test "Supply cap guardian can set borrow caps"
-    NewComptroller price:1.0
-    ListedVToken ZRX vZRX
-    Comptroller SetSupplyCapGuardian Geoff
-    From Geoff (Comptroller SetMarketSupplyCaps (vZRX) (0.5e18))
-    AllowFailures
-    From Robert (Comptroller SetMarketSupplyCaps (vZRX) (0.01e18)) -- Robert still can't...
-    Assert Revert "revert only admin or supply cap guardian can set supply caps"
-    Assert Equal (Comptroller SupplyCaps vZRX) (Exactly 0.5e18)
-    Assert Equal (Comptroller SupplyCapGuardian) (User Geoff Address)
-
-Test "Only admin can set Supply Cap Guardian"
-    NewComptroller price:1.0
-    AllowFailures
-    From Robert (Comptroller SetSupplyCapGuardian Robert) -- Robert has really gone rogue
-    Assert Revert
+    Assert Revert "revert only admin can set supply caps"
 
 Test "Invalid markets while setting Market SupplyCaps"
     NewComptroller price:1.0
     ListedVToken ZRX vZRX
     ListedVToken BAT vBAT
-    Comptroller SetSupplyCapGuardian Geoff
     AllowFailures
-    From Geoff (Comptroller SetMarketSupplyCaps (vZRX) (0.5e18 0.7e18))
+    Comptroller SetMarketSupplyCaps (vZRX) (0.5e18 0.7e18)
     Assert Revert "revert invalid input"
 
 Test "Invalid SupplyCap while setting Market SupplyCaps"
     NewComptroller price:1.0
     ListedVToken ZRX vZRX
     ListedVToken BAT vBAT
-    Comptroller SetSupplyCapGuardian Geoff
     AllowFailures
-    From Geoff (Comptroller SetMarketSupplyCaps (vZRX vBAT) (0.5e18))
+    Comptroller SetMarketSupplyCaps (vZRX vBAT) (0.5e18)
     Assert Revert "revert invalid input"
 

--- a/spec/scenario/SupplyCap.scen
+++ b/spec/scenario/SupplyCap.scen
@@ -1,0 +1,92 @@
+Test "Attempt to set supplyCap for BEP20"
+    NewComptroller price:1.0
+    NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (10e18)
+    Assert Equal (Comptroller SupplyCaps vZRX) (Exactly 10e18)
+
+Test "Attempt to supply below set cap BEP20"
+    NewComptroller price:1.0
+    ListedVToken ZRX vZRX initialExchangeRate:1
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
+    Prep Geoff 100e18 ZRX vZRX
+    Assert Equal (Bep20 ZRX TokenBalance Geoff) (Exactly 100e18)
+    Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 0)
+    Mint Geoff 100e18 vZRX
+    Assert Equal (Bep20 ZRX TokenBalance Geoff) (Exactly 0)
+    Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 1e20)
+
+Test "Attempt to supply equal to set cap BEP20"
+    NewComptroller price:1.0
+    ListedVToken ZRX vZRX initialExchangeRate:1
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
+    Prep Geoff 1000e18 ZRX vZRX
+    Assert Equal (Bep20 ZRX TokenBalance Geoff) (Exactly 1000e18)
+    Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 0)
+    Mint Geoff 1000e18 vZRX
+    Assert Equal (Bep20 ZRX TokenBalance Geoff) (Exactly 0)
+    Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 1e21)
+
+Test "Attempt to supply over set cap BEP20"
+    NewComptroller price:1.0
+    ListedVToken ZRX vZRX initialExchangeRate:1
+    Comptroller SetMarketSupplyCaps (vZRX) (1000e18)
+    Prep Geoff 1001e18 ZRX vZRX
+    Assert Equal (Bep20 ZRX TokenBalance Geoff) (Exactly 1001e18)
+    Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 0)
+    AllowFailures
+    Mint Geoff 1001e18 vZRX
+    Assert Revert "revert market supply cap reached"
+
+Test "Attempt to supply with no cap set BEP20"
+    NewComptroller price:1.0
+    ListedVToken ZRX vZRX initialExchangeRate:1
+    Prep Geoff 100e18 ZRX vZRX
+    Assert Equal (Bep20 ZRX TokenBalance Geoff) (Exactly 100e18)
+    Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 0)
+    AllowFailures
+    Mint Geoff 100e18 vZRX
+    Assert Revert "revert market supply cap is 0"
+
+Test "Setting supply cap restricted to admin"
+    NewComptroller price:1.0
+    ListedVToken ZRX vZRX
+    ListedBNBToken vBNB initialExchangeRate:0.005e9
+    AllowFailures
+    From Robert (Comptroller SetMarketSupplyCaps (vBNB) (0.01e18))
+    Assert Revert "revert only admin or supply cap guardian can set supply caps"
+
+Test "Supply cap guardian can set borrow caps"
+    NewComptroller price:1.0
+    ListedVToken ZRX vZRX
+    Comptroller SetSupplyCapGuardian Geoff
+    From Geoff (Comptroller SetMarketSupplyCaps (vZRX) (0.5e18))
+    AllowFailures
+    From Robert (Comptroller SetMarketSupplyCaps (vZRX) (0.01e18)) -- Robert still can't...
+    Assert Revert "revert only admin or supply cap guardian can set supply caps"
+    Assert Equal (Comptroller SupplyCaps vZRX) (Exactly 0.5e18)
+    Assert Equal (Comptroller SupplyCapGuardian) (User Geoff Address)
+
+Test "Only admin can set Supply Cap Guardian"
+    NewComptroller price:1.0
+    AllowFailures
+    From Robert (Comptroller SetSupplyCapGuardian Robert) -- Robert has really gone rogue
+    Assert Revert
+
+Test "Invalid markets while setting Market SupplyCaps"
+    NewComptroller price:1.0
+    ListedVToken ZRX vZRX
+    ListedVToken BAT vBAT
+    Comptroller SetSupplyCapGuardian Geoff
+    AllowFailures
+    From Geoff (Comptroller SetMarketSupplyCaps (vZRX) (0.5e18 0.7e18))
+    Assert Revert "revert invalid input"
+
+Test "Invalid SupplyCap while setting Market SupplyCaps"
+    NewComptroller price:1.0
+    ListedVToken ZRX vZRX
+    ListedVToken BAT vBAT
+    Comptroller SetSupplyCapGuardian Geoff
+    AllowFailures
+    From Geoff (Comptroller SetMarketSupplyCaps (vZRX vBAT) (0.5e18))
+    Assert Revert "revert invalid input"
+

--- a/spec/scenario/Timelock.scen
+++ b/spec/scenario/Timelock.scen
@@ -58,6 +58,7 @@ Test "Accept vToken admin from Timelock"
     Assert Equal (Timelock Admin) (User Geoff Address)
     NewComptroller
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Assert Equal (VToken vZRX Admin) (Address Root)
     Assert Equal (VToken vZRX PendingAdmin) (Address Zero)
     From Root (VToken vZRX SetPendingAdmin (Timelock Address))
@@ -98,6 +99,7 @@ Test "Accept unitroller admin from Timelock"
 Test "Reduce reserves for VBep20 from Timelock and send reserves to external address"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff 50e18 ZRX vZRX
     Mint Geoff 50e18 vZRX
     Assert Equal (Bep20 vZRX TokenBalance Geoff) (Exactly 500e8)
@@ -143,6 +145,7 @@ Test "Reduce reserves for VBep20 from Timelock and send reserves to external add
 Test "Reduce reserves for VBNB from Timelock and send reserves to external address"
     NewComptroller
     ListedBNBToken vBNB initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vBNB) (2e30)
     CallMintBnb Geoff 50e18 vBNB
     Assert Equal (Bep20 vBNB TokenBalance Geoff) (Exactly 500e8)
     Assert Equal (VToken vBNB UnderlyingBalance Geoff) (Exactly 50e18)

--- a/spec/scenario/TokenTransfer.scen
+++ b/spec/scenario/TokenTransfer.scen
@@ -2,6 +2,7 @@
 Test "Simple vToken Transfer"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Just to be sure, check initial balances
@@ -15,6 +16,7 @@ Test "Simple vToken Transfer"
 Test "Simple vToken Transfer When Underlying Paused"
     NewComptroller
     ListedVToken WBTC vWBTC initialExchangeRate:0.1 tokenType:WBTC
+    Comptroller SetMarketSupplyCaps (vWBTC) (2e30)
     Prep Geoff Some WBTC vWBTC
     Mint Geoff 50e8 vWBTC
     -- Just to be sure, check initial balances
@@ -29,6 +31,7 @@ Test "Simple vToken Transfer When Underlying Paused"
 Test "Simple vToken Transfer 1:1 Rate"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e0
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Just to be sure, check initial balances
@@ -42,6 +45,7 @@ Test "Simple vToken Transfer 1:1 Rate"
 Test "Simple vToken Transfer Not Allowed by Comptroller"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e0
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Comptroller SetCollateralFactor vZRX 0.1
     EnterMarkets Geoff vZRX
     Prep Geoff Some ZRX vZRX
@@ -57,6 +61,7 @@ Test "Simple vToken Transfer Not Allowed by Comptroller"
 Test "Simple vToken Transfer From"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Just to be sure, check initial balances
@@ -75,6 +80,7 @@ Test "Simple vToken Transfer From"
 Test "vToken Transfer From Not Allowed"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     --
@@ -87,6 +93,7 @@ Test "vToken Transfer From Not Allowed"
 Test "vToken Transfer paused"
     NewComptroller
     ListedVToken ZRX vZRX initialExchangeRate:1e9
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 50e18 vZRX
     -- Just to be sure, check initial balances

--- a/spec/scenario/Unitroller.scen
+++ b/spec/scenario/Unitroller.scen
@@ -8,7 +8,9 @@ Test "Standard Upgrade"
     Comptroller SetPriceOracle (PriceOracle Address)
     Comptroller SetCloseFactor 0.2
     ListedVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     ListedVToken DAI vDAI
+    Comptroller SetMarketSupplyCaps (vDAI) (2e30)
     Assert Equal (Comptroller Implementation) (Address ScenComptroller)
     Assert Equal (Comptroller CloseFactor) 0.2
     -- Upgrade to V*
@@ -137,6 +139,8 @@ Pending "Keeps all storage"
     Give vBAT 10e18 BAT -- Faucet some bat to borrow
     Support vZRX collateralFactor:0.5
     Support vBAT collateralFactor:0.4
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
+    Comptroller SetMarketSupplyCaps (vBAT) (2e30)
     Prep Geoff Some ZRX vZRX
     Mint Geoff 100e18 vZRX
     EnterMarkets Geoff vZRX vBAT

--- a/spec/scenario/VAIMintFee.scen
+++ b/spec/scenario/VAIMintFee.scen
@@ -3,6 +3,7 @@ Macro NewMintVAI mintVAIAmount mintAmount user=Geoff collateralPrice=1.0 closeFa
     PricedComptrollerWithVAIController closeFactor:0.9
     VAIController SetTreasuryData Guardian Jared 1e14
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     PriceOracle SetPrice vZRX collateralPrice
     Support vZRX collateralFactor:0.7
     Comptroller SetVAIMintRate 7e3
@@ -13,6 +14,7 @@ Macro SimpleMintVAI user mintVAIAmount mintAmount
     Mint user mintAmount vZRX
     EnterMarkets user vZRX
     MintVAI user mintVAIAmount
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
 
 Test "VAI Mint Fee"
     NewMintVAI mintVAIAmount:1e18 mintAmount:1.43e18

--- a/spec/scenario/VTokenAdmin.scen
+++ b/spec/scenario/VTokenAdmin.scen
@@ -2,6 +2,7 @@
 Test "Set admin"
     NewComptroller
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Assert Equal (VToken vZRX Admin) (Address Root)
     Assert Equal (VToken vZRX PendingAdmin) (Address Zero)
     From Root (VToken vZRX SetPendingAdmin Geoff)
@@ -14,6 +15,7 @@ Test "Set admin"
 Test "Set admin to contructor argument"
     NewComptroller
     NewVToken ZRX vZRX admin:Torrey
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Assert Equal (VToken vZRX Admin) (Address Torrey)
     Assert Equal (VToken vZRX PendingAdmin) (Address Zero)
     From Torrey (VToken vZRX SetPendingAdmin Geoff)
@@ -27,6 +29,7 @@ Test "Set admin to contructor argument"
 Test "Fail to set pending admin"
     NewComptroller
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Invariant Remains (VToken vZRX Admin) (Address Root)
     Invariant Remains (VToken vZRX PendingAdmin) (Address Zero)
     AllowFailures
@@ -36,6 +39,7 @@ Test "Fail to set pending admin"
 Test "Fail to accept admin"
     NewComptroller
     NewVToken ZRX vZRX
+    Comptroller SetMarketSupplyCaps (vZRX) (2e30)
     Invariant Remains (VToken vZRX Admin) (Address Root)
     Invariant Remains (VToken vZRX PendingAdmin) (Address Zero)
     AllowFailures

--- a/tests/Comptroller/accountLiquidityTest.js
+++ b/tests/Comptroller/accountLiquidityTest.js
@@ -2,7 +2,8 @@ const {
   makeComptroller,
   makeVToken,
   enterMarkets,
-  quickMint
+  quickMint,
+  setMarketSupplyCap
 } = require('../Utils/Venus');
 
 describe('Comptroller', () => {
@@ -23,6 +24,7 @@ describe('Comptroller', () => {
     it("allows a borrow up to collateralFactor, but not more", async () => {
       const collateralFactor = 0.5, underlyingPrice = 1, user = accounts[1], amount = 1e6;
       const vToken = await makeVToken({supportMarket: true, collateralFactor, underlyingPrice});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
 
       let error, liquidity, shortfall;
 
@@ -48,15 +50,18 @@ describe('Comptroller', () => {
       ({1: liquidity, 2: shortfall} = await call(vToken.comptroller, 'getHypotheticalAccountLiquidity', [user, vToken._address, amount, 0]));
       expect(liquidity).toEqualNumber(0);
       expect(shortfall).toEqualNumber(0);
-    });
+    }, 300000);
 
     it("allows entering 3 markets, supplying to 2 and borrowing up to collateralFactor in the 3rd", async () => {
       const amount1 = 1e6, amount2 = 1e3, user = accounts[1];
       const cf1 = 0.5, cf2 = 0.666, cf3 = 0, up1 = 3, up2 = 2.718, up3 = 1;
       const c1 = amount1 * cf1 * up1, c2 = amount2 * cf2 * up2, collateral = Math.floor(c1 + c2);
       const vToken1 = await makeVToken({supportMarket: true, collateralFactor: cf1, underlyingPrice: up1});
+      await setMarketSupplyCap(vToken1.comptroller, [vToken1._address], [100000000000]);
       const vToken2 = await makeVToken({supportMarket: true, comptroller: vToken1.comptroller, collateralFactor: cf2, underlyingPrice: up2});
+      await setMarketSupplyCap(vToken2.comptroller, [vToken2._address], [100000000000]);
       const vToken3 = await makeVToken({supportMarket: true, comptroller: vToken1.comptroller, collateralFactor: cf3, underlyingPrice: up3});
+      await setMarketSupplyCap(vToken3.comptroller, [vToken3._address], [100000000000]);
 
       await enterMarkets([vToken1, vToken2, vToken3], user);
       await quickMint(vToken1, user, amount1);
@@ -100,6 +105,7 @@ describe('Comptroller', () => {
   describe("getHypotheticalAccountLiquidity", () => {
     it("returns 0 if not 'in' any markets", async () => {
       const vToken = await makeVToken();
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       const {0: error, 1: liquidity, 2: shortfall} = await call(vToken.comptroller, 'getHypotheticalAccountLiquidity', [accounts[0], vToken._address, 0, 0]);
       expect(error).toEqualNumber(0);
       expect(liquidity).toEqualNumber(0);
@@ -109,6 +115,7 @@ describe('Comptroller', () => {
     it("returns collateral factor times dollar amount of tokens minted in a single market", async () => {
       const collateralFactor = 0.5, exchangeRate = 1, underlyingPrice = 1;
       const vToken = await makeVToken({supportMarket: true, collateralFactor, exchangeRate, underlyingPrice});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       const from = accounts[0], balance = 1e7, amount = 1e6;
       await enterMarkets([vToken], from);
       await send(vToken.underlying, 'harnessSetBalance', [from, balance], {from});

--- a/tests/Comptroller/comptrollerTest.js
+++ b/tests/Comptroller/comptrollerTest.js
@@ -82,7 +82,6 @@ describe('Comptroller', () => {
     testZeroAddress('_setCollateralFactor', [address(0), 0]);
     testZeroAddress('_setPauseGuardian', [address(0)]);
     testZeroAddress('_setBorrowCapGuardian', [address(0)]);
-    testZeroAddress('_setSupplyCapGuardian', [address(0)]);
     testZeroAddress('_setVAIController', [address(0)]);
     testZeroAddress('_setTreasuryData', [address(0), address(0), 0]);
     testZeroAddress('_setComptrollerLens', [address(0)]);

--- a/tests/Comptroller/comptrollerTest.js
+++ b/tests/Comptroller/comptrollerTest.js
@@ -82,6 +82,7 @@ describe('Comptroller', () => {
     testZeroAddress('_setCollateralFactor', [address(0), 0]);
     testZeroAddress('_setPauseGuardian', [address(0)]);
     testZeroAddress('_setBorrowCapGuardian', [address(0)]);
+    testZeroAddress('_setSupplyCapGuardian', [address(0)]);
     testZeroAddress('_setVAIController', [address(0)]);
     testZeroAddress('_setTreasuryData', [address(0), address(0), 0]);
     testZeroAddress('_setComptrollerLens', [address(0)]);

--- a/tests/SpinaramaTest.js
+++ b/tests/SpinaramaTest.js
@@ -8,7 +8,8 @@ const {
   makeVToken,
   balanceOf,
   borrowSnapshot,
-  enterMarkets
+  enterMarkets,
+  setMarketSupplyCap
 } = require('./Utils/Venus');
 
 describe('Spinarama', () => {
@@ -21,6 +22,7 @@ describe('Spinarama', () => {
   describe('#mintMint', () => {
     it('should succeed', async () => {
       const vToken = await makeVToken({supportMarket: true, underlyingPrice: 1});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       await send(vToken.underlying, 'harnessSetBalance', [from, 100], {from});
       await send(vToken.underlying, 'approve', [vToken._address, '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'], {from});
       await minerStop();
@@ -34,6 +36,7 @@ describe('Spinarama', () => {
 
     it('should partial succeed', async () => {
       const vToken = await makeVToken({supportMarket: true, underlyingPrice: 1});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       await send(vToken.underlying, 'harnessSetBalance', [from, 100], {from});
       await send(vToken.underlying, 'approve', [vToken._address, 10], {from});
       await minerStop();
@@ -54,6 +57,7 @@ describe('Spinarama', () => {
   describe('#mintRedeem', () => {
     it('should succeed', async () => {
       const vToken = await makeVToken({supportMarket: true, underlyingPrice: 1});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       await send(vToken.underlying, 'harnessSetBalance', [from, 100], {from});
       await send(vToken.underlying, 'approve', [vToken._address, 10], {from});
       await send(vToken.comptroller.vai, 'approve', [vToken.comptroller._address, 100], {from});
@@ -70,6 +74,7 @@ describe('Spinarama', () => {
   describe('#redeemMint', () => {
     it('should succeed', async () => {
       const vToken = await makeVToken({supportMarket: true, underlyingPrice: 1});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       await send(vToken, 'harnessSetTotalSupply', [10]);
       await send(vToken, 'harnessSetExchangeRate', [bnbMantissa(1)]);
       await send(vToken, 'harnessSetBalance', [from, 10]);
@@ -88,7 +93,9 @@ describe('Spinarama', () => {
   describe('#repayRepay', () => {
     it('should succeed', async () => {
       const vToken1 = await makeVToken({supportMarket: true, underlyingPrice: 1, collateralFactor: .5});
+      await setMarketSupplyCap(vToken1.comptroller, [vToken1._address], [100000000000]);
       const vToken2 = await makeVToken({supportMarket: true, underlyingPrice: 1, comptroller: vToken1.comptroller});
+      await setMarketSupplyCap(vToken2.comptroller, [vToken2._address], [100000000000]);
       await send(vToken1.underlying, 'harnessSetBalance', [from, 10]);
       await send(vToken1.underlying, 'approve', [vToken1._address, 10], {from});
       await send(vToken2.underlying, 'harnessSetBalance', [vToken2._address, 10]);

--- a/tests/Tokens/adminTest.js
+++ b/tests/Tokens/adminTest.js
@@ -1,5 +1,5 @@
 const {address} = require('../Utils/BSC');
-const {makeVToken} = require('../Utils/Venus');
+const {makeVToken, setMarketSupplyCap} = require('../Utils/Venus');
 
 describe('admin / _setPendingAdmin / _acceptAdmin', () => {
   let vToken, root, accounts;
@@ -7,6 +7,7 @@ describe('admin / _setPendingAdmin / _acceptAdmin', () => {
   beforeEach(async () => {
     [root, ...accounts] = saddle.accounts;
     vToken = await makeVToken();
+    await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
   });
 
   describe('admin()', () => {

--- a/tests/Tokens/mintAndRedeemVBNBFeeTest.js
+++ b/tests/Tokens/mintAndRedeemVBNBFeeTest.js
@@ -12,7 +12,7 @@ const {
   setBalance,
   setBNBBalance,
   getBalances,
-  adjustBalances,
+  adjustBalances
 } = require('../Utils/Venus');
 
 const exchangeRate = 5;

--- a/tests/Tokens/mintAndRedeemVBNBTest.js
+++ b/tests/Tokens/mintAndRedeemVBNBTest.js
@@ -12,7 +12,7 @@ const {
   setBalance,
   setBNBBalance,
   getBalances,
-  adjustBalances,
+  adjustBalances
 } = require('../Utils/Venus');
 
 const exchangeRate = 5;

--- a/tests/Tokens/reservesTest.js
+++ b/tests/Tokens/reservesTest.js
@@ -4,7 +4,7 @@ const {
   both
 } = require('../Utils/BSC');
 
-const {fastForward, makeVToken} = require('../Utils/Venus');
+const {fastForward, makeVToken, setMarketSupplyCap} = require('../Utils/Venus');
 
 const factor = bnbMantissa(.02);
 
@@ -22,6 +22,7 @@ describe('VToken', function () {
     let vToken;
     beforeEach(async () => {
       vToken = await makeVToken();
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
     });
 
     it("rejects change by non-admin", async () => {

--- a/tests/Tokens/setComptrollerTest.js
+++ b/tests/Tokens/setComptrollerTest.js
@@ -1,6 +1,7 @@
 const {
   makeComptroller,
-  makeVToken
+  makeVToken,
+  setMarketSupplyCap
 } = require('../Utils/Venus');
 
 describe('VToken', function () {
@@ -12,6 +13,7 @@ describe('VToken', function () {
     oldComptroller = vToken.comptroller;
     newComptroller = await makeComptroller();
     expect(newComptroller._address).not.toEqual(oldComptroller._address);
+    await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
   });
 
   describe('_setComptroller', () => {

--- a/tests/Tokens/setInterestRateModelTest.js
+++ b/tests/Tokens/setInterestRateModelTest.js
@@ -2,7 +2,8 @@ const {both} = require('../Utils/BSC');
 const {
   fastForward,
   makeVToken,
-  makeInterestRateModel
+  makeInterestRateModel,
+  setMarketSupplyCap
 } = require('../Utils/Venus');
 
 describe('VToken', function () {
@@ -19,6 +20,7 @@ describe('VToken', function () {
       vToken = await makeVToken();
       oldModel = vToken.interestRateModel;
       expect(oldModel._address).not.toEqual(newModel._address);
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
     });
 
     it("fails if called by non-admin", async () => {

--- a/tests/Tokens/transferTest.js
+++ b/tests/Tokens/transferTest.js
@@ -1,4 +1,4 @@
-const {makeVToken} = require('../Utils/Venus');
+const {makeVToken, setMarketSupplyCap} = require('../Utils/Venus');
 
 describe('VToken', function () {
   let root, accounts;
@@ -9,12 +9,14 @@ describe('VToken', function () {
   describe('transfer', () => {
     it("cannot transfer from a zero balance", async () => {
       const vToken = await makeVToken({supportMarket: true});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       expect(await call(vToken, 'balanceOf', [root])).toEqualNumber(0);
       expect(await send(vToken, 'transfer', [accounts[0], 100])).toHaveTokenFailure('MATH_ERROR', 'TRANSFER_NOT_ENOUGH');
     });
 
     it("transfers 50 tokens", async () => {
       const vToken = await makeVToken({supportMarket: true});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       await send(vToken, 'harnessSetBalance', [root, 100]);
       expect(await call(vToken, 'balanceOf', [root])).toEqualNumber(100);
       await send(vToken, 'transfer', [accounts[0], 50]);
@@ -24,6 +26,7 @@ describe('VToken', function () {
 
     it("doesn't transfer when src == dst", async () => {
       const vToken = await makeVToken({supportMarket: true});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       await send(vToken, 'harnessSetBalance', [root, 100]);
       expect(await call(vToken, 'balanceOf', [root])).toEqualNumber(100);
       expect(await send(vToken, 'transfer', [root, 50])).toHaveTokenFailure('BAD_INPUT', 'TRANSFER_NOT_ALLOWED');

--- a/tests/Tokens/vTokenTest.js
+++ b/tests/Tokens/vTokenTest.js
@@ -6,7 +6,8 @@ const {
 const {
   makeVToken,
   setBorrowRate,
-  pretendBorrow
+  pretendBorrow,
+  setMarketSupplyCap
 } = require('../Utils/Venus');
 
 describe('VToken', function () {
@@ -26,6 +27,7 @@ describe('VToken', function () {
 
     it("succeeds with bep-20 underlying and non-zero exchange rate", async () => {
       const vToken = await makeVToken();
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       expect(await call(vToken, 'underlying')).toEqual(vToken.underlying._address);
       expect(await call(vToken, 'admin')).toEqual(root);
     });
@@ -41,6 +43,7 @@ describe('VToken', function () {
 
     beforeEach(async () => {
       vToken = await makeVToken({ name: "VToken Foo", symbol: "cFOO", decimals: 10 });
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
     });
 
     it('should return correct name', async () => {
@@ -59,6 +62,7 @@ describe('VToken', function () {
   describe('balanceOfUnderlying', () => {
     it("has an underlying balance", async () => {
       const vToken = await makeVToken({ supportMarket: true, exchangeRate: 2 });
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       await send(vToken, 'harnessSetBalance', [root, 100]);
       expect(await call(vToken, 'balanceOfUnderlying', [root])).toEqualNumber(200);
     });
@@ -106,6 +110,7 @@ describe('VToken', function () {
     beforeEach(async () => {
       borrower = accounts[0];
       vToken = await makeVToken();
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
     });
 
     beforeEach(async () => {
@@ -177,6 +182,7 @@ describe('VToken', function () {
 
     beforeEach(async () => {
       vToken = await makeVToken({ exchangeRate });
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
     });
 
     it("returns initial exchange rate with zero vTokenSupply", async () => {
@@ -222,6 +228,7 @@ describe('VToken', function () {
   describe('getCash', () => {
     it("gets the cash", async () => {
       const vToken = await makeVToken();
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       const result = await call(vToken, 'getCash');
       expect(result).toEqualNumber(0);
     });

--- a/tests/Tokens/xvsLikeTest.js
+++ b/tests/Tokens/xvsLikeTest.js
@@ -1,5 +1,5 @@
 const {
-  makeVToken,
+  makeVToken,setMarketSupplyCap
 } = require('../Utils/Venus');
   
 describe('VXvsLikeDelegate', function () {
@@ -7,6 +7,7 @@ describe('VXvsLikeDelegate', function () {
     it("does not delegate if not the admin", async () => {
       const [root, a1] = saddle.accounts;
       const vToken = await makeVToken({kind: 'vxvs'});
+      await setMarketSupplyCap(vToken.comptroller, [vToken._address], [100000000000]);
       await expect(send(vToken, '_delegateXvsLikeTo', [a1], {from: a1})).rejects.toRevert('revert only the admin may set the xvs-like delegate');
     });
 

--- a/tests/Utils/Venus.js
+++ b/tests/Utils/Venus.js
@@ -19,6 +19,7 @@ async function makeComptroller(opts = {}) {
 
   if (kind == 'bool') {
     const comptroller = await deploy('BoolComptroller');
+
     const xvs = opts.xvs || await deploy('XVS', [opts.venusOwner || root]);
     const vai = opts.vai || await makeVAI();
 
@@ -128,7 +129,6 @@ async function makeVToken(opts = {}) {
     root = saddle.account,
     kind = 'vbep20'
   } = opts || {};
-
   const comptroller = opts.comptroller || await makeComptroller(opts.comptrollerOpts);
   const interestRateModel = opts.interestRateModel || await makeInterestRateModel(opts.interestRateModelOpts);
   const exchangeRate = bnbMantissa(dfn(opts.exchangeRate, 1));
@@ -552,6 +552,10 @@ async function pretendVAIMint(comptroller, vaicontroller, vai, vaiMinter, princi
   await send(vaicontroller, 'harnessSetBlockNumber', [bnbUnsigned(blockNumber)]);
 }
 
+async function setMarketSupplyCap(comptroller, vTokens, supplyCaps) {
+  await send(comptroller, '_setMarketSupplyCaps', [vTokens, supplyCaps]);
+}
+
 module.exports = {
   makeComptroller,
   makeVToken,
@@ -592,5 +596,6 @@ module.exports = {
   getBorrowRate,
   getSupplyRate,
   pretendBorrow,
-  pretendVAIMint
+  pretendVAIMint,
+  setMarketSupplyCap
 };

--- a/tests/VRTVault/vrtVaultProxyTest.js
+++ b/tests/VRTVault/vrtVaultProxyTest.js
@@ -181,7 +181,6 @@ describe('VRTVaultProxy', () => {
     it("should update the implementation and assert the existing-storage on upgraded implementation", async () => {
       
       const vrtVaultAddressBeforeUpgrade = vrtVaultAddress;
-      console.log(`vrtVaultAddress before upgrade: ${vrtVaultAddressBeforeUpgrade}`)
 
       vrtVault = await deploy('VRTVaultHarness', [], { from: root });
       vrtVaultAddress = vrtVault._address;


### PR DESCRIPTION
Background:    

  Limit the amount of collateralized supply per token 
  so that we can reduce the potential impact in situations like we had with LUNA.

Requirement:

  E.g. they want to be able to say: “no more than 5M FIL can be used as collateral in total”. 
  As we don’t track collateral per coin,  so proposal is  to add a supply cap 

## Checklist
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
