### PR TITLE
[VEN-1238] Deny Claim/Deposit for Pending Withdrawal Request

### DIFF
--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -174,10 +174,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
         PoolInfo storage pool = poolInfos[_rewardToken][_pid];
         UserInfo storage user = userInfos[_rewardToken][_pid][msg.sender];
         _updatePool(_rewardToken, _pid);
-        require(
-            pendingWithdrawalsBeforeUpgrade(_rewardToken, _pid, msg.sender) == 0,
-            "execute pending withdrawal"
-        );
+        require(pendingWithdrawalsBeforeUpgrade(_rewardToken, _pid, msg.sender) == 0, "execute pending withdrawal");
 
         if (user.amount > 0) {
             uint256 pending = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12).sub(
@@ -209,10 +206,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
         PoolInfo storage pool = poolInfos[_rewardToken][_pid];
         UserInfo storage user = userInfos[_rewardToken][_pid][_account];
         _updatePool(_rewardToken, _pid);
-        require(
-            pendingWithdrawalsBeforeUpgrade(_rewardToken, _pid, _account) == 0,
-            "execute pending withdrawal"
-        );
+        require(pendingWithdrawalsBeforeUpgrade(_rewardToken, _pid, _account) == 0, "execute pending withdrawal");
 
         if (user.amount > 0) {
             uint256 pending = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12).sub(

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -210,7 +210,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
         UserInfo storage user = userInfos[_rewardToken][_pid][_account];
         _updatePool(_rewardToken, _pid);
         require(
-            pendingWithdrawalsBeforeUpgrade(_rewardToken, _pid, msg.sender) == 0,
+            pendingWithdrawalsBeforeUpgrade(_rewardToken, _pid, _account) == 0,
             "execute existing withdrawal before requesting a claim"
         );
 

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -176,7 +176,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
         _updatePool(_rewardToken, _pid);
         require(
             pendingWithdrawalsBeforeUpgrade(_rewardToken, _pid, msg.sender) == 0,
-            "execute existing withdrawal before requesting new deposit"
+            "execute pending withdrawal"
         );
 
         if (user.amount > 0) {
@@ -211,7 +211,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
         _updatePool(_rewardToken, _pid);
         require(
             pendingWithdrawalsBeforeUpgrade(_rewardToken, _pid, _account) == 0,
-            "execute existing withdrawal before requesting a claim"
+            "execute pending withdrawal"
         );
 
         if (user.amount > 0) {
@@ -375,7 +375,7 @@ contract XVSVault is XVSVaultStorage, ECDSA {
         uint beforeUpgradeWithdrawalAmount;
 
         (beforeUpgradeWithdrawalAmount, ) = getRequestedWithdrawalAmount(requests);
-        require(beforeUpgradeWithdrawalAmount == 0, "execute existing withdrawal before requesting new withdrawal");
+        require(beforeUpgradeWithdrawalAmount == 0, "execute pending withdrawal");
 
         _updatePool(_rewardToken, _pid);
         uint256 pending = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12).sub(

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -197,7 +197,7 @@ describe("XVSVault", async () => {
     await mine(1000);
     await xvsVault.requestOldWithdrawal(xvs.address, poolId, bigNumber18.mul(50));
     await expect(xvsVault.requestWithdrawal(xvs.address, poolId, bigNumber18.mul(50))).to.be.revertedWith(
-      "execute existing withdrawal before requesting new withdrawal",
+      "execute pending withdrawal",
     );
 
     await mine(500);
@@ -232,11 +232,11 @@ describe("XVSVault", async () => {
     await xvsVault.requestOldWithdrawal(xvs.address, poolId, bigNumber18.mul(50));
 
     await expect(xvsVault.deposit(xvs.address, poolId, bigNumber18.mul(50))).to.be.revertedWith(
-      "execute existing withdrawal before requesting new deposit",
+      "execute pending withdrawal",
     );
 
     await expect(xvsVault.claim(deployer.address, xvs.address, poolId)).to.be.revertedWith(
-      "execute existing withdrawal before requesting a claim",
+      "execute pending withdrawal",
     );
 
     await mine(500);


### PR DESCRIPTION
## Description

Right now if a user has a pending withdrawal before upgrade then the deposit/claim revert due to underflow in calculations. So to get around this the user needs to execute the pending withdrawals first.

The fix is to enhance the experience by blocking claim/deposit call when there is a before upgrade withdrawal request pending and reverting with a proper error message.

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
