### PR TITLE
[VEN-792] Stop XVS Reward during Cooldown

### DIFF
--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -8,8 +8,6 @@ import "./XVSVaultProxy.sol";
 import "./XVSVaultStorage.sol";
 import "./XVSVaultErrorReporter.sol";
 
-import "hardhat/console.sol";
-
 interface IXVSStore {
     function safeRewardTransfer(address _token, address _to, uint256 _amount) external;
     function setRewardToken(address _tokenAddress, bool status) external;

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -321,7 +321,10 @@ contract XVSVault is XVSVaultStorage, ECDSA {
 
         user.amount = user.amount.sub(_amount);
 
-        totalPendingWithdrawals[_rewardToken][_pid] = totalPendingWithdrawals[_rewardToken][_pid].sub(_amount);
+        // we do this for backward compatibility 
+        if (totalPendingWithdrawals[_rewardToken][_pid] >= _amount)) {
+            totalPendingWithdrawals[_rewardToken][_pid] = totalPendingWithdrawals[_rewardToken][_pid].sub(_amount);
+        }
 
         pool.token.safeTransfer(address(msg.sender), _amount);
 

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -350,19 +350,11 @@ contract XVSVault is XVSVaultStorage, ECDSA {
     }
 
     /**
-     * @notice Pops the requests with unlock time < now from the requests
-     *   array and deducts the computed amount from the user's pending
-     *   withdrawals counter. Assumes that the requests array is sorted
-     *   by unclock time (descending).
-     * @dev This function **removes** the eligible requests from the requests
-     *   array. If this function is called, the withdrawal should actually
-     *   happen (or the transaction should be reverted).
+     * @notice Returns before and after upgrade pending withdrawal amount
      * @param _user The user struct storage pointer
      * @param _requests The user's requests array storage pointer
-     * @return beforeUpgradeWithdrawalAmount The amount eligible for withdrawal before upgrade (this amount should be
-     *   sent to the user, otherwise the state would be inconsistent).
-     * @return afterUpgradeWithdrawalAmount The amount eligible for withdrawal after upgrade (this amount should be
-     *   sent to the user, otherwise the state would be inconsistent).
+     * @return beforeUpgradeWithdrawalAmount The amount eligible for withdrawal before upgrade 
+     * @return afterUpgradeWithdrawalAmount The amount eligible for withdrawal after upgrade 
      */
     function getRequestedWithdrawalAmount(
         UserInfo storage _user,

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -275,7 +275,9 @@ contract XVSVault is XVSVaultStorage, ECDSA {
      *   happen (or the transaction should be reverted).
      * @param _user The user struct storage pointer
      * @param _requests The user's requests array storage pointer
-     * @return withdrawalAmount The amount eligible for withdrawal (this amount should be
+     * @return beforeUpgradeWithdrawalAmount The amount eligible for withdrawal before upgrade (this amount should be
+     *   sent to the user, otherwise the state would be inconsistent).
+     * @return afterUpgradeWithdrawalAmount The amount eligible for withdrawal after upgrade (this amount should be
      *   sent to the user, otherwise the state would be inconsistent).
      */
     function popEligibleWithdrawalRequests(

--- a/contracts/XVSVault/XVSVaultStorage.sol
+++ b/contracts/XVSVault/XVSVaultStorage.sol
@@ -108,5 +108,6 @@ contract XVSVaultStorage is XVSVaultStorageV1 {
     /// @notice The number of checkpoints for each account
     mapping (address => uint32) public numCheckpoints;
 
+    /// @notice Tracks pending withdrawals for all users for a particular reward token and pool id
     mapping(address => mapping(uint256 => uint256)) totalPendingWithdrawals;
 }

--- a/contracts/XVSVault/XVSVaultStorage.sol
+++ b/contracts/XVSVault/XVSVaultStorage.sol
@@ -106,4 +106,6 @@ contract XVSVaultStorage is XVSVaultStorageV1 {
 
     /// @notice The number of checkpoints for each account
     mapping (address => uint32) public numCheckpoints;
+
+    mapping(address => mapping(uint256 => uint256)) totalPendingWithdrawals;
 }

--- a/contracts/XVSVault/XVSVaultStorage.sol
+++ b/contracts/XVSVault/XVSVaultStorage.sol
@@ -57,6 +57,7 @@ contract XVSVaultStorageV1 is XVSVaultAdminStorage {
     struct WithdrawalRequest {
         uint256 amount;
         uint256 lockedUntil;
+        bool afterUpgrade;
     }
 
     // Info of each user that stakes tokens.

--- a/contracts/test/XVSVaultScenario.sol
+++ b/contracts/test/XVSVaultScenario.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+import "../XVSVault/XVSVault.sol";
+
+contract XVSVaultScenario is XVSVault {
+    function pushOldWithdrawalRequest(
+        UserInfo storage _user,
+        WithdrawalRequest[] storage _requests,
+        uint _amount,
+        uint _lockedUntil
+    )
+        internal
+    {
+        uint i = _requests.length;
+        _requests.push(WithdrawalRequest(0, 0, false));
+        // Keep it sorted so that the first to get unlocked request is always at the end
+        for (; i > 0 && _requests[i - 1].lockedUntil <= _lockedUntil; --i) {
+            _requests[i] = _requests[i - 1];
+        }
+        _requests[i] = WithdrawalRequest(_amount, _lockedUntil, false);
+        _user.pendingWithdrawals = _user.pendingWithdrawals.add(_amount);
+    }
+
+  function requestOldWithdrawal(address _rewardToken, uint256 _pid, uint256 _amount)
+        external
+        nonReentrant
+    {
+        _ensureValidPool(_rewardToken, _pid);
+        require(_amount > 0, "requested amount cannot be zero");
+        UserInfo storage user = userInfos[_rewardToken][_pid][msg.sender];
+        require(user.amount >= user.pendingWithdrawals.add(_amount), "requested amount is invalid");
+
+        PoolInfo storage pool = poolInfos[_rewardToken][_pid];
+        WithdrawalRequest[] storage requests = withdrawalRequests[_rewardToken][_pid][msg.sender];
+        uint lockedUntil = pool.lockPeriod.add(block.timestamp);
+
+        pushOldWithdrawalRequest(user, requests, _amount, lockedUntil);
+
+        // Update Delegate Amount
+        if (_rewardToken == address(xvsAddress)) {
+            _moveDelegates(delegates[msg.sender], address(0), uint96(_amount));
+        }
+
+        emit ReqestedWithdrawal(msg.sender, _rewardToken, _pid, _amount);
+    }
+}

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -1,0 +1,145 @@
+import { MockContract, smock } from "@defi-wonderland/smock";
+import { loadFixture, mine } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { BigNumber, Wallet } from "ethers";
+import { ethers } from "hardhat";
+import { XVS, XVSStore, XVSVault } from "../../../typechain";
+
+const bigNumber18 = BigNumber.from("1000000000000000000"); // 1e18
+const rewardPerBlock = bigNumber18.mul(1)
+const lockPeriod = 300
+const allocPoint = 100
+const poolId = 0
+
+interface XVSVaultFixture {
+  xvsVault: XVSVault;
+  xvs: XVS;
+  xvsStore: XVSStore;
+}
+
+describe("XVSVault", async () => {
+  let user1: Wallet
+  let user2: Wallet 
+  let xvs: XVS
+  let xvsVault: XVSVault
+  let xvsStore: XVSStore
+
+  before("get signers", async () => {
+    [user1, user2] = await (ethers as any).getSigners();
+  });
+
+  async function deployXVSVaultFixture(): Promise<XVSVaultFixture> {
+    const xvsFactory = await ethers.getContractFactory("XVS");
+    xvs = (await xvsFactory.deploy(user1.address)) as XVS;
+
+    const xvsStoreFactory = await ethers.getContractFactory("XVSStore");
+    xvsStore = (await xvsStoreFactory.deploy()) as XVSStore;
+
+    const xvsVaultFactory = await ethers.getContractFactory("XVSVault");
+    xvsVault = (await xvsVaultFactory.deploy()) as XVSVault;
+
+    return { xvsVault, xvs, xvsStore };
+  }
+
+  beforeEach("deploy and configure XVSVault contracts", async () => {
+    ({ xvsVault, xvs, xvsStore } = await loadFixture(deployXVSVaultFixture));
+    
+    await xvsStore.setNewOwner(xvsVault.address)
+    await xvsVault.setXvsStore(xvs.address, xvsStore.address)
+    await xvs.transfer(xvsStore.address, bigNumber18.mul(1000))
+
+    await xvsStore.setRewardToken(xvs.address, true);
+
+    await xvsVault.add(
+      xvs.address,
+      allocPoint,
+      xvs.address,
+      rewardPerBlock,
+      lockPeriod
+    )
+  });
+
+  it("check xvs balance", async () => {
+    expect(await xvs.balanceOf(xvsStore.address)).to.eq(bigNumber18.mul(1000));
+  });
+
+  it("check if pool exists", async () => {
+    const pool = await xvsVault.poolInfos(xvs.address, 0)
+    expect(pool.token).to.eq(xvs.address)
+    expect(pool.allocPoint).to.eq(allocPoint)
+    expect(pool.accRewardPerShare).to.eq(0)
+    expect(pool.lockPeriod).to.eq(lockPeriod)
+  });
+
+  it("earn reward for staking", async () => {
+    const depositAmount = bigNumber18.mul(100);
+    
+    await xvs.approve(xvsVault.address, depositAmount)
+    await xvsVault.deposit(
+      xvs.address,
+      poolId,
+      depositAmount
+    )
+
+    expect(await xvs.balanceOf(xvsVault.address)).to.eq(depositAmount)
+    
+    let userInfo = await xvsVault.getUserInfo(
+      xvs.address,
+      poolId,
+      user1.address
+    )
+
+    expect(userInfo.amount).to.eq(depositAmount)
+    expect(userInfo.rewardDebt).to.eq(0)
+
+    await mine(1000)
+
+    let previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+
+    await xvsVault.requestWithdrawal(
+      xvs.address,
+      poolId,
+      depositAmount
+    )
+
+    let currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+
+    expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance))
+
+    await mine(500)
+    
+    previousXVSBalance = currentXVSBalance
+
+    await xvsVault.executeWithdrawal(
+      xvs.address,
+      poolId
+    )
+
+    currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+    
+    expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance))
+  });
+
+  it("no reward for pending withdrawals", async () => {
+    const depositAmount = bigNumber18.mul(100);
+    
+    await xvs.approve(xvsVault.address, depositAmount)
+    await xvsVault.deposit(
+      xvs.address,
+      poolId,
+      depositAmount
+    )
+
+    let previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+
+    await xvsVault.requestWithdrawal(
+      xvs.address,
+      poolId,
+      depositAmount
+    )
+
+    let currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+
+    expect(Number(previousXVSBalance) + 1).to.be.equal(Number(currentXVSBalance))
+  });
+})

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -115,12 +115,12 @@ describe("XVSVault", async () => {
 
   it("handle pre-upgrade withdrawal requests", async () => {
     const depositAmount = bigNumber18.mul(100);
-    
+
     await xvs.approve(xvsVault.address, depositAmount);
     await xvsVault.deposit(xvs.address, poolId, depositAmount);
 
     let previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
-    
+
     await mine(1000);
     await xvsVault.requestOldWithdrawal(xvs.address, poolId, depositAmount);
 
@@ -139,12 +139,12 @@ describe("XVSVault", async () => {
 
   it("handle pre-upgrade and post-upgrade withdrawal requests", async () => {
     const depositAmount = bigNumber18.mul(100);
-    
+
     await xvs.approve(xvsVault.address, depositAmount);
     await xvsVault.deposit(xvs.address, poolId, depositAmount);
 
     let previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
-    
+
     await mine(1000);
     await xvsVault.requestOldWithdrawal(xvs.address, poolId, bigNumber18.mul(50));
     await xvsVault.requestWithdrawal(xvs.address, poolId, bigNumber18.mul(50));

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -1,15 +1,15 @@
-import { MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture, mine } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { BigNumber, Wallet } from "ethers";
 import { ethers } from "hardhat";
+
 import { XVS, XVSStore, XVSVault } from "../../../typechain";
 
 const bigNumber18 = BigNumber.from("1000000000000000000"); // 1e18
-const rewardPerBlock = bigNumber18.mul(1)
-const lockPeriod = 300
-const allocPoint = 100
-const poolId = 0
+const rewardPerBlock = bigNumber18.mul(1);
+const lockPeriod = 300;
+const allocPoint = 100;
+const poolId = 0;
 
 interface XVSVaultFixture {
   xvsVault: XVSVault;
@@ -18,14 +18,13 @@ interface XVSVaultFixture {
 }
 
 describe("XVSVault", async () => {
-  let user1: Wallet
-  let user2: Wallet 
-  let xvs: XVS
-  let xvsVault: XVSVault
-  let xvsStore: XVSStore
+  let user1: Wallet;
+  let xvs: XVS;
+  let xvsVault: XVSVault;
+  let xvsStore: XVSStore;
 
   before("get signers", async () => {
-    [user1, user2] = await (ethers as any).getSigners();
+    [user1] = await (ethers as any).getSigners();
   });
 
   async function deployXVSVaultFixture(): Promise<XVSVaultFixture> {
@@ -43,20 +42,14 @@ describe("XVSVault", async () => {
 
   beforeEach("deploy and configure XVSVault contracts", async () => {
     ({ xvsVault, xvs, xvsStore } = await loadFixture(deployXVSVaultFixture));
-    
-    await xvsStore.setNewOwner(xvsVault.address)
-    await xvsVault.setXvsStore(xvs.address, xvsStore.address)
-    await xvs.transfer(xvsStore.address, bigNumber18.mul(1000))
+
+    await xvsStore.setNewOwner(xvsVault.address);
+    await xvsVault.setXvsStore(xvs.address, xvsStore.address);
+    await xvs.transfer(xvsStore.address, bigNumber18.mul(1000));
 
     await xvsStore.setRewardToken(xvs.address, true);
 
-    await xvsVault.add(
-      xvs.address,
-      allocPoint,
-      xvs.address,
-      rewardPerBlock,
-      lockPeriod
-    )
+    await xvsVault.add(xvs.address, allocPoint, xvs.address, rewardPerBlock, lockPeriod);
   });
 
   it("check xvs balance", async () => {
@@ -64,82 +57,59 @@ describe("XVSVault", async () => {
   });
 
   it("check if pool exists", async () => {
-    const pool = await xvsVault.poolInfos(xvs.address, 0)
-    expect(pool.token).to.eq(xvs.address)
-    expect(pool.allocPoint).to.eq(allocPoint)
-    expect(pool.accRewardPerShare).to.eq(0)
-    expect(pool.lockPeriod).to.eq(lockPeriod)
+    const pool = await xvsVault.poolInfos(xvs.address, 0);
+    expect(pool.token).to.eq(xvs.address);
+    expect(pool.allocPoint).to.eq(allocPoint);
+    expect(pool.accRewardPerShare).to.eq(0);
+    expect(pool.lockPeriod).to.eq(lockPeriod);
   });
 
   it("earn reward for staking", async () => {
     const depositAmount = bigNumber18.mul(100);
-    
-    await xvs.approve(xvsVault.address, depositAmount)
-    await xvsVault.deposit(
-      xvs.address,
-      poolId,
-      depositAmount
-    )
 
-    expect(await xvs.balanceOf(xvsVault.address)).to.eq(depositAmount)
-    
-    let userInfo = await xvsVault.getUserInfo(
-      xvs.address,
-      poolId,
-      user1.address
-    )
+    await xvs.approve(xvsVault.address, depositAmount);
+    await xvsVault.deposit(xvs.address, poolId, depositAmount);
 
-    expect(userInfo.amount).to.eq(depositAmount)
-    expect(userInfo.rewardDebt).to.eq(0)
+    expect(await xvs.balanceOf(xvsVault.address)).to.eq(depositAmount);
 
-    await mine(1000)
+    const userInfo = await xvsVault.getUserInfo(xvs.address, poolId, user1.address);
 
-    let previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+    expect(userInfo.amount).to.eq(depositAmount);
+    expect(userInfo.rewardDebt).to.eq(0);
 
-    await xvsVault.requestWithdrawal(
-      xvs.address,
-      poolId,
-      depositAmount
-    )
+    await mine(1000);
 
-    let currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+    let previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
 
-    expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance))
+    await xvsVault.requestWithdrawal(xvs.address, poolId, depositAmount);
 
-    await mine(500)
-    
-    previousXVSBalance = currentXVSBalance
+    let currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
 
-    await xvsVault.executeWithdrawal(
-      xvs.address,
-      poolId
-    )
+    expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance));
 
-    currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
-    
-    expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance))
+    await mine(500);
+
+    previousXVSBalance = currentXVSBalance;
+
+    await xvsVault.executeWithdrawal(xvs.address, poolId);
+
+    currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
+
+    expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance));
   });
 
   it("no reward for pending withdrawals", async () => {
     const depositAmount = bigNumber18.mul(100);
-    
-    await xvs.approve(xvsVault.address, depositAmount)
-    await xvsVault.deposit(
-      xvs.address,
-      poolId,
-      depositAmount
-    )
 
-    let previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+    await xvs.approve(xvsVault.address, depositAmount);
+    await xvsVault.deposit(xvs.address, poolId, depositAmount);
 
-    await xvsVault.requestWithdrawal(
-      xvs.address,
-      poolId,
-      depositAmount
-    )
+    const previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
 
-    let currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString())
+    await xvsVault.requestWithdrawal(xvs.address, poolId, depositAmount);
 
-    expect(Number(previousXVSBalance) + 1).to.be.equal(Number(currentXVSBalance))
+    const currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
+
+    expect(Number(previousXVSBalance) + 1).to.be.equal(Number(currentXVSBalance));
   });
-})
+});

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -147,13 +147,22 @@ describe("XVSVault", async () => {
 
     await mine(1000);
     await xvsVault.requestOldWithdrawal(xvs.address, poolId, bigNumber18.mul(50));
-    await xvsVault.requestWithdrawal(xvs.address, poolId, bigNumber18.mul(50));
+    await expect(xvsVault.requestWithdrawal(xvs.address, poolId, bigNumber18.mul(50))).to.be.revertedWith(
+      "execute existing withdrawal before requesting new withdrawal",
+    );
 
+    await mine(500);
+    await xvsVault.executeWithdrawal(xvs.address, poolId);
     let currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
 
     expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance));
 
     previousXVSBalance = currentXVSBalance;
+
+    await mine(500);
+    xvsVault.requestWithdrawal(xvs.address, poolId, bigNumber18.mul(50));
+
+    currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(user1.address)).toString());
 
     await mine(500);
     await xvsVault.executeWithdrawal(xvs.address, poolId);


### PR DESCRIPTION
## Description

- Added a new state variable `totalPendingWithdrawals` to track pending withdrawals across all users. 
- We calculate and transfer rewards in requestWithdrawal instead executeWithdrawal 
- If a user has unexecuted pending withdrawal after upgrade then then need to execute that before requesting new withdrawals
- Added `afterUpgrade` flag for WithdrawalRequest so that we can handle existing withdrawals correctly and pay rewards in executeWithdrawal.

Resolves #VEN-792

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
