### PR TITLE
feat: unlist-market function to facilitate unlisting of LUNA and UST

### DIFF
--- a/contracts/ErrorReporter.sol
+++ b/contracts/ErrorReporter.sol
@@ -13,6 +13,7 @@ contract ComptrollerErrorReporter {
         MARKET_NOT_ENTERED, // no longer possible
         MARKET_NOT_LISTED,
         MARKET_ALREADY_LISTED,
+        MARKET_ALREADY_UNLISTED,
         MATH_ERROR,
         NONZERO_BORROW_BALANCE,
         PRICE_ERROR,
@@ -42,6 +43,7 @@ contract ComptrollerErrorReporter {
         SET_PENDING_IMPLEMENTATION_OWNER_CHECK,
         SET_PRICE_ORACLE_OWNER_CHECK,
         SUPPORT_MARKET_EXISTS,
+        SUPPORT_MARKET_DOESNOT_EXISTS,
         SUPPORT_MARKET_OWNER_CHECK,
         SET_PAUSE_GUARDIAN_OWNER_CHECK,
         SET_VAI_MINT_RATE_CHECK,


### PR DESCRIPTION
## Description

1. LUNA and UST are to be unlisted from markets
2. Comptroller to have a new function `_unlistMarket` similar to `_supportMarket`
3. set market's `isListed` to false in `markets`
4. delete the vToken entry from `allMarkets`
5. ensure check for the function call `_unlistMarket`

JIRA: https://jira.toolsfdg.net/browse/VEN-234

## Checklist

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
