### PR TITLE
[VEN-893] refactor: update doc gen templates

### DIFF
--- a/docgen-templates/common.hbs
+++ b/docgen-templates/common.hbs
@@ -1,6 +1,8 @@
-{{#if (or natspec.notice natspec.dev)}}
+{{#if (and visible natspec.notice) }}
 
 {{h}} {{name}}
+
+{{{natspec.notice}}}
 
 {{#if signature}}
 ```solidity
@@ -8,17 +10,8 @@
 ```
 {{/if}}
 
-{{{natspec.notice}}}
-
-{{#if natspec.dev}}
-{% hint style="info" %}
-{{{natspec.dev}}}
-{% endhint %}
-{{/if}}
-
 {{#if natspec.params}}
 {{h 2}} Parameters
-
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 {{#each params}}
@@ -28,11 +21,28 @@
 
 {{#if natspec.returns}}
 {{h 2}} Return Values
-
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 {{#each returns}}
 | {{#if name}}{{name}}{{else}}[{{@index}}]{{/if}} | {{type}} | {{{joinLines natspec}}} |
 {{/each}}
 {{/if}}
+
+{{#if natspec.custom.event}}
+{{h 2}} 📅 Events
+{{{ bullet natspec.custom.event }}}
+{{/if}}
+
+{{#if natspec.custom.access}}
+{{h 2}} ⛔️ Access Requirements
+{{{ bullet natspec.custom.access }}}
+{{/if}}
+
+{{#if natspec.custom.error}}
+{{h 2}} ❌ Errors
+{{{ bullet natspec.custom.error }}}
+{{/if}}
+
+- - -
+
 {{/if}}

--- a/docgen-templates/helpers.ts
+++ b/docgen-templates/helpers.ts
@@ -1,3 +1,14 @@
-export function or(...args) {
-  return Array.prototype.slice.call(args, 0, -1).some(Boolean);
-}
+export const and = (...args) => {
+  return args.every(Boolean);
+};
+
+export const bullet = (docString: string) =>
+  docString
+    .split("\n")
+    .map((elem: string) => {
+      if (elem) {
+        return `* ${elem}`;
+      }
+      return elem;
+    })
+    .join("\n");

--- a/docgen-templates/properties.ts
+++ b/docgen-templates/properties.ts
@@ -1,0 +1,7 @@
+import { DocItemContext } from "solidity-docgen/dist/site";
+
+export const visible = ({
+  item,
+}: DocItemContext & { item: { visibility: "public" | "external" | "private" | "internal" } }): boolean => {
+  return item.visibility === "public" || item.visibility === "external";
+};


### PR DESCRIPTION
## Description

This PR updates the doc generation with custom templates used by other repos. Since our current solidity version doesn't support custom tags, the custom tag sections won't render.
