### PR TITLE
[VEN-1099] Unified Claim Reward for Vaults

### DIFF
--- a/contracts/VRTVault/VRTVault.sol
+++ b/contracts/VRTVault/VRTVault.sol
@@ -176,13 +176,28 @@ contract VRTVault is VRTVaultStorage {
      * @notice claim the accruedInterest of the user's VRTDeposits in the Vault
      */
     function claim() external nonReentrant isInitialized userHasPosition(msg.sender) isActive {
-        address userAddress = msg.sender;
-        uint256 accruedInterest = getAccruedInterest(userAddress);
+        _claim(msg.sender);
+    }
+
+    /**
+     * @notice claim the accruedInterest of the user's VRTDeposits in the Vault
+     * @param account The account for which to claim rewards
+     */
+    function claim(address account) external nonReentrant isInitialized userHasPosition(account) isActive {
+        _claim(account);
+    }
+
+    /**
+     * @notice Low level claim function
+     * @param account The account for which to claim rewards
+     */
+    function _claim(address account) internal {
+        uint256 accruedInterest = getAccruedInterest(account);
         if (accruedInterest > 0) {
-            UserInfo storage user = userInfo[userAddress];
+            UserInfo storage user = userInfo[account];
             uint256 vrtBalance = vrt.balanceOf(address(this));
             require(vrtBalance >= accruedInterest, "Failed to transfer VRT, Insufficient VRT in Vault.");
-            emit Claim(userAddress, accruedInterest);
+            emit Claim(account, accruedInterest);
             user.accrualStartBlockNumber = getBlockNumber();
             vrt.safeTransfer(user.userAddress, accruedInterest);
         }

--- a/contracts/Vault/VAIVault.sol
+++ b/contracts/Vault/VAIVault.sol
@@ -77,6 +77,14 @@ contract VAIVault is VAIVaultStorage {
     }
 
     /**
+     * @notice Claim XVS from VAIVault
+     * @param account The account for which to claim XVS
+     */
+    function claim(address account) public nonReentrant {
+        _withdraw(account, 0);
+    }
+
+    /**
      * @notice Low level withdraw function
      * @param account The account to withdraw from vault
      * @param _amount The amount to withdraw from vault

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -61,7 +61,6 @@ contract XVSVault is XVSVaultStorage, ECDSA {
     /// @notice Event emitted when reward claimed
     event Claim(address indexed user, address indexed rewardToken, uint256 indexed pid, uint256 amount);
 
-
     constructor() public {
         admin = msg.sender;
     }
@@ -206,10 +205,13 @@ contract XVSVault is XVSVaultStorage, ECDSA {
             uint256 pending = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12).sub(
                 user.rewardDebt
             );
-            IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, _account, pending);
+
             user.rewardDebt = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12);
 
-            emit Claim(_account, _rewardToken, _pid, pending);
+            if (pending > 0) {
+                IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, _account, pending);
+                emit Claim(_account, _rewardToken, _pid, pending);
+            }
         }
     }
 

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -58,6 +58,10 @@ contract XVSVault is XVSVaultStorage, ECDSA {
     /// @notice An event emitted when a pool allocation points are updated
     event PoolUpdated(address indexed rewardToken, uint indexed pid, uint oldAllocPoints, uint newAllocPoints);
 
+    /// @notice Event emitted when reward claimed
+    event Claim(address indexed user, address indexed rewardToken, uint256 indexed pid, uint256 amount);
+
+
     constructor() public {
         admin = msg.sender;
     }
@@ -203,9 +207,10 @@ contract XVSVault is XVSVaultStorage, ECDSA {
                 user.rewardDebt
             );
             IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, _account, pending);
-        }
+            user.rewardDebt = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12);
 
-        user.rewardDebt = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12);
+            emit Claim(_account, _rewardToken, _pid, pending);
+        }
     }
 
     /**

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -187,7 +187,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
         if (address(pool.token) == address(xvsAddress)) {
             _moveDelegates(address(0), delegates[msg.sender], uint96(_amount));
         }
-        
+
         emit Deposit(msg.sender, _rewardToken, _pid, _amount);
     }
 

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -208,10 +208,8 @@ contract XVSVault is XVSVaultStorage, ECDSA {
 
             user.rewardDebt = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12);
 
-            if (pending > 0) {
-                IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, _account, pending);
-                emit Claim(_account, _rewardToken, _pid, pending);
-            }
+            IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, _account, pending);
+            emit Claim(_account, _rewardToken, _pid, pending);
         }
     }
 

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -177,6 +177,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
                 user.rewardDebt
             );
             IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, msg.sender, pending);
+            emit Claim(msg.sender, _rewardToken, _pid, pending);
         }
         pool.token.safeTransferFrom(address(msg.sender), address(this), _amount);
         user.amount = user.amount.add(_amount);
@@ -186,7 +187,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
         if (address(pool.token) == address(xvsAddress)) {
             _moveDelegates(address(0), delegates[msg.sender], uint96(_amount));
         }
-
+        
         emit Deposit(msg.sender, _rewardToken, _pid, _amount);
     }
 
@@ -379,6 +380,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
             _moveDelegates(delegates[msg.sender], address(0), uint96(_amount));
         }
 
+        emit Claim(msg.sender, _rewardToken, _pid, pending);
         emit ReqestedWithdrawal(msg.sender, _rewardToken, _pid, _amount);
     }
 

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -46,7 +46,7 @@ describe("XVSVault", async () => {
 
     await xvsStore.setNewOwner(xvsVault.address);
     await xvsVault.setXvsStore(xvs.address, xvsStore.address);
-    await xvs.connect(deployer).transfer(xvsStore.address, bigNumber18.mul(1000));
+    await xvs.connect(deployer).transfer(xvsStore.address, bigNumber18.mul(10000));
     await xvs.connect(deployer).transfer(user.address, bigNumber18.mul(1000));
 
     await xvsStore.setRewardToken(xvs.address, true);
@@ -55,7 +55,7 @@ describe("XVSVault", async () => {
   });
 
   it("check xvs balance", async () => {
-    expect(await xvs.balanceOf(xvsStore.address)).to.eq(bigNumber18.mul(1000));
+    expect(await xvs.balanceOf(xvsStore.address)).to.eq(bigNumber18.mul(10000));
   });
 
   it("check if pool exists", async () => {
@@ -81,24 +81,46 @@ describe("XVSVault", async () => {
 
     await mine(1000);
 
-    let previousXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(deployer.address)).toString());
-
-    await xvsVault.requestWithdrawal(xvs.address, poolId, depositAmount);
-
-    let currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(deployer.address)).toString());
-
-    expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance));
+    let previousXVSBalance = await xvs.balanceOf(deployer.address);
+    await xvsVault.connect(deployer).requestWithdrawal(xvs.address, poolId, depositAmount);
+    let currentXVSBalance = await xvs.balanceOf(deployer.address);
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
 
     await mine(500);
 
-    previousXVSBalance = currentXVSBalance;
-
+    previousXVSBalance = await xvs.balanceOf(deployer.address);
     await xvsVault.executeWithdrawal(xvs.address, poolId);
-
-    currentXVSBalance = ethers.utils.formatEther((await xvs.balanceOf(deployer.address)).toString());
-
-    expect(Number(previousXVSBalance)).to.be.lt(Number(currentXVSBalance));
+    currentXVSBalance = await xvs.balanceOf(deployer.address)
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(depositAmount.toString())
   });
+
+  it("claim reward", async () => {
+    const depositAmount = bigNumber18.mul(100);
+
+    await xvs.approve(xvsVault.address, depositAmount);
+    await xvsVault.deposit(xvs.address, poolId, depositAmount);
+
+    await mine(1000);
+
+    let previousXVSBalance = await xvs.balanceOf(deployer.address);
+    await xvsVault.claim(deployer.address, xvs.address, poolId);
+    let currentXVSBalance = await xvs.balanceOf(deployer.address)
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
+
+    await mine(1000);
+
+    previousXVSBalance = await xvs.balanceOf(deployer.address);
+    await xvsVault.claim(deployer.address, xvs.address, poolId);
+    currentXVSBalance = await xvs.balanceOf(deployer.address)
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
+
+    await mine(1000);
+
+    previousXVSBalance = await xvs.balanceOf(deployer.address);
+    await xvsVault.connect(deployer).requestWithdrawal(xvs.address, poolId, depositAmount);
+    currentXVSBalance = await xvs.balanceOf(deployer.address);
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
+  })
 
   it("no reward for pending withdrawals", async () => {
     const depositAmount = bigNumber18.mul(100);

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -84,14 +84,14 @@ describe("XVSVault", async () => {
     let previousXVSBalance = await xvs.balanceOf(deployer.address);
     await xvsVault.connect(deployer).requestWithdrawal(xvs.address, poolId, depositAmount);
     let currentXVSBalance = await xvs.balanceOf(deployer.address);
-    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString());
 
     await mine(500);
 
     previousXVSBalance = await xvs.balanceOf(deployer.address);
     await xvsVault.executeWithdrawal(xvs.address, poolId);
-    currentXVSBalance = await xvs.balanceOf(deployer.address)
-    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(depositAmount.toString())
+    currentXVSBalance = await xvs.balanceOf(deployer.address);
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(depositAmount.toString());
   });
 
   it("claim reward", async () => {
@@ -104,29 +104,29 @@ describe("XVSVault", async () => {
 
     let previousXVSBalance = await xvs.balanceOf(deployer.address);
     await xvsVault.claim(deployer.address, xvs.address, poolId);
-    let currentXVSBalance = await xvs.balanceOf(deployer.address)
-    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
+    let currentXVSBalance = await xvs.balanceOf(deployer.address);
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString());
 
     await mine(1000);
 
     previousXVSBalance = await xvs.balanceOf(deployer.address);
     await xvsVault.claim(deployer.address, xvs.address, poolId);
-    currentXVSBalance = await xvs.balanceOf(deployer.address)
-    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
+    currentXVSBalance = await xvs.balanceOf(deployer.address);
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString());
 
     await mine(1000);
 
     previousXVSBalance = await xvs.balanceOf(deployer.address);
     await xvsVault.connect(deployer).requestWithdrawal(xvs.address, poolId, depositAmount);
     currentXVSBalance = await xvs.balanceOf(deployer.address);
-    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString());
 
     await mine(500);
 
     previousXVSBalance = await xvs.balanceOf(deployer.address);
     await xvsVault.executeWithdrawal(xvs.address, poolId);
-    currentXVSBalance = await xvs.balanceOf(deployer.address)
-    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(depositAmount.toString())
+    currentXVSBalance = await xvs.balanceOf(deployer.address);
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(depositAmount.toString());
 
     await xvs.approve(xvsVault.address, depositAmount);
     await xvsVault.deposit(xvs.address, poolId, depositAmount);
@@ -135,9 +135,17 @@ describe("XVSVault", async () => {
 
     previousXVSBalance = await xvs.balanceOf(deployer.address);
     await xvsVault.claim(deployer.address, xvs.address, poolId);
-    currentXVSBalance = await xvs.balanceOf(deployer.address)
-    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
-  })
+    currentXVSBalance = await xvs.balanceOf(deployer.address);
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString());
+
+    await xvsVault.setRewardAmountPerBlock(xvs.address, 0);
+    await mine(1000);
+
+    previousXVSBalance = await xvs.balanceOf(deployer.address);
+    await xvsVault.claim(deployer.address, xvs.address, poolId);
+    currentXVSBalance = await xvs.balanceOf(deployer.address);
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1).toString());
+  });
 
   it("no reward for pending withdrawals", async () => {
     const depositAmount = bigNumber18.mul(100);

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -120,6 +120,23 @@ describe("XVSVault", async () => {
     await xvsVault.connect(deployer).requestWithdrawal(xvs.address, poolId, depositAmount);
     currentXVSBalance = await xvs.balanceOf(deployer.address);
     expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
+
+    await mine(500);
+
+    previousXVSBalance = await xvs.balanceOf(deployer.address);
+    await xvsVault.executeWithdrawal(xvs.address, poolId);
+    currentXVSBalance = await xvs.balanceOf(deployer.address)
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(depositAmount.toString())
+
+    await xvs.approve(xvsVault.address, depositAmount);
+    await xvsVault.deposit(xvs.address, poolId, depositAmount);
+
+    await mine(1000);
+
+    previousXVSBalance = await xvs.balanceOf(deployer.address);
+    await xvsVault.claim(deployer.address, xvs.address, poolId);
+    currentXVSBalance = await xvs.balanceOf(deployer.address)
+    expect(currentXVSBalance.sub(previousXVSBalance).toString()).to.be.equal(bigNumber18.mul(1001).toString())
   })
 
   it("no reward for pending withdrawals", async () => {


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

- Adds `claim(address account)` to VRTVault to claim rewards for another account. 
- Adds `claim(address account)` to VAIVault to claim rewards for another account. 
- Adds `claim(address _account, address _rewardToken, uint256 _pid)` to XVSVault to claim rewards for another account.

For `claim(address account)` method in VRTVault and VAIVault we don't need new unit tests as implementation code is same as the `claim()` method

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
