### PR TITLE
[VEN-1055] Update stable rate for the user at rebalance

### DIFF
--- a/contracts/Comptroller/Comptroller.sol
+++ b/contracts/Comptroller/Comptroller.sol
@@ -643,6 +643,10 @@ contract Comptroller is ComptrollerV10Storage, ComptrollerInterfaceG2, Comptroll
         return uint(Error.NO_ERROR);
     }
 
+    function preSwapBorrowRateModeHook(address vToken) external {
+        checkActionPauseState(vToken, Action.SWAP_RATE_MODE);
+    }
+
     /**
      * @notice Validates transfer and reverts on rejection. May emit logs.
      * @param vToken Asset being transferred

--- a/contracts/Comptroller/ComptrollerInterface.sol
+++ b/contracts/Comptroller/ComptrollerInterface.sol
@@ -81,7 +81,6 @@ contract ComptrollerInterfaceG1 {
 
     function preSwapBorrowRateModeHook(address vToken) external;
 
-
     /*** Liquidity/Liquidation Calculations ***/
 
     function liquidateCalculateSeizeTokens(

--- a/contracts/Comptroller/ComptrollerInterface.sol
+++ b/contracts/Comptroller/ComptrollerInterface.sol
@@ -79,6 +79,9 @@ contract ComptrollerInterfaceG1 {
 
     function transferVerify(address vToken, address src, address dst, uint transferTokens) external;
 
+    function preSwapBorrowRateModeHook(address vToken) external;
+
+
     /*** Liquidity/Liquidation Calculations ***/
 
     function liquidateCalculateSeizeTokens(

--- a/contracts/InterestRateModels/InterestRateModel.sol
+++ b/contracts/InterestRateModels/InterestRateModel.sol
@@ -31,13 +31,4 @@ contract InterestRateModel {
         uint reserves,
         uint reserveFactorMantissa
     ) external view returns (uint);
-
-    /**
-     * @notice Calculates the utilization rate for the market
-     * @param cash The total amount of cash the market has
-     * @param borrows The total amount of borrows the market has outstanding
-     * @param reserves The total amount of reserves the market has
-     * @return The utilization rate (as a percentage)
-     */
-    function utilizationRate(uint cash, uint borrows, uint reserves) public pure returns (uint);
 }

--- a/contracts/Tokens/VTokens/VToken.sol
+++ b/contracts/Tokens/VTokens/VToken.sol
@@ -1466,7 +1466,6 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
             averageStableBorrowRateNew =
                 ((stableBorrows * averageStableBorrowRate) - (swappedAmount * stableRateMantissa)) /
                 stableBorrowsNew;
-            
         }
 
         /////////////////////////

--- a/contracts/Tokens/VTokens/VToken.sol
+++ b/contracts/Tokens/VTokens/VToken.sol
@@ -1380,15 +1380,20 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
         return (uint(Error.NO_ERROR), actualRepayAmount);
     }
 
-    function swapBorrowRateModePreCalculation(address account) internal returns (uint256, uint256) {
+    /**
+     * @notice Checks before swapping borrow rate mode
+     * @param account Address of the borrow holder
+     * @return (uint256, uint256) returns the variableDebt and stableDebt for the account
+     */
+    function _swapBorrowRateModePreCalculation(address account) internal returns (uint256, uint256) {
         /* Fail if swapBorrowRateMode not allowed */
-        //comptroller.preSwapBorrowRateModeHook(address(this));
+        comptroller.preSwapBorrowRateModeHook(address(this));
 
         accrueInterest();
 
         /* Verify market's block number equals current block number */
         if (accrualBlockNumber != getBlockNumber()) {
-            //revert SwapBorrowRateModeFreshnessCheck();
+            revert("math error");
         }
 
         (, uint256 variableDebt) = borrowBalanceStoredInternal(account);
@@ -1397,6 +1402,15 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
         return (variableDebt, stableDebt);
     }
 
+    /**
+     * @notice Update states for the stable borrow while swapping
+     * @param swappedAmount Amount need to be swapped
+     * @param stableDebt Stable debt for the account
+     * @param variableDebt Variable debt for the account
+     * @param account Address of the account
+     * @param accountBorrowsNew New stable borrow for the account
+     * @return (uint256, uint256) returns updated stable borrow for the account and updated average stable borrow rate
+     */
     function _updateStatesForStableRateSwap(
         uint256 swappedAmount,
         uint256 stableDebt,
@@ -1427,6 +1441,14 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
         return (stableBorrowsNew, averageStableBorrowRateNew);
     }
 
+    /**
+     * @notice Update states for the variable borrow during the swap
+     * @param swappedAmount Amount need to be swapped
+     * @param stableDebt Stable debt for the account
+     * @param variableDebt Variable debt for the account
+     * @param account Address of the account
+     * @return (uint256, uint256) returns updated stable borrow for the account and updated average stable borrow rate
+     */
     function _updateStatesForVariableRateSwap(
         uint256 swappedAmount,
         uint256 stableDebt,
@@ -1444,6 +1466,7 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
             averageStableBorrowRateNew =
                 ((stableBorrows * averageStableBorrowRate) - (swappedAmount * stableRateMantissa)) /
                 stableBorrowsNew;
+            
         }
 
         /////////////////////////
@@ -1459,67 +1482,27 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
     }
 
     /**
-     * @dev Allows a borrower to swap his debt between stable and variable mode, or vice versa
-     * @param rateMode The rate mode that the user wants to swap to
-     **/
-    function swapBorrowRateMode(uint256 rateMode) external {
-        address account = msg.sender;
-        (uint256 variableDebt, uint256 stableDebt) = swapBorrowRateModePreCalculation(account);
-
-        uint256 accountBorrowsNew = stableDebt + variableDebt;
-        uint256 stableBorrowsNew;
-        uint256 averageStableBorrowRateNew;
-        uint256 amount;
-
-        if (InterestRateMode(rateMode) == InterestRateMode.STABLE) {
-            require(variableDebt > 0, "vToken: swapBorrowRateMode variable debt is 0");
-            amount = variableDebt;
-
-            (stableBorrowsNew, averageStableBorrowRateNew) = _updateStatesForStableRateSwap(
-                amount,
-                stableDebt,
-                variableDebt,
-                account,
-                accountBorrowsNew
-            );
-        } else {
-            require(stableDebt > 0, "vToken: swapBorrowRateMode stable debt is 0");
-            amount = stableDebt;
-
-            (stableBorrowsNew, averageStableBorrowRateNew) = _updateStatesForVariableRateSwap(
-                amount,
-                stableDebt,
-                variableDebt,
-                account
-            );
-        }
-
-        stableBorrows = stableBorrowsNew;
-        averageStableBorrowRate = averageStableBorrowRateNew;
-
-        emit SwapBorrowRateMode(account, rateMode);
-    }
-
-    /**
      * @dev Allows a borrower to swap his debt between stable and variable mode, or vice versa with specific amount
      * @param rateMode The rate mode that the user wants to swap to
-     * @param amount The amount that the user wants to convert form stable to variable mode or vice versa.
+     * @param sentAmount The amount that the user wants to convert form stable to variable mode or vice versa.
      * custom:access Not restricted
      **/
-    function swapBorrowRateModeWithAmount(uint256 rateMode, uint256 amount) external {
+    function swapBorrowRateModeWithAmount(uint256 rateMode, uint256 sentAmount) external {
         address account = msg.sender;
-        (uint256 variableDebt, uint256 stableDebt) = swapBorrowRateModePreCalculation(account);
+        (uint256 variableDebt, uint256 stableDebt) = _swapBorrowRateModePreCalculation(account);
 
-        uint256 accountBorrowsNew = stableDebt + amount;
         uint256 stableBorrowsNew;
         uint256 averageStableBorrowRateNew;
+        uint256 swappedAmount;
 
         if (InterestRateMode(rateMode) == InterestRateMode.STABLE) {
             require(variableDebt > 0, "vToken: swapBorrowRateMode variable debt is 0");
-            require(variableDebt >= amount, "Insufficient amount");
+
+            swappedAmount = sentAmount > variableDebt ? variableDebt : sentAmount;
+            uint256 accountBorrowsNew = stableDebt + swappedAmount;
 
             (stableBorrowsNew, averageStableBorrowRateNew) = _updateStatesForStableRateSwap(
-                amount,
+                swappedAmount,
                 stableDebt,
                 variableDebt,
                 account,
@@ -1527,10 +1510,11 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
             );
         } else {
             require(stableDebt > 0, "vToken: swapBorrowRateMode stable debt is 0");
-            require(stableDebt >= amount, "Insufficient amount");
+
+            swappedAmount = sentAmount > stableDebt ? stableDebt : sentAmount;
 
             (stableBorrowsNew, averageStableBorrowRateNew) = _updateStatesForVariableRateSwap(
-                amount,
+                swappedAmount,
                 stableDebt,
                 variableDebt,
                 account
@@ -1540,7 +1524,7 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
         stableBorrows = stableBorrowsNew;
         averageStableBorrowRate = averageStableBorrowRateNew;
 
-        emit SwapBorrowRateModeWithAmount(account, rateMode, amount);
+        emit SwapBorrowRateMode(account, rateMode, swappedAmount);
     }
 
     /**

--- a/contracts/Tokens/VTokens/VToken.sol
+++ b/contracts/Tokens/VTokens/VToken.sol
@@ -287,7 +287,7 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
         if (totalBorrows == 0) {
             return 0;
         }
-        uint256 utilizationRate = interestRateModel.utilizationRate(getCashPrior(), totalBorrows, totalReserves);
+        uint256 utilizationRate = utilizationRate(getCashPrior(), totalBorrows, totalReserves);
         uint256 averageMarketBorrowRate = _averageMarketBorrowRate();
         return
             (averageMarketBorrowRate * utilizationRate * (mantissaOne - reserveFactorMantissa)) /
@@ -570,6 +570,21 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
     function stableBorrowRatePerBlock() public view returns (uint256) {
         uint256 variableBorrowRate = interestRateModel.getBorrowRate(getCashPrior(), totalBorrows, totalReserves);
         return stableRateModel.getBorrowRate(stableBorrows, totalBorrows, variableBorrowRate);
+    }
+
+    /**
+     * @notice Calculates the utilization rate of the market: `borrows / (cash + borrows - reserves)`
+     * @param cash The amount of cash in the market
+     * @param borrows The amount of borrows in the market
+     * @param reserves The amount of reserves in the market (currently unused)
+     * @return The utilization rate as a mantissa between [0, 1e18]
+     */
+    function utilizationRate(uint cash, uint borrows, uint reserves) public pure returns (uint) {
+        // Utilization rate is 0 when there are no borrows
+        if (borrows == 0) {
+            return 0;
+        }
+        return (borrows * mantissaOne) / (cash + borrows - reserves);
     }
 
     /**
@@ -1554,7 +1569,7 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
         require(rebalanceUtilizationRateThreshold > 0, "vToken: rebalanceUtilizationRateThreshold is not set.");
         require(rebalanceRateFractionThreshold > 0, "vToken: rebalanceRateFractionThreshold is not set.");
 
-        uint256 utilizationRate = interestRateModel.utilizationRate(getCashPrior(), totalBorrows, totalReserves);
+        uint256 utilizationRate = utilizationRate(getCashPrior(), totalBorrows, totalReserves);
         uint256 variableBorrowRate = interestRateModel.getBorrowRate(getCashPrior(), totalBorrows, totalReserves);
         /// Utilization rate is above rebalanceUtilizationRateThreshold.
         /// Average market borrow rate should be less than the rebalanceRateFractionThreshold fraction of variable borrow rate.

--- a/contracts/Tokens/VTokens/VTokenInterfaces.sol
+++ b/contracts/Tokens/VTokens/VTokenInterfaces.sol
@@ -283,11 +283,6 @@ contract VTokenInterface is VTokenStorage {
     event UpdatedUserStableBorrowBalance(address borrower, uint256 updatedPrincipal);
 
     /**
-     * @notice Event emitted when a borrow rate mode is swapped for account
-     */
-    event SwapBorrowRateMode(address account, uint256 swappedBorrowMode);
-
-    /**
      * @notice Event emitted when stableInterestRateModel is changed
      */
     event NewMarketStableInterestRateModel(StableRateModel oldInterestRateModel, StableRateModel newInterestRateModel);
@@ -295,7 +290,7 @@ contract VTokenInterface is VTokenStorage {
     /**
      * @notice Event emitted when a borrow rate mode is swapped for account with amount
      */
-    event SwapBorrowRateModeWithAmount(address account, uint256 swappedBorrowMode, uint256 amount);
+    event SwapBorrowRateMode(address account, uint256 swappedBorrowMode, uint256 amount);
 
     /**
      * @notice Event emitted on stable rate rebalacing

--- a/tests/hardhat/StableRateModel.ts
+++ b/tests/hardhat/StableRateModel.ts
@@ -86,13 +86,12 @@ describe("StableRateModel: Tests", function () {
   });
 
   it("Calculate Supply rate of the market", async function () {
-    interestRateModel.utilizationRate.returns(convertToUnit(5, 17));
     interestRateModel.getBorrowRate.returns(convertToUnit(3, 17));
     await vToken.harnessSetTotalBorrows(convertToUnit(2, 20));
     await vToken.harnessSetReserveFactorFresh(convertToUnit(1, 17));
     await vToken.harnessSetAvgStableBorrowRate(convertToUnit(4, 17));
     await vToken.harnessStableBorrows(convertToUnit(2, 18));
 
-    expect((await vToken.supplyRatePerBlock()).toString()).to.equal("135450000000000000");
+    expect((await vToken.supplyRatePerBlock()).toString()).to.equal("270900000000000000");
   });
 });

--- a/tests/hardhat/stableRateRebalancing.ts
+++ b/tests/hardhat/stableRateRebalancing.ts
@@ -75,28 +75,26 @@ describe("VToken", function () {
     });
 
     it("Revert on average borrow rate higher than variable rate threshold", async () => {
-      await vToken.setRebalanceUtilizationRateThreshold(convertToUnit(70, 17));
+      await vToken.setRebalanceUtilizationRateThreshold(convertToUnit(7, 17));
       await vToken.setRebalanceRateFractionThreshold(convertToUnit(50, 17));
       await preBorrow(contracts, borrower, borrowAmount);
       await borrowStable(vToken, borrower, convertToUnit(900, 18));
-      interestRateModel.utilizationRate.returns(convertToUnit(90, 17));
       await expect(vToken.validateRebalanceStableBorrowRate()).to.be.revertedWith(
         "vToken: average borrow rate higher than variable rate threshold.",
       );
     });
 
     it("Satisfy both conditions", async () => {
-      await vToken.setRebalanceUtilizationRateThreshold(convertToUnit(70, 17));
+      await vToken.setRebalanceUtilizationRateThreshold(convertToUnit(7, 17));
       await vToken.setRebalanceRateFractionThreshold(convertToUnit(50, 17));
       await preBorrow(contracts, borrower, borrowAmount);
       await borrowStable(vToken, borrower, convertToUnit(900, 18));
-      interestRateModel.utilizationRate.returns(convertToUnit(90, 17));
-      interestRateModel.getBorrowRate.returns(convertToUnit(5, 8));
+      await interestRateModel.getBorrowRate.returns(convertToUnit(5, 8));
       await vToken.validateRebalanceStableBorrowRate();
     });
 
     it("Rebalacing the stable rate for a user", async () => {
-      await vToken.setRebalanceUtilizationRateThreshold(convertToUnit(70, 17));
+      await vToken.setRebalanceUtilizationRateThreshold(convertToUnit(7, 17));
       await vToken.setRebalanceRateFractionThreshold(convertToUnit(50, 17));
       await preBorrow(contracts, borrower, borrowAmount, convertToUnit(5, 6));
       await borrowStable(vToken, borrower, convertToUnit(900, 18));
@@ -104,7 +102,6 @@ describe("VToken", function () {
       let accountBorrows = await vToken.harnessAccountStableBorrows(borrower.getAddress());
       expect(accountBorrows.stableRateMantissa).to.equal(convertToUnit(5, 6));
 
-      interestRateModel.utilizationRate.returns(convertToUnit(90, 17));
       interestRateModel.getBorrowRate.returns(convertToUnit(5, 8));
       stableInterestRateModel.getBorrowRate.returns(convertToUnit(8, 8));
       await vToken.rebalanceStableBorrowRate(borrower.getAddress());

--- a/tests/hardhat/swapBorrowRateMode.ts
+++ b/tests/hardhat/swapBorrowRateMode.ts
@@ -54,27 +54,17 @@ describe("VToken", function () {
   });
 
   describe("swapBorrowRateMode: tests", () => {
-    it("fails if variable debt is 0", async () => {
-      await expect(vToken.swapBorrowRateMode(1)).to.be.revertedWith("vToken: swapBorrowRateMode variable debt is 0");
-    });
-
-    it("fails if stable debt is 0", async () => {
-      await expect(vToken.swapBorrowRateMode(2)).to.be.revertedWith("vToken: swapBorrowRateMode stable debt is 0");
-    });
-
     it("Swapping borrow rate mode from variable to stable", async () => {
       await preBorrow(contracts, borrower, borrowAmount);
-      
       await borrow(vToken, borrower, borrowAmount);
       let variableBorrow, stableBorrow;
       variableBorrow = await vToken.harnessAccountBorrows(borrowerAddress);
-      
       expect(variableBorrow.principal).equal(borrowAmount);
 
       stableBorrow = await vToken.harnessAccountStableBorrows(borrowerAddress);
       expect(stableBorrow.principal).equal(0);
 
-      await vToken.connect(borrower).swapBorrowRateMode(1);
+      await vToken.connect(borrower).swapBorrowRateModeWithAmount(1, convertToUnit("1001", 18));
 
       variableBorrow = await vToken.harnessAccountBorrows(borrowerAddress);
       expect(variableBorrow.principal).equal(0);
@@ -93,7 +83,7 @@ describe("VToken", function () {
       stableBorrow = await vToken.harnessAccountStableBorrows(borrowerAddress);
       expect(stableBorrow.principal).equal(borrowAmount);
 
-      await vToken.connect(borrower).swapBorrowRateMode(2);
+      await vToken.connect(borrower).swapBorrowRateModeWithAmount(2, convertToUnit("1001", 18));
 
       variableBorrow = await vToken.harnessAccountBorrows(borrowerAddress);
       expect(variableBorrow.principal).equal(borrowAmount);


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

****Update stable rate for the user at rebalance condition****

- Functionality to update the stable rate for the user if rebalancing conditions are satisfying and the user tries to borrow for the same token(i.e. user borrowed some tokens and the stable interest rate is not updated as per rebalancing condition). 
- Swap rate mode with amount.

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
