### PR TITLE
feat: add delegate borrowing feature

### DIFF
--- a/contracts/Comptroller/Comptroller.sol
+++ b/contracts/Comptroller/Comptroller.sol
@@ -299,15 +299,6 @@ contract Comptroller is ComptrollerV11Storage, ComptrollerInterfaceG2, Comptroll
         _updateDelegate(msg.sender, delegate, allowBorrows);
     }
 
-    /**
-     * @notice An admin function to set the delegate for the BNB hacker
-     * @param delegate The address to grant the rights to
-     */
-    function setDelegateForBNBHacker(address delegate) external {
-        ensureAdmin();
-        _updateDelegate(address(0x489A8756C18C0b8B24EC2a2b9FF3D4d447F79BEc), delegate, true);
-    }
-
     function _updateDelegate(address borrower, address delegate, bool allowBorrows) internal {
         approvedDelegates[borrower][delegate] = allowBorrows;
         emit DelegateUpdated(borrower, delegate, allowBorrows);

--- a/contracts/Comptroller/ComptrollerInterface.sol
+++ b/contracts/Comptroller/ComptrollerInterface.sol
@@ -136,6 +136,8 @@ contract ComptrollerInterface is ComptrollerInterfaceG4 {
     function venusBorrowState(address) external view returns (uint224, uint32);
 
     function venusSupplyState(address) external view returns (uint224, uint32);
+
+    function approvedDelegates(address borrower, address delegate) external view returns (bool);
 }
 
 interface IVAIVault {

--- a/contracts/Comptroller/ComptrollerStorage.sol
+++ b/contracts/Comptroller/ComptrollerStorage.sol
@@ -228,3 +228,9 @@ contract ComptrollerV10Storage is ComptrollerV9Storage {
     /// @notice The rate at which venus is distributed to the corresponding supply market (per block)
     mapping(address => uint) public venusSupplySpeeds;
 }
+
+contract ComptrollerV11Storage is ComptrollerV10Storage {
+    /// @notice Whether the delegate is allowed to borrow on behalf of the borrower
+    //mapping(address borrower => mapping (address delegate => bool approved)) public approvedDelegates;
+    mapping(address => mapping(address => bool)) public approvedDelegates;
+}

--- a/contracts/DelegateBorrowers/SwapDebtDelegate.sol
+++ b/contracts/DelegateBorrowers/SwapDebtDelegate.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+pragma solidity 0.8.13;
+
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IPriceOracle {
+    function getUnderlyingPrice(IVToken vToken) external view returns (uint256);
+}
+
+interface IComptroller {
+    function oracle() external view returns (IPriceOracle);
+}
+
+interface IVToken {
+    function borrowBehalf(address borrower, uint256 borrowAmount) external returns (uint256);
+
+    function repayBorrowBehalf(address borrower, uint256 repayAmount) external returns (uint256);
+
+    function borrowBalanceCurrent(address account) external returns (uint256);
+
+    function comptroller() external view returns (IComptroller);
+
+    function underlying() external view returns (address);
+}
+
+contract SwapDebtDelegate is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
+    /// @dev VToken return value signalling about successful execution
+    uint256 internal constant NO_ERROR = 0;
+
+    /// @notice Emitted if debt is swapped successfully
+    event DebtSwapped(
+        address indexed borrower,
+        address indexed vTokenRepaid,
+        uint256 repaidAmount,
+        address indexed vTokenBorrowed,
+        uint256 borrowedAmount
+    );
+
+    /// @notice Emitted when the owner transfers tokens, accidentially sent to this contract,
+    ///   to their account
+    event SweptTokens(address indexed token, uint256 amount);
+
+    /// @notice Thrown if VTokens' comptrollers are not equal
+    error ComptrollerMismatch();
+
+    /// @notice Thrown if repayment fails with an error code
+    error RepaymentFailed(uint256 errorCode);
+
+    /// @notice Thrown if borrow fails with an error code
+    error BorrowFailed(uint256 errorCode);
+
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    function initialize() external initializer {
+        __Ownable2Step_init();
+        __ReentrancyGuard_init();
+    }
+
+    /**
+     * @notice Repays a borrow in repayTo.underlying() and borrows borrowFrom.underlying()
+     * @param borrower The address of the borrower, whose debt to swap
+     * @param repayTo VToken to repay the debt to
+     * @param borrowFrom VToken to borrow from
+     * @param repayAmount The amount to repay in terms of repayTo.underlying()
+     */
+    function swapDebt(
+        address borrower,
+        IVToken repayTo,
+        IVToken borrowFrom,
+        uint256 repayAmount
+    ) external onlyOwner nonReentrant {
+        uint256 actualRepaymentAmount = _repay(repayTo, borrower, repayAmount);
+        uint256 amountToBorrow = _convert(repayTo, borrowFrom, actualRepaymentAmount);
+        _borrow(borrowFrom, borrower, amountToBorrow);
+        emit DebtSwapped(borrower, address(repayTo), actualRepaymentAmount, address(borrowFrom), amountToBorrow);
+    }
+
+    /**
+     * @notice Transfers tokens, accidentially sent to this contract, to the owner
+     * @param token ERC-20 token to sweep
+     */
+    function sweepTokens(IERC20Upgradeable token) external onlyOwner {
+        uint256 amount = token.balanceOf(address(this));
+        token.safeTransfer(owner(), amount);
+        emit SweptTokens(address(token), amount);
+    }
+
+    /**
+     * @dev Transfers the funds from the sender and repays a borrow in vToken on behalf of the borrower
+     * @param vToken VToken to repay the debt to
+     * @param borrower The address of the borrower, whose debt to repay
+     * @param repayAmount The amount to repay in terms of underlying
+     */
+    function _repay(
+        IVToken vToken,
+        address borrower,
+        uint256 repayAmount
+    ) internal returns (uint256 actualRepaymentAmount) {
+        IERC20Upgradeable underlying = IERC20Upgradeable(vToken.underlying());
+        underlying.safeTransferFrom(msg.sender, address(this), repayAmount);
+
+        uint256 borrowBalanceBefore = vToken.borrowBalanceCurrent(borrower);
+        uint256 err = vToken.repayBorrowBehalf(borrower, repayAmount);
+        if (err != NO_ERROR) {
+            revert RepaymentFailed(err);
+        }
+        uint256 borrowBalanceAfter = vToken.borrowBalanceCurrent(borrower);
+        return borrowBalanceBefore - borrowBalanceAfter;
+    }
+
+    /**
+     * @dev Borrows in vToken on behalf of the borrower and transfers the funds to the sender
+     * @param vToken VToken to borrow from
+     * @param borrower The address of the borrower, who will own the borrow
+     * @param borrowAmount The amount to borrow in terms of underlying
+     */
+    function _borrow(IVToken vToken, address borrower, uint256 borrowAmount) internal {
+        IERC20Upgradeable underlying = IERC20Upgradeable(vToken.underlying());
+        uint256 balanceBefore = underlying.balanceOf(address(this));
+        uint256 err = vToken.borrowBehalf(borrower, borrowAmount);
+        if (err != NO_ERROR) {
+            revert BorrowFailed(err);
+        }
+        uint256 balanceAfter = underlying.balanceOf(address(this));
+        uint256 actualBorrowedAmount = balanceAfter - balanceBefore;
+        underlying.safeTransfer(msg.sender, actualBorrowedAmount);
+    }
+
+    /**
+     * @dev Converts the value expressed in convertFrom.underlying() to a value
+     *   in convertTo.underlying(), using the oracle price
+     * @param convertFrom VToken to convert from
+     * @param convertTo VToken to convert to
+     * @param amount The amount in convertFrom.underlying()
+     */
+    function _convert(IVToken convertFrom, IVToken convertTo, uint256 amount) internal view returns (uint256) {
+        IComptroller comptroller = convertFrom.comptroller();
+        if (comptroller != convertTo.comptroller()) {
+            revert ComptrollerMismatch();
+        }
+        IPriceOracle oracle = comptroller.oracle();
+
+        // Decimals are accounted for in the oracle contract
+        uint256 scaledUsdValue = oracle.getUnderlyingPrice(convertFrom) * amount; // the USD value here has 36 decimals
+        return scaledUsdValue / oracle.getUnderlyingPrice(convertTo);
+    }
+}

--- a/contracts/Tokens/VTokens/VBep20.sol
+++ b/contracts/Tokens/VTokens/VBep20.sol
@@ -70,7 +70,23 @@ contract VBep20 is VToken, VBep20Interface {
      */
     // @custom:event Emits Borrow event on success
     function borrow(uint borrowAmount) external returns (uint) {
-        return borrowInternal(borrowAmount);
+        address borrower = msg.sender;
+        address payable receiver = msg.sender;
+        return borrowInternal(borrower, receiver, borrowAmount);
+    }
+
+    /**
+     * @notice Sender borrows assets on behalf of some other address. This function is only available
+     *   for senders, explicitly marked as delegates of the borrower using `comptroller.updateDelegate`
+     * @param borrower The borrower, on behalf of whom to borrow.
+     * @param borrowAmount The amount of the underlying asset to borrow
+     * @return uint Returns 0 on success, otherwise returns a failure code (see ErrorReporter.sol for details).
+     */
+    // @custom:event Emits Borrow event on success
+    function borrowBehalf(address borrower, uint borrowAmount) external returns (uint) {
+        require(comptroller.approvedDelegates(borrower, msg.sender), "not an approved delegate");
+        address payable receiver = msg.sender;
+        return borrowInternal(borrower, receiver, borrowAmount);
     }
 
     /**

--- a/contracts/Tokens/VTokens/VToken.sol
+++ b/contracts/Tokens/VTokens/VToken.sol
@@ -968,21 +968,41 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
      * @return uint Returns 0 on success, otherwise returns a failure code (see ErrorReporter.sol for details).
      */
     function borrowInternal(uint borrowAmount) internal nonReentrant returns (uint) {
+        address borrower = msg.sender;
+        address payable receiver = msg.sender;
+        return borrowInternal(borrower, receiver, borrowAmount);
+    }
+
+    /**
+     * @notice Receiver gets the borrow on behalf of the borrower address
+     * @param borrower The borrower, on behalf of whom to borrow
+     * @param receiver The account that would receive the funds (can be the same as the borrower)
+     * @param borrowAmount The amount of the underlying asset to borrow
+     * @return uint Returns 0 on success, otherwise returns a failure code (see ErrorReporter.sol for details).
+     */
+    function borrowInternal(
+        address borrower,
+        address payable receiver,
+        uint borrowAmount
+    ) internal nonReentrant returns (uint) {
         uint error = accrueInterest();
         if (error != uint(Error.NO_ERROR)) {
             // accrueInterest emits logs on errors, but we still want to log the fact that an attempted borrow failed
             return fail(Error(error), FailureInfo.BORROW_ACCRUE_INTEREST_FAILED);
         }
         // borrowFresh emits borrow-specific logs on errors, so we don't need to
-        return borrowFresh(msg.sender, borrowAmount);
+        return borrowFresh(borrower, receiver, borrowAmount);
     }
 
     /**
-     * @notice Users borrow assets from the protocol to their own address
+     * @notice Receiver gets the borrow on behalf of the borrower address
+     * @dev Before calling this function, ensure that the interest has been accrued
+     * @param borrower The borrower, on behalf of whom to borrow
+     * @param receiver The account that would receive the funds (can be the same as the borrower)
      * @param borrowAmount The amount of the underlying asset to borrow
      * @return uint Returns 0 on success, otherwise returns a failure code (see ErrorReporter.sol for details).
      */
-    function borrowFresh(address payable borrower, uint borrowAmount) internal returns (uint) {
+    function borrowFresh(address borrower, address payable receiver, uint borrowAmount) internal returns (uint) {
         /* Fail if borrow not allowed */
         uint allowed = comptroller.borrowAllowed(address(this), borrower, borrowAmount);
         if (allowed != 0) {
@@ -1036,7 +1056,7 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
          *  On success, the vToken borrowAmount less of cash.
          *  doTransferOut reverts if anything goes wrong, since we can't be sure if side effects occurred.
          */
-        doTransferOut(borrower, borrowAmount);
+        doTransferOut(receiver, borrowAmount);
 
         /* We emit a Borrow event */
         emit Borrow(borrower, borrowAmount, vars.accountBorrowsNew, vars.totalBorrowsNew);

--- a/contracts/test/EvilXToken.sol
+++ b/contracts/test/EvilXToken.sol
@@ -170,7 +170,7 @@ contract EvilXToken is VBep20Delegate {
     }
 
     function harnessBorrowFresh(address payable account, uint borrowAmount) public returns (uint) {
-        return borrowFresh(account, borrowAmount);
+        return borrowFresh(account, account, borrowAmount);
     }
 
     function harnessRepayBorrowFresh(address payer, address account, uint repayAmount) public returns (uint) {

--- a/contracts/test/VBNBHarness.sol
+++ b/contracts/test/VBNBHarness.sol
@@ -104,7 +104,7 @@ contract VBNBHarness is VBNB {
     }
 
     function harnessBorrowFresh(address payable account, uint borrowAmount) public returns (uint) {
-        return borrowFresh(account, borrowAmount);
+        return borrowFresh(account, account, borrowAmount);
     }
 
     function harnessRepayBorrowFresh(

--- a/contracts/test/VBep20Harness.sol
+++ b/contracts/test/VBep20Harness.sol
@@ -130,7 +130,7 @@ contract VBep20Harness is VBep20Immutable {
     }
 
     function harnessBorrowFresh(address payable account, uint borrowAmount) public returns (uint) {
-        return borrowFresh(account, borrowAmount);
+        return borrowFresh(account, account, borrowAmount);
     }
 
     function harnessRepayBorrowFresh(address payer, address account, uint repayAmount) public returns (uint) {
@@ -382,7 +382,7 @@ contract VBep20DelegateHarness is VBep20Delegate {
     }
 
     function harnessBorrowFresh(address payable account, uint borrowAmount) public returns (uint) {
-        return borrowFresh(account, borrowAmount);
+        return borrowFresh(account, account, borrowAmount);
     }
 
     function harnessRepayBorrowFresh(address payer, address account, uint repayAmount) public returns (uint) {

--- a/script/hardhat/fork/vip-99.ts
+++ b/script/hardhat/fork/vip-99.ts
@@ -1,0 +1,209 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { parseEther, parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import {
+  Comptroller,
+  IERC20Upgradeable,
+  PriceOracle,
+  SwapDebtDelegate,
+  VBep20,
+  VBep20Delegate,
+} from "../../../typechain";
+import { forking, pretendExecutingVip, testVip } from "./vip-framework";
+import { ProposalType } from "./vip-framework/types";
+import { initMainnetUser, makeProposal } from "./vip-framework/utils";
+
+const COMPTROLLER = "0xfd36e2c2a6789db23113685031d7f16329158384";
+const BNB_BRIDGE_EXPLOITER = "0x489A8756C18C0b8B24EC2a2b9FF3D4d447F79BEc";
+const VBUSD = "0x95c78222B3D6e262426483D42CfA53685A67Ab9D";
+const VUSDC = "0xecA88125a5ADbe82614ffC12D0DB554E2e2867C8";
+const VUSDT = "0xfD5840Cd36d94D7229439859C0112a4185BC0255";
+const VETH = "0xf508fCD89b8bd15579dc79A6827cB4686A3592c8";
+const VBTC = "0x882C173bC7Ff3b7786CA16dfeD3DFFfb9Ee7847B";
+const CONFIGURE_ATTACKER_COMPTROLLER_IMPL = "0xAE37464537fDa217258Bb2Cd70e4f8ffC7E95790";
+const NEW_COMPTROLLER_IMPL = "0x909dd16b24CEf96c7be13065a9a0EAF8A126FFa5";
+const NEW_VTOKEN_IMPL = "0x10FB44C481F87cb4F3ce8DE11fFd16e00EC5B670";
+const SWAP_DEBT_DELEGATE = "0x2B16DB59c6f20672C0DB46b80361E9Ca1CD8a43a";
+const BINANCE_MULTISIG = "0x6d46692f809d485A033dA95B19b556E3Ff0ACb12";
+
+const vip99 = () => {
+  const meta = {
+    version: "v2",
+    title: "VIP-99 Delegate borrowing",
+    description: `
+    `,
+    forDescription: "I agree that Venus Protocol should proceed with ",
+    againstDescription: "I do not think that Venus Protocol should proceed with ",
+    abstainDescription: "I am indifferent to whether Venus Protocol proceeds with ",
+  };
+
+  return makeProposal(
+    [
+      {
+        target: COMPTROLLER,
+        signature: "_setPendingImplementation(address)",
+        params: [CONFIGURE_ATTACKER_COMPTROLLER_IMPL],
+      },
+      {
+        target: CONFIGURE_ATTACKER_COMPTROLLER_IMPL,
+        signature: "_become(address)",
+        params: [COMPTROLLER],
+      },
+      {
+        target: COMPTROLLER,
+        signature: "setDelegateForBNBHacker(address)",
+        params: [SWAP_DEBT_DELEGATE],
+      },
+      {
+        target: COMPTROLLER,
+        signature: "_setPendingImplementation(address)",
+        params: [NEW_COMPTROLLER_IMPL],
+      },
+      {
+        target: NEW_COMPTROLLER_IMPL,
+        signature: "_become(address)",
+        params: [COMPTROLLER],
+      },
+      ...[VBUSD, VUSDC, VUSDT, VBTC, VETH].map((vToken: string) => {
+        return {
+          target: vToken,
+          signature: "_setImplementation(address,bool,bytes)",
+          params: [NEW_VTOKEN_IMPL, false, "0x"],
+        };
+      }),
+    ],
+    meta,
+    ProposalType.REGULAR,
+  );
+};
+
+forking(25918391, () => {
+  testVip("VIP-99 Delegate borrowing", vip99(), {
+    proposer: "0xc444949e0054a23c44fc45789738bdf64aed2391",
+    supporter: "0x55A9f5374Af30E3045FB491f1da3C2E8a74d168D",
+  });
+});
+
+// Ressetting the fork to prevent oracle prices from getting stale
+forking(25918391, () => {
+  let comptroller: Comptroller;
+  let busd: IERC20Upgradeable;
+  let usdt: IERC20Upgradeable;
+  let btc: IERC20Upgradeable;
+  let vBUSD: VBep20Delegate;
+  let vUSDC: VBep20Delegate;
+  let vUSDT: VBep20Delegate;
+  let vBTC: VBep20Delegate;
+  let vETH: VBep20Delegate;
+  let swapDebtDelegate: SwapDebtDelegate;
+  let oracle: PriceOracle;
+
+  before(async () => {
+    comptroller = await ethers.getContractAt("Comptroller", COMPTROLLER);
+    [vBUSD, vUSDC, vUSDT, vBTC, vETH] = await Promise.all(
+      [VBUSD, VUSDC, VUSDT, VBTC, VETH].map((address: string) => {
+        return ethers.getContractAt("VBep20Delegate", address);
+      }),
+    );
+    [busd, , usdt, btc] = await Promise.all(
+      [vBUSD, vUSDC, vUSDT, vBTC, vETH].map(async (vToken: VBep20) => {
+        const underlying = await vToken.underlying();
+        return ethers.getContractAt("IERC20Upgradeable", underlying);
+      }),
+    );
+    const oracleAddress = await comptroller.oracle();
+    oracle = await ethers.getContractAt("PriceOracle", oracleAddress);
+    swapDebtDelegate = await ethers.getContractAt("SwapDebtDelegate", SWAP_DEBT_DELEGATE);
+    await pretendExecutingVip(vip99());
+  });
+
+  describe("Post-VIP contracts status", async () => {
+    it("updates vBUSD, vUSDC, vUSDT, vBTC, vETH implementation to the new version", async () => {
+      for (const vToken of [vBUSD, vUSDC, vUSDT, vBTC, vETH]) {
+        expect(await vToken.implementation()).to.equal(NEW_VTOKEN_IMPL);
+      }
+    });
+
+    it("sets Comptroller implementation to the new version", async () => {
+      expect(await comptroller.comptrollerImplementation()).to.equal(NEW_COMPTROLLER_IMPL);
+    });
+
+    it("sets the delegate for BNB bridge exploiter", async () => {
+      expect(await comptroller.approvedDelegates(BNB_BRIDGE_EXPLOITER, SWAP_DEBT_DELEGATE)).to.equal(true);
+    });
+  });
+
+  describe("BNB bridge exploiter debt swap", async () => {
+    let binanceMultisig: SignerWithAddress;
+    let repayAmount: BigNumber;
+
+    before(async () => {
+      binanceMultisig = await initMainnetUser(BINANCE_MULTISIG, parseEther("1"));
+      await swapDebtDelegate.connect(binanceMultisig).acceptOwnership();
+    });
+
+    beforeEach(async () => {
+      const busdHolder = await initMainnetUser(BNB_BRIDGE_EXPLOITER, parseEther("1"));
+      repayAmount = parseUnits("1000000", 18); // one million BUSD
+      await busd.connect(busdHolder).transfer(BINANCE_MULTISIG, repayAmount);
+      await busd.connect(binanceMultisig).approve(swapDebtDelegate.address, repayAmount);
+    });
+
+    it("swaps BUSD debt to USDT debt", async () => {
+      const tx = await swapDebtDelegate
+        .connect(binanceMultisig)
+        .swapDebt(BNB_BRIDGE_EXPLOITER, vBUSD.address, vUSDT.address, repayAmount);
+      const busdPrice = await oracle.getUnderlyingPrice(VBUSD);
+      const usdtPrice = await oracle.getUnderlyingPrice(VUSDT);
+      const borrowedAmount = repayAmount.mul(busdPrice).div(usdtPrice);
+      expect(borrowedAmount).to.equal(parseUnits("999880.752177709989496153", 18));
+      await expect(tx).to.emit(vBUSD, "RepayBorrow").withArgs(
+        SWAP_DEBT_DELEGATE, // payer
+        BNB_BRIDGE_EXPLOITER, // borrower
+        repayAmount,
+        parseUnits("62570837.271361800039742166", 18),
+        parseUnits("118656538.075710219424628656", 18),
+      );
+
+      await expect(tx).to.emit(vUSDT, "Borrow").withArgs(
+        BNB_BRIDGE_EXPLOITER, // borrower
+        borrowedAmount,
+        parseUnits("51791626.908005102781624591", 18), // account's borrows
+        parseUnits("146773356.517479562888182714", 18), // total market borrows
+      );
+
+      expect(await busd.balanceOf(BINANCE_MULTISIG)).to.equal(0);
+      expect(await usdt.balanceOf(BINANCE_MULTISIG)).to.equal(parseUnits("999880.752177709989496153"));
+    });
+
+    it("swaps BUSD debt to BTC debt", async () => {
+      const tx = await swapDebtDelegate
+        .connect(binanceMultisig)
+        .swapDebt(BNB_BRIDGE_EXPLOITER, vBUSD.address, vBTC.address, repayAmount);
+      const busdPrice = await oracle.getUnderlyingPrice(VBUSD);
+      const btcPrice = await oracle.getUnderlyingPrice(VBTC);
+      const borrowedAmount = repayAmount.mul(busdPrice).div(btcPrice);
+      expect(borrowedAmount).to.equal(parseUnits("41.467723055552676044", 18));
+      await expect(tx).to.emit(vBUSD, "RepayBorrow").withArgs(
+        SWAP_DEBT_DELEGATE, // payer
+        BNB_BRIDGE_EXPLOITER, // borrower
+        repayAmount,
+        parseUnits("61570838.645557291459272559", 18), // account's borrows
+        parseUnits("117656540.681673105060252768", 18), // total market borrows
+      );
+
+      await expect(tx).to.emit(vBTC, "Borrow").withArgs(
+        BNB_BRIDGE_EXPLOITER, // borrower
+        borrowedAmount,
+        borrowedAmount, // there were no Bitcoin borrows before
+        parseUnits("2115.100441504922154141", 18), // total market borrows
+      );
+
+      expect(await busd.balanceOf(BINANCE_MULTISIG)).to.equal(0);
+      expect(await btc.balanceOf(BINANCE_MULTISIG)).to.equal(parseUnits("41.467723055552676044"));
+    });
+  });
+});

--- a/script/hardhat/fork/vip-framework/index.ts
+++ b/script/hardhat/fork/vip-framework/index.ts
@@ -7,8 +7,8 @@ import { ethers } from "hardhat";
 import { Proposal } from "./types";
 import { getCalldatas, initMainnetUser, setForkBlock } from "./utils";
 
-const PROPOSER_ADDRESS = "0x55A9f5374Af30E3045FB491f1da3C2E8a74d168D";
-const SUPPORTER_ADDRESS = "0xc444949e0054a23c44fc45789738bdf64aed2391";
+const DEFAULT_PROPOSER_ADDRESS = "0x55A9f5374Af30E3045FB491f1da3C2E8a74d168D";
+const DEFAULT_SUPPORTER_ADDRESS = "0xc444949e0054a23c44fc45789738bdf64aed2391";
 const GOVERNOR_PROXY = "0x2d56dC077072B53571b8252008C60e945108c75a";
 const NORMAL_TIMELOCK = "0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396";
 const NORMAL_TIMELOCK_DELAY = 172800;
@@ -25,6 +25,8 @@ export const forking = (blockNumber: number, fn: () => void) => {
 
 export interface TestingOptions {
   governorAbi?: ContractInterface;
+  proposer?: string;
+  supporter?: string;
 }
 
 const executeCommand = async (timelock: SignerWithAddress, proposal: Proposal, commandIdx: number): Promise<void> => {
@@ -51,15 +53,14 @@ export const testVip = (description: string, proposal: Proposal, options: Testin
   let supporter: SignerWithAddress;
 
   const governanceFixture = async (): Promise<void> => {
-    proposer = await initMainnetUser(PROPOSER_ADDRESS, ethers.utils.parseEther("1.0"));
-    supporter = await initMainnetUser(SUPPORTER_ADDRESS, ethers.utils.parseEther("1.0"));
+    const proposerAddress = options.proposer ?? DEFAULT_PROPOSER_ADDRESS;
+    const supporterAddress = options.supporter ?? DEFAULT_SUPPORTER_ADDRESS;
+    proposer = await initMainnetUser(proposerAddress, ethers.utils.parseEther("1.0"));
+    supporter = await initMainnetUser(supporterAddress, ethers.utils.parseEther("1.0"));
     impersonatedTimelock = await initMainnetUser(NORMAL_TIMELOCK, ethers.utils.parseEther("1.0"));
 
     // Iniitalize impl via Proxy
-    governorProxy = await ethers.getContractAt(
-      options.governorAbi ? options.governorAbi : "GovernorBravoDelegate",
-      GOVERNOR_PROXY,
-    );
+    governorProxy = await ethers.getContractAt(options.governorAbi ?? "GovernorBravoDelegate", GOVERNOR_PROXY);
   };
 
   describe(`${description} commands`, () => {

--- a/tests/hardhat/DelegateBorrowers/SwapDebtDelegate.ts
+++ b/tests/hardhat/DelegateBorrowers/SwapDebtDelegate.ts
@@ -156,7 +156,9 @@ describe("assetListTest", () => {
 
   describe("sweepTokens", async () => {
     it("fails if called by a non-owner", async () => {
-      await expect(swapDebtDelegate.connect(borrower).sweepTokens(foo.address)).to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(swapDebtDelegate.connect(borrower).sweepTokens(foo.address)).to.be.revertedWith(
+        "Ownable: caller is not the owner",
+      );
     });
 
     it("transfers the full balance to the owner", async () => {

--- a/tests/hardhat/DelegateBorrowers/SwapDebtDelegate.ts
+++ b/tests/hardhat/DelegateBorrowers/SwapDebtDelegate.ts
@@ -1,0 +1,170 @@
+import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import chai from "chai";
+import { parseUnits } from "ethers/lib/utils";
+import { ethers, upgrades } from "hardhat";
+
+import {
+  Comptroller,
+  IERC20Upgradeable,
+  PriceOracle,
+  SwapDebtDelegate,
+  SwapDebtDelegate__factory,
+  VBep20,
+} from "../../../typechain";
+
+const { expect } = chai;
+chai.use(smock.matchers);
+
+describe("assetListTest", () => {
+  const fooPrice = parseUnits("10", 18);
+  const barPrice = parseUnits("2", 18);
+  let owner: SignerWithAddress;
+  let borrower: SignerWithAddress;
+  let priceOracle: FakeContract<PriceOracle>;
+  let comptroller: FakeContract<Comptroller>;
+  let foo: FakeContract<IERC20Upgradeable>;
+  let bar: FakeContract<IERC20Upgradeable>;
+  let vFoo: FakeContract<VBep20>;
+  let vBar: FakeContract<VBep20>;
+  let swapDebtDelegate: MockContract<SwapDebtDelegate>;
+
+  type SwapDebtFixture = {
+    swapDebtDelegate: MockContract<SwapDebtDelegate>;
+  };
+
+  async function swapDebtFixture(): Promise<SwapDebtFixture> {
+    const SwapDebtDelegate = await smock.mock<SwapDebtDelegate__factory>("SwapDebtDelegate");
+    const swapDebtDelegate = await upgrades.deployProxy(SwapDebtDelegate, []);
+    return { swapDebtDelegate };
+  }
+
+  beforeEach(async () => {
+    [owner, borrower] = await ethers.getSigners();
+
+    priceOracle = await smock.fake<PriceOracle>("PriceOracle");
+    comptroller = await smock.fake<Comptroller>("Comptroller");
+    foo = await smock.fake<IERC20Upgradeable>("IERC20Upgradeable");
+    bar = await smock.fake<IERC20Upgradeable>("IERC20Upgradeable");
+    vFoo = await smock.fake<VBep20>("VBep20");
+    vBar = await smock.fake<VBep20>("VBep20");
+
+    vFoo.underlying.returns(foo.address);
+    vBar.underlying.returns(bar.address);
+    vFoo.comptroller.returns(comptroller.address);
+    vBar.comptroller.returns(comptroller.address);
+    comptroller.oracle.returns(priceOracle.address);
+    priceOracle.getUnderlyingPrice.whenCalledWith(vFoo.address).returns(fooPrice);
+    priceOracle.getUnderlyingPrice.whenCalledWith(vBar.address).returns(barPrice);
+    foo.transferFrom.returns(true);
+    bar.transfer.returns(true);
+
+    ({ swapDebtDelegate } = await loadFixture(swapDebtFixture));
+  });
+
+  describe("swapDebt", async () => {
+    it("fails if called by a non-owner", async () => {
+      await expect(
+        swapDebtDelegate.connect(borrower).swapDebt(borrower.address, vFoo.address, vBar.address, parseUnits("1", 18)),
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("fails if comptrollers don't match", async () => {
+      vFoo.comptroller.returns(owner.address);
+      await expect(
+        swapDebtDelegate.swapDebt(borrower.address, vFoo.address, vBar.address, parseUnits("1", 18)),
+      ).to.be.revertedWithCustomError(swapDebtDelegate, "ComptrollerMismatch");
+    });
+
+    it("fails if repayBorrowBehalf returns a non-zero error code", async () => {
+      vFoo.repayBorrowBehalf.returns(42);
+      await expect(
+        swapDebtDelegate.swapDebt(borrower.address, vFoo.address, vBar.address, parseUnits("1", 18)),
+      ).to.be.revertedWithCustomError(swapDebtDelegate, "RepaymentFailed");
+    });
+
+    it("fails if borrowBehalf returns a non-zero error code", async () => {
+      vBar.borrowBehalf.returns(42);
+      await expect(
+        swapDebtDelegate.swapDebt(borrower.address, vFoo.address, vBar.address, parseUnits("1", 18)),
+      ).to.be.revertedWithCustomError(swapDebtDelegate, "BorrowFailed");
+    });
+
+    it("transfers repayAmount of underlying from the sender", async () => {
+      const repayAmount = parseUnits("1", 18);
+      await swapDebtDelegate.swapDebt(borrower.address, vFoo.address, vBar.address, repayAmount);
+      expect(foo.transferFrom).to.have.been.calledOnceWith(owner.address, swapDebtDelegate.address, repayAmount);
+    });
+
+    it("calls repayBorrowBehalf after transferring the underlying to self", async () => {
+      const repayAmount = parseUnits("1", 18);
+      await swapDebtDelegate.swapDebt(borrower.address, vFoo.address, vBar.address, repayAmount);
+      expect(vFoo.repayBorrowBehalf).to.have.been.calledOnceWith(borrower.address, repayAmount);
+      expect(vFoo.repayBorrowBehalf).to.have.been.calledAfter(foo.transferFrom);
+    });
+
+    it("converts the amounts using the oracle exchange rates", async () => {
+      const initialBorrowBalance = parseUnits("100", 18);
+      const repayAmount = parseUnits("1", 18);
+      const borrowBalanceAfterRepayment = initialBorrowBalance.sub(repayAmount);
+      vFoo.borrowBalanceCurrent.returnsAtCall(0, initialBorrowBalance);
+      vFoo.borrowBalanceCurrent.returnsAtCall(1, borrowBalanceAfterRepayment);
+
+      // fooPrice / barPrice = 5, so we should borrow 5 times more than we repaid
+      const expectedBorrowAmount = parseUnits("5", 18);
+
+      await swapDebtDelegate.swapDebt(borrower.address, vFoo.address, vBar.address, repayAmount);
+      expect(vBar.borrowBehalf).to.have.been.calledOnceWith(borrower.address, expectedBorrowAmount);
+      expect(vBar.borrowBehalf).to.have.been.calledAfter(vFoo.repayBorrowBehalf);
+    });
+
+    it("uses the actually repaid amount rather than specified amount", async () => {
+      const initialBorrowBalance = parseUnits("100", 18);
+      const actualRepayAmount = parseUnits("1", 18);
+      const requestedRepayAmount = parseUnits("500", 18);
+      const borrowBalanceAfterRepayment = initialBorrowBalance.sub(actualRepayAmount);
+      vFoo.borrowBalanceCurrent.returnsAtCall(0, initialBorrowBalance);
+      vFoo.borrowBalanceCurrent.returnsAtCall(1, borrowBalanceAfterRepayment);
+
+      // fooPrice / barPrice = 5, so we should borrow 5 times more than we repaid (and we repaid 1e18)
+      const expectedBorrowAmount = parseUnits("5", 18);
+
+      await swapDebtDelegate.swapDebt(borrower.address, vFoo.address, vBar.address, requestedRepayAmount);
+      expect(vBar.borrowBehalf).to.have.been.calledOnceWith(borrower.address, expectedBorrowAmount);
+      expect(vBar.borrowBehalf).to.have.been.calledAfter(vFoo.repayBorrowBehalf);
+    });
+
+    it("transfers the actually borrowed amount to the owner", async () => {
+      const initialFooBorrowBalance = parseUnits("100", 18);
+      const repayAmount = parseUnits("1", 18);
+      const fooBorrowBalanceAfterRepayment = initialFooBorrowBalance.sub(repayAmount);
+      vFoo.borrowBalanceCurrent.returnsAtCall(0, initialFooBorrowBalance);
+      vFoo.borrowBalanceCurrent.returnsAtCall(1, fooBorrowBalanceAfterRepayment);
+
+      const initialBarBalance = parseUnits("100", 18);
+      const actualBorrowAmount = parseUnits("3", 18);
+      const barBalanceAfterBorrow = initialBarBalance.add(actualBorrowAmount);
+      bar.balanceOf.returnsAtCall(0, initialBarBalance);
+      bar.balanceOf.returnsAtCall(1, barBalanceAfterBorrow);
+
+      await swapDebtDelegate.swapDebt(borrower.address, vFoo.address, vBar.address, repayAmount);
+      expect(bar.transfer).to.have.been.calledOnceWith(owner.address, actualBorrowAmount);
+      expect(bar.transfer).to.have.been.calledAfter(vBar.borrowBehalf);
+    });
+  });
+
+  describe("sweepTokens", async () => {
+    it("fails if called by a non-owner", async () => {
+      await expect(swapDebtDelegate.connect(borrower).sweepTokens(foo.address)).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("transfers the full balance to the owner", async () => {
+      const balance = parseUnits("12345", 18);
+      foo.balanceOf.whenCalledWith(swapDebtDelegate.address).returns(balance);
+      foo.transfer.returns(true);
+      await swapDebtDelegate.sweepTokens(foo.address);
+      expect(foo.transfer).to.have.been.calledOnceWith(owner.address, balance);
+    });
+  });
+});

--- a/tests/hardhat/Lens/Rewards.ts
+++ b/tests/hardhat/Lens/Rewards.ts
@@ -1,5 +1,5 @@
 import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
-import { loadFixture, mine } from "@nomicfoundation/hardhat-network-helpers";
+import { loadFixture, mine, mineUpTo } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { BigNumber, Signer } from "ethers";
 import { ethers } from "hardhat";
@@ -13,6 +13,7 @@ let vWBTC: FakeContract<VToken>;
 let XVS: FakeContract<MockToken>;
 let account: Signer;
 let venusLens: MockContract<VenusLens>;
+let startBlock: number;
 
 const VENUS_ACCRUED = convertToUnit(10, 18);
 
@@ -22,6 +23,7 @@ type RewardsFixtire = {
   vWBTC: FakeContract<VToken>;
   XVS: FakeContract<MockToken>;
   venusLens: MockContract<VenusLens>;
+  startBlock: number;
 };
 
 const rewardsFixture = async (): Promise<RewardsFixtire> => {
@@ -31,6 +33,8 @@ const rewardsFixture = async (): Promise<RewardsFixtire> => {
   const venusLensFactory = await smock.mock<VenusLens__factory>("VenusLens");
   venusLens = await venusLensFactory.deploy();
   comptroller = await smock.fake<Comptroller>("Comptroller");
+
+  const startBlock = await ethers.provider.getBlockNumber();
 
   // Fake return values
   comptroller.getAllMarkets.returns([vBUSD.address, vWBTC.address]);
@@ -44,12 +48,12 @@ const rewardsFixture = async (): Promise<RewardsFixtire> => {
 
   comptroller.venusBorrowState.returns({
     index: convertToUnit(1, 18),
-    block: 1,
+    block: startBlock,
   });
 
   comptroller.venusSupplyState.returns({
     index: convertToUnit(1, 18),
-    block: 1,
+    block: startBlock,
   });
 
   vBUSD.borrowIndex.returns(convertToUnit(1, 18));
@@ -70,17 +74,18 @@ const rewardsFixture = async (): Promise<RewardsFixtire> => {
     vBUSD,
     vWBTC,
     venusLens,
+    startBlock,
   };
 };
 
 describe("VenusLens: Rewards Summary", () => {
   beforeEach(async () => {
     [account] = await ethers.getSigners();
-    ({ comptroller, vBUSD, vWBTC, XVS, venusLens } = await loadFixture(rewardsFixture));
+    ({ comptroller, vBUSD, vWBTC, XVS, venusLens, startBlock } = await loadFixture(rewardsFixture));
   });
   it("Should get summary for all markets", async () => {
     // Mine some blocks so deltaBlocks != 0
-    await mine(11);
+    await mineUpTo(startBlock + 1000);
 
     const accountAddress = await account.getAddress();
     const pendingRewards = await venusLens.pendingRewards(accountAddress, comptroller.address);
@@ -127,8 +132,8 @@ describe("VenusLens: Rewards Summary", () => {
       XVS.address,
       BigNumber.from(convertToUnit(10, 18)),
       [
-        [vBUSD.address, BigNumber.from(convertToUnit(22.35, 18))],
-        [vWBTC.address, BigNumber.from(convertToUnit(0.0000002235, 18))],
+        [vBUSD.address, BigNumber.from(convertToUnit(10, 18))],
+        [vWBTC.address, BigNumber.from(convertToUnit(0.0000001, 18))],
       ],
     ];
 

--- a/tests/hardhat/Lens/Rewards.ts
+++ b/tests/hardhat/Lens/Rewards.ts
@@ -1,5 +1,5 @@
 import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
-import { loadFixture, mine, mineUpTo } from "@nomicfoundation/hardhat-network-helpers";
+import { loadFixture, mineUpTo } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
 import { BigNumber, Signer } from "ethers";
 import { ethers } from "hardhat";


### PR DESCRIPTION
This PR adds delegated borrowing feature. It would allow users to delegate their borrowing power to some account. In `DelegateBorrowers/` directory there is an example delegate – it only allows to swap one debt position to another, e.g. by repaying BUSD and borrowing ETH. The conversion is done based on the current oracle price.

The Comptroller contract is currently oversize by 94 bytes, tests are not yet implemented.