### PR TITLE
chore: set liquidator compiler version to more stable

### DIFF
--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.17;
+pragma solidity 0.8.13;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";

--- a/contracts/test/LiquidatorHarness.sol
+++ b/contracts/test/LiquidatorHarness.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-pragma solidity 0.8.17;
+pragma solidity 0.8.13;
 
 import "../Liquidator/Liquidator.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -90,7 +90,7 @@ const config: HardhatUserConfig = {
         },
       },
       {
-        version: "0.8.17",
+        version: "0.8.13",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
Auditors often report that using too recent compiler versions may lead to facing yet undiscovered bugs. Version 0.8.13 is stable, and the known issues there are not relevant to our contracts. We use 0.8.13 in our other repos, so in addition to security reasons, I'm also making this change for consistency.