### PR TITLE
Enhance SnapshotLens - add isACollateral indicator

### DIFF
--- a/contracts/Lens/SnapshotLens.sol
+++ b/contracts/Lens/SnapshotLens.sol
@@ -15,7 +15,6 @@ contract SnapshotLens is ExponentialNoError {
         string assetName;
         address vTokenAddress;
         address underlyingAssetAddress;
-        bool isACollateral;
         uint256 supply;
         uint256 supplyInUsd;
         uint256 collateral;
@@ -26,6 +25,7 @@ contract SnapshotLens is ExponentialNoError {
         uint vTokenDecimals;
         uint underlyingDecimals;
         uint exchangeRate;
+        bool isACollateral;
     }
 
     /** Snapshot calculation **/
@@ -57,13 +57,10 @@ contract SnapshotLens is ExponentialNoError {
 
         // For each asset the account is in
         VToken[] memory assets = Comptroller(comptrollerAddress).getAllMarkets();
-        uint256 assetsCount = assets.length;
-        AccountSnapshot[] memory accountSnapshots = new AccountSnapshot[](assetsCount);
-
-        for (uint256 i = 0; i < assetsCount; ++i){
+        AccountSnapshot[] memory accountSnapshots = new AccountSnapshot[](assets.length);
+        for (uint256 i = 0; i < assets.length; ++i){
             accountSnapshots[i] = getAccountSnapshot(account, comptrollerAddress, assets[i]);
         }
-
         return accountSnapshots;
     }
 

--- a/networks/testnet.json
+++ b/networks/testnet.json
@@ -1,7 +1,7 @@
 {
   "Contracts": {
     "VenusLens": "0x4C97B56d596d5cCc11727c0AD7d171E7F0d5134e",
-    "SnapshotLens": "0x5F6F8D0D58C8Cadd6A184F1d72Ae2a0b38D1AadB",
+    "SnapshotLens": "0x61610DeC84448Ed17A2a0317667a99ca0CC6f697",
     "WhitepaperInterestRateModel": "0xdE9beC5102ee897a2c934321309517dD6c0106F4",
     "Comptroller": "0xfd301ad2503b25a7670a45b11a043c20b04ee896",
     "Unitroller": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",

--- a/tests/Lens/SnapshotLensTest.js
+++ b/tests/Lens/SnapshotLensTest.js
@@ -4,92 +4,150 @@ const {
   enterMarkets
 } = require('../Utils/Venus');
 
-const MAX_STALE_PERIOD = 100 * 60;
-
 function cullTuple(tuple) {
-    return Object.keys(tuple).reduce((acc, key) => {
-      if (Number.isNaN(Number(key))) {
-        return {
-          ...acc,
-          [key]: tuple[key]
-        };
-      } else {
-        return acc;
-      }
-    }, {});
-  }
+  return Object.keys(tuple).reduce((acc, key) => {
+    if (Number.isNaN(Number(key))) {
+      return {
+        ...acc,
+        [key]: tuple[key]
+      };
+    } else {
+      return acc;
+    }
+  }, {});
+}
 
 describe('SnapshotLens', () => {
-    let snapshotLens, comptroller;
-    let borrower, accounts;
-    let usdcFeed;
-    let oracle, vBnb, 
-        vUsdc, vUsdcAddress, usdcAddress, 
-        vUsdt, vUsdtAddress, usdtAddress;
+  let snapshotLens, comptroller;
+  let borrower, accounts;
+  let usdcFeed;
+  let oracle, vBnb,
+    vUsdc, vUsdcAddress, usdcAddress,
+    vUsdt, vUsdtAddress, usdtAddress;
 
-    beforeEach(async () => {
-      [borrower, ...accounts] = saddle.accounts;
-      snapshotLens = await deploy('SnapshotLens');
-      //oracle = await deploy("VenusChainlinkOracle", [MAX_STALE_PERIOD]);
-      oracle = await makePriceOracle();
+  beforeEach(async () => {
+    [borrower, ...accounts] = saddle.accounts;
+    snapshotLens = await deploy('SnapshotLens');
+    oracle = await makePriceOracle();
 
-      vBnb = await makeVToken({
-        kind: "vbnb",
-        comptrollerOpts: { kind: "v1-no-proxy" },
-        supportMarket: true,
-      });
-
-      comptroller = vBnb.comptroller;
-      const result = await send(comptroller, '_setPriceOracle', [oracle._address]);
-      expect(result).toSucceed();
-
-      vUsdc = await makeVToken({
-        comptroller: vBnb.comptroller,
-        supportMarket: true,
-        underlyingOpts: {
-          decimals: 6,
-          symbol: "USDC"
-        },
-        name: "USD Coin"
-      });
-
-      vUsdcAddress = vUsdc._address;
-      usdcAddress = vUsdc.underlying._address;
-
-      //usdcFeed = await makeChainlinkOracle({ decimals: 8, initialAnswer: 100000000 });
-      //await send(oracle, "setFeed", ["USDC", usdcFeed._address]);
-
-      await send(oracle, 'setUnderlyingPrice', [vUsdc._address, 1]);
-
-      let price = await call(oracle, "getUnderlyingPrice", [vUsdc._address]);
-      expect(price).toEqual("1");
-
-      vUsdt = await makeVToken({
-        comptroller: vBnb.comptroller,
-        supportMarket: true,
-        underlyingOpts: {
-          decimals: 6,
-          symbol: "USDT"
-        },
-        name: "USD Tether"
-      });
-
-      vUsdtAddress = vUsdt._address;
-      usdtAddress = vUsdt.underlying._address;
-
-      //usdtFeed = await makeChainlinkOracle({ decimals: 8, initialAnswer: 100000000 });
-      //await send(oracle, "setFeed", ["USDT", usdtFeed._address]);
-
-      await send(oracle, 'setUnderlyingPrice', [vUsdt._address, 1]);
-      let price2 = await call(oracle, "getUnderlyingPrice", [vUsdt._address]);
-      expect(price2).toEqual("1");
+    vBnb = await makeVToken({
+      kind: "vbnb",
+      comptrollerOpts: { kind: "v1-no-proxy" },
+      supportMarket: true,
     });
 
-    describe('snapshot', () => {
-      it('is correct for vUsdc', async () => {
-        expect(
-          cullTuple(await call(snapshotLens, 'getAccountSnapshot', [borrower, comptroller._address, vUsdc._address]))
-        ).toEqual(
+    comptroller = vBnb.comptroller;
+    const result = await send(comptroller, '_setPriceOracle', [oracle._address]);
+    expect(result).toSucceed();
+
+    vUsdc = await makeVToken({
+      comptroller: vBnb.comptroller,
+      supportMarket: true,
+      underlyingOpts: {
+        decimals: 6,
+        symbol: "USDC"
+      },
+      name: "USD Coin"
+    });
+
+    vUsdcAddress = vUsdc._address;
+    usdcAddress = vUsdc.underlying._address;
+
+    await send(oracle, 'setUnderlyingPrice', [vUsdc._address, 1]);
+
+    let price = await call(oracle, "getUnderlyingPrice", [vUsdc._address]);
+    expect(price).toEqual("1");
+
+    vUsdt = await makeVToken({
+      comptroller: vBnb.comptroller,
+      supportMarket: true,
+      underlyingOpts: {
+        decimals: 6,
+        symbol: "USDT"
+      },
+      name: "USD Tether"
+    });
+
+    vUsdtAddress = vUsdt._address;
+    usdtAddress = vUsdt.underlying._address;
+
+    await send(oracle, 'setUnderlyingPrice', [vUsdt._address, 1]);
+    let price2 = await call(oracle, "getUnderlyingPrice", [vUsdt._address]);
+    expect(price2).toEqual("1");
+  });
+
+  describe('snapshot', () => {
+    it('is correct for vUsdc', async () => {
+      expect(
+        cullTuple(await call(snapshotLens, 'getAccountSnapshot', [borrower, comptroller._address, vUsdc._address]))
+      ).toEqual(
+        {
+          account: borrower,
+          assetName: "USD Coin",
+          vTokenAddress: vUsdcAddress,
+          underlyingAssetAddress: usdcAddress,
+          supply: "0",
+          supplyInUsd: "0",
+          collateral: "0",
+          borrows: "0",
+          borrowsInUsd: "0",
+          assetPrice: "1",
+          accruedInterest: "1000000000000000000",
+          vTokenDecimals: "8",
+          underlyingDecimals: "6",
+          exchangeRate: "1000000000000000000",
+          isACollateral: false,
+        }
+      );
+    });
+
+    it('is correct for vUsdt', async () => {
+      expect(
+        cullTuple(await call(snapshotLens, 'getAccountSnapshot', [borrower, comptroller._address, vUsdt._address]))
+      ).toEqual(
+        {
+          account: borrower,
+          assetName: "USD Tether",
+          vTokenAddress: vUsdtAddress,
+          underlyingAssetAddress: usdtAddress,
+          supply: "0",
+          supplyInUsd: "0",
+          collateral: "0",
+          borrows: "0",
+          borrowsInUsd: "0",
+          assetPrice: "1",
+          accruedInterest: "1000000000000000000",
+          vTokenDecimals: "8",
+          underlyingDecimals: "6",
+          exchangeRate: "1000000000000000000",
+          isACollateral: false
+        }
+      );
+    });
+
+    it('get accountSnapshots for Borrower with all markets, he has entered', async () => {
+      expect(await enterMarkets([vUsdc, vUsdt], borrower)).toSucceed();
+      expect(
+        (await call(snapshotLens, 'getAccountSnapshot', [borrower, comptroller._address])).map(cullTuple)
+      ).toEqual(
+        [
+          {
+            account: borrower,
+            accruedInterest: "1000000000000000000",
+            assetName: "VToken vBNB",
+            assetPrice: "1000000000000000000",
+            borrows: "0",
+            borrowsInUsd: "0",
+            collateral: "0",
+            exchangeRate: "1000000000000000000",
+            isACollateral: false,
+            supply: "0",
+            supplyInUsd: "0",
+            underlyingAssetAddress: "0x0000000000000000000000000000000000000000",
+            underlyingDecimals: "18",
+            vTokenAddress: vBnb._address,
+            vTokenDecimals: "8",
+          },
           {
             account: borrower,
             assetName: "USD Coin",
@@ -105,14 +163,8 @@ describe('SnapshotLens', () => {
             vTokenDecimals: "8",
             underlyingDecimals: "6",
             exchangeRate: "1000000000000000000",
-          }
-        );
-      });
-
-      it('is correct for vUsdt', async () => {
-        expect(
-          cullTuple(await call(snapshotLens, 'getAccountSnapshot', [borrower, comptroller._address, vUsdt._address]))
-        ).toEqual(
+            isACollateral: true,
+          },
           {
             account: borrower,
             assetName: "USD Tether",
@@ -128,58 +180,69 @@ describe('SnapshotLens', () => {
             vTokenDecimals: "8",
             underlyingDecimals: "6",
             exchangeRate: "1000000000000000000",
+            isACollateral: true
           }
-        );
-      });
-
-      it('get accountSnapshots for Borrower with all markets, he has entered', async () => {
-        expect(await enterMarkets([vUsdc, vUsdt], borrower)).toSucceed();
-        expect(
-          (await call(snapshotLens, 'getAccountSnapshot', [borrower, comptroller._address])).map(cullTuple)
-        ).toEqual(
-          [
-            {
-              account: borrower,
-              assetName: "USD Coin",
-              vTokenAddress: vUsdcAddress,
-              underlyingAssetAddress: usdcAddress,
-              supply: "0",
-              supplyInUsd: "0",
-              collateral: "0",
-              borrows: "0",
-              borrowsInUsd: "0",
-              assetPrice: "1",
-              accruedInterest: "1000000000000000000",
-              vTokenDecimals: "8",
-              underlyingDecimals: "6",
-              exchangeRate: "1000000000000000000",
-            },
-            {
-              account: borrower,
-              assetName: "USD Tether",
-              vTokenAddress: vUsdtAddress,
-              underlyingAssetAddress: usdtAddress,
-              supply: "0",
-              supplyInUsd: "0",
-              collateral: "0",
-              borrows: "0",
-              borrowsInUsd: "0",
-              assetPrice: "1",
-              accruedInterest: "1000000000000000000",
-              vTokenDecimals: "8",
-              underlyingDecimals: "6",
-              exchangeRate: "1000000000000000000",
-            }
-          ]
-        );
-      });
-
-      it('get empty accountSnapshots for Borrower who has never entered any market', async () => {
-        expect(
-          (await call(snapshotLens, 'getAccountSnapshot', [borrower, comptroller._address])).map(cullTuple)
-        ).toEqual([]);
-      });
-
+        ]
+      );
     });
 
+    it('get accountSnapshots for Borrower who has never entered any market', async () => {
+      expect(
+        (await call(snapshotLens, 'getAccountSnapshot', [borrower, comptroller._address])).map(cullTuple)
+      ).toEqual([
+        {
+          account: borrower,
+          accruedInterest: "1000000000000000000",
+          assetName: "VToken vBNB",
+          assetPrice: "1000000000000000000",
+          borrows: "0",
+          borrowsInUsd: "0",
+          collateral: "0",
+          exchangeRate: "1000000000000000000",
+          isACollateral: false,
+          supply: "0",
+          supplyInUsd: "0",
+          underlyingAssetAddress: "0x0000000000000000000000000000000000000000",
+          underlyingDecimals: "18",
+          vTokenAddress: vBnb._address,
+          vTokenDecimals: "8",
+        },
+        {
+          account: borrower,
+          accruedInterest: "1000000000000000000",
+          assetName: "USD Coin",
+          assetPrice: "1",
+          borrows: "0",
+          borrowsInUsd: "0",
+          collateral: "0",
+          exchangeRate: "1000000000000000000",
+          isACollateral: false,
+          supply: "0",
+          supplyInUsd: "0",
+          underlyingAssetAddress: usdcAddress,
+          underlyingDecimals: "6",
+          vTokenAddress: vUsdcAddress,
+          vTokenDecimals: "8",
+        },
+        {
+          account: borrower,
+          accruedInterest: "1000000000000000000",
+          assetName: "USD Tether",
+          assetPrice: "1",
+          borrows: "0",
+          borrowsInUsd: "0",
+          collateral: "0",
+          exchangeRate: "1000000000000000000",
+          isACollateral: false,
+          supply: "0",
+          supplyInUsd: "0",
+          underlyingAssetAddress: usdtAddress,
+          underlyingDecimals: "6",
+          vTokenAddress: vUsdtAddress,
+          vTokenDecimals: "8",
+        },
+      ]);
+    });
   });
+
+});


### PR DESCRIPTION
## Description

Enhance SnapshotLens - add isACollateral indicator

## Change Details:

1. Previous version of SnapshotLens contract gets the snapshot for account on the assets they are using as a collateral
2. Updated version is to get snapshot for all markets 
3. For market which has bee chosen by user as a collateral, an indicator is to be set to response struct
    A Boolean indicator

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
