### PR TITLE
Allow transferring funds from timelock

### DIFF
--- a/contracts/Governance/GovernorBravoDelegate.sol
+++ b/contracts/Governance/GovernorBravoDelegate.sol
@@ -147,12 +147,12 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
       * @notice Executes a queued proposal if eta has passed
       * @param proposalId The id of the proposal to execute
       */
-    function execute(uint proposalId) external payable {
+    function execute(uint proposalId) external {
         require(state(proposalId) == ProposalState.Queued, "GovernorBravo::execute: proposal can only be executed if it is queued");
         Proposal storage proposal = proposals[proposalId];
         proposal.executed = true;
         for (uint i = 0; i < proposal.targets.length; i++) {
-            timelock.executeTransaction.value(proposal.values[i])(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+            timelock.executeTransaction(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
         }
         emit ProposalExecuted(proposalId);
     }

--- a/contracts/Governance/GovernorBravoDelegate.sol
+++ b/contracts/Governance/GovernorBravoDelegate.sol
@@ -15,7 +15,7 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV1, GovernorBravoE
     uint public constant MAX_PROPOSAL_THRESHOLD = 300000e18; //300,000 Xvs
 
     /// @notice The minimum setable voting period
-    uint public constant MIN_VOTING_PERIOD = 20 * 60 * 24; // About 24 hours, 3 secs per block
+    uint public constant MIN_VOTING_PERIOD = 20 * 60 * 3; // About 3 hours, 3 secs per block
 
     /// @notice The max setable voting period
     uint public constant MAX_VOTING_PERIOD = 20 * 60 * 24 * 14; // About 2 weeks, 3 secs per block

--- a/spec/scenario/GovernorBravo/Execute.scen
+++ b/spec/scenario/GovernorBravo/Execute.scen
@@ -35,7 +35,7 @@ Macro GivenQueuedProposal
     GivenSucceededProposal
     GovernorBravo LegitGov Proposal LastProposal Queue
 
-Test "Execute a simple queued proposal with value"
+Test "Execute a simple queued proposal"
     GivenQueuedProposal
     Assert Equal ("Queued") (GovernorBravo LegitGov Proposal LastProposal State)
     IncreaseTime 605000
@@ -46,16 +46,19 @@ Test "Execute a simple queued proposal with value"
 
 Test "Execute a complex queued proposal with value"
     DeployGov
-    GovernorBravo LegitGov Propose "Add and sub" [(Address CNT1) (Address CNT1)] [1 1] ["increment(uint256,uint256)" "decrement(uint256)"] [["7" "4"] ["2"]]
+    Send (Address Timelock) 1e18 -- Fund Timelock
+    GovernorBravo LegitGov Propose "Add, sub, send value" [(Address CNT1) (Address CNT1) (Address Geoff)] [0 0 1e18] ["increment(uint256,uint256)" "decrement(uint256)" ""] [["7" "4"] ["2"] [""]]
     SucceedProposal
     GovernorBravo LegitGov Proposal LastProposal Queue
     IncreaseTime 604910
     Assert Equal (Counter CNT1 Count) 0
     Assert Equal (Counter CNT1 Count2) 0
-    Trx Value 2 (GovernorBravo LegitGov Proposal LastProposal Execute)
+    Assert Equal (BNBBalance Geoff) (100e18)
+    GovernorBravo LegitGov Proposal LastProposal Execute
     Assert Equal ("Executed") (GovernorBravo LegitGov Proposal LastProposal State)
     Assert Equal (Counter CNT1 Count) 5
     Assert Equal (Counter CNT1 Count2) 4
+    Assert Equal (BNBBalance Geoff) (101e18)
 
 Test "Revert when trying to execute a succeeded but unqueued proposal"
     DeployGov


### PR DESCRIPTION
## Description

Problem: Currently it's impossible to withdraw BNB reserves because GovernorBravo requires the money flows to and from the timelock contract to be equal.

Solution: Allow GovernorBravo to withdraw funds from timelock by changing the behavior of the proposal `value` parameter.

With the new upgrade, the proposal parameter `value` would mean the value transferred from the timelock contract, and not the incoming value of the `execute` invocation.

_Note: the modified `MIN_VOTING_PERIOD` constant is technically unrelated to this PR, but this change was introduced on chain during LUNA incident coverage_

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
