### PR TITLE
Add missing implementations to BoolComptroller

### DIFF
--- a/contracts/ComptrollerInterface.sol
+++ b/contracts/ComptrollerInterface.sol
@@ -81,7 +81,6 @@ contract ComptrollerInterfaceG2 is ComptrollerInterfaceG1 {
 }
 
 contract ComptrollerInterface is ComptrollerInterfaceG2 {
-
     function markets(address) external view returns (bool, uint);
     function oracle() external view returns (PriceOracle);
     function getAccountLiquidity(address) external view returns (uint, uint, uint);

--- a/contracts/test/ComptrollerHarness.sol
+++ b/contracts/test/ComptrollerHarness.sol
@@ -525,6 +525,22 @@ contract BoolComptroller is ComptrollerInterface {
         treasuryAddress = treasuryAddress_;
         treasuryPercent = treasuryPercent_;
     }
+
+    /*** Functions from ComptrollerInterface not implemented by BoolComptroller ***/
+
+    function markets(address) external view returns (bool, uint) { revert(); }
+    function oracle() external view returns (PriceOracle) { revert(); }
+    function getAccountLiquidity(address) external view returns (uint, uint, uint) { revert(); }
+    function getAssetsIn(address) external view returns (VToken[] memory) { revert(); }
+    function claimVenus(address) external { revert(); }
+    function venusAccrued(address) external view returns (uint) { revert(); }
+    function venusSpeeds(address) external view returns (uint) { revert(); }
+    function getAllMarkets() external view returns (VToken[] memory) { revert(); }
+    function venusSupplierIndex(address, address) external view returns (uint) { revert(); }
+    function venusInitialIndex() external view returns (uint224) { revert(); }
+    function venusBorrowerIndex(address, address) external view returns (uint) { revert(); }
+    function venusBorrowState(address) external view returns (uint224, uint32) { revert(); }
+    function venusSupplyState(address) external view returns (uint224, uint32) { revert(); }
 }
 
 contract EchoTypesComptroller is UnitrollerAdminStorage {


### PR DESCRIPTION
## Description

Problem: Commit c8eaaebb20fd57b2398506b9416ebf3d40bbf603 added more methods to ComptrollerInterface so that it could be used in other contracts instead of Comptroller directly. However, this introduced a problem, because BoolComptroller in tests inherited from ComptrollerInterface. Some of the methods lacked implementation, but since we're on an ancient compiler version, this lead to a deploy-time failure instead of the compile time failure.

Solution: Add stub implementations that just revert, so that the deployment of BoolComptroller succeeds.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
