### PR TITLE
Refactor/peg stability

### DIFF
--- a/script/hardhat/fork/vip-99.ts
+++ b/script/hardhat/fork/vip-99.ts
@@ -115,7 +115,7 @@ forking(25918391, () => {
       }),
     );
     const oracleAddress = await comptroller.oracle();
-    oracle = await ethers.getContractAt("contracts/Oracle/PriceOracle.sol:PriceOracle", oracleAddress);
+    oracle = await ethers.getContractAt("PriceOracle", oracleAddress);
     swapDebtDelegate = await ethers.getContractAt("SwapDebtDelegate", SWAP_DEBT_DELEGATE);
     await pretendExecutingVip(vip99());
   });

--- a/tests/hardhat/Comptroller/XVSSpeeds.ts
+++ b/tests/hardhat/Comptroller/XVSSpeeds.ts
@@ -18,8 +18,8 @@ describe("Comptroller", () => {
     const ComptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
     comptroller = await ComptrollerFactory.deploy();
     accessControl = await smock.fake<IAccessControlManager>("AccessControlManager");
-    vToken1 = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
-    vToken2 = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
+    vToken1 = await smock.fake<VToken>("VToken");
+    vToken2 = await smock.fake<VToken>("VToken");
 
     await accessControl.isAllowedToCall.returns(true);
     await vToken1.isVToken.returns(true);

--- a/tests/hardhat/Comptroller/assetListTest.ts
+++ b/tests/hardhat/Comptroller/assetListTest.ts
@@ -49,7 +49,7 @@ describe("assetListTest", () => {
     const ComptrollerLensFactory = await smock.mock<ComptrollerLens__factory>("ComptrollerLens");
     const comptroller = await ComptrollerFactory.deploy();
     const comptrollerLens = await ComptrollerLensFactory.deploy();
-    const oracle = await smock.fake<PriceOracle>("contracts/Oracle/PriceOracle.sol:PriceOracle");
+    const oracle = await smock.fake<PriceOracle>("PriceOracle");
     accessControl.isAllowedToCall.returns(true);
     await comptroller._setAccessControl(accessControl.address);
     await comptroller._setComptrollerLens(comptrollerLens.address);

--- a/tests/hardhat/Comptroller/comptrollerTest.ts
+++ b/tests/hardhat/Comptroller/comptrollerTest.ts
@@ -29,7 +29,7 @@ type SimpleComptrollerFixture = {
 };
 
 async function deploySimpleComptroller(): Promise<SimpleComptrollerFixture> {
-  const oracle = await smock.fake<PriceOracle>("contracts/Oracle/PriceOracle.sol:PriceOracle");
+  const oracle = await smock.fake<PriceOracle>("PriceOracle");
   const accessControl = await smock.fake<IAccessControlManager>("AccessControlManager");
   accessControl.isAllowedToCall.returns(true);
   const ComptrollerLensFactory = await smock.mock<ComptrollerLens__factory>("ComptrollerLens");
@@ -133,7 +133,7 @@ describe("Comptroller", () => {
 
     async function deploy(): Promise<Contracts> {
       const contracts = await deploySimpleComptroller();
-      const newOracle = await smock.fake<PriceOracle>("contracts/Oracle/PriceOracle.sol:PriceOracle");
+      const newOracle = await smock.fake<PriceOracle>("PriceOracle");
       return { ...contracts, newOracle };
     }
 
@@ -214,7 +214,7 @@ describe("Comptroller", () => {
 
     async function deploy(): Promise<Contracts> {
       const contracts = await deploySimpleComptroller();
-      const vToken = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
+      const vToken = await smock.fake<VToken>("VToken");
       vToken.comptroller.returns(contracts.comptroller.address);
       vToken.isVToken.returns(true);
       return { vToken, ...contracts };
@@ -263,8 +263,8 @@ describe("Comptroller", () => {
 
     async function deploy(): Promise<Contracts> {
       const contracts = await deploySimpleComptroller();
-      const vToken1 = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
-      const vToken2 = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
+      const vToken1 = await smock.fake<VToken>("VToken");
+      const vToken2 = await smock.fake<VToken>("VToken");
       const token = await smock.fake<EIP20Interface>("EIP20Interface");
       return { ...contracts, vToken1, vToken2, token };
     }
@@ -314,7 +314,7 @@ describe("Comptroller", () => {
 
     async function deploy(): Promise<Contracts> {
       const contracts = await deploySimpleComptroller();
-      const vToken = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
+      const vToken = await smock.fake<VToken>("VToken");
       await contracts.comptroller._supportMarket(vToken.address);
       return { ...contracts, vToken };
     }
@@ -363,7 +363,7 @@ describe("Comptroller", () => {
       });
 
       it("reverts if market is not listed", async () => {
-        const someVToken = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
+        const someVToken = await smock.fake<VToken>("VToken");
         await expect(
           comptroller.mintAllowed(someVToken.address, await root.getAddress(), convertToUnit("1", 18)),
         ).to.be.revertedWith("market not listed");

--- a/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
+++ b/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
@@ -60,7 +60,7 @@ describe("Comptroller", () => {
     const ComptrollerLensFactory = await smock.mock<ComptrollerLens__factory>("ComptrollerLens");
     const comptroller = await ComptrollerFactory.deploy();
     const comptrollerLens = await ComptrollerLensFactory.deploy();
-    const oracle = await smock.fake<PriceOracle>("contracts/Oracle/PriceOracle.sol:PriceOracle");
+    const oracle = await smock.fake<PriceOracle>("PriceOracle");
     accessControl.isAllowedToCall.returns(true);
     await comptroller._setAccessControl(accessControl.address);
     await comptroller._setComptrollerLens(comptrollerLens.address);

--- a/tests/hardhat/Comptroller/pauseTest.ts
+++ b/tests/hardhat/Comptroller/pauseTest.ts
@@ -30,7 +30,7 @@ async function pauseFixture(): Promise<PauseFixture> {
   const ComptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
   const comptroller = await ComptrollerFactory.deploy();
   await comptroller._setAccessControl(accessControl.address);
-  const oracle = await smock.fake<PriceOracle>("contracts/Oracle/PriceOracle.sol:PriceOracle");
+  const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
   accessControl.isAllowedToCall.returns(true);
   await comptroller._setPriceOracle(oracle.address);

--- a/tests/hardhat/DelegateBorrowers/SwapDebtDelegate.ts
+++ b/tests/hardhat/DelegateBorrowers/SwapDebtDelegate.ts
@@ -43,7 +43,7 @@ describe("assetListTest", () => {
   beforeEach(async () => {
     [owner, borrower] = await ethers.getSigners();
 
-    priceOracle = await smock.fake<PriceOracle>("contracts/Oracle/PriceOracle.sol:PriceOracle");
+    priceOracle = await smock.fake<PriceOracle>("PriceOracle");
     comptroller = await smock.fake<Comptroller>("Comptroller");
     foo = await smock.fake<IERC20Upgradeable>("IERC20Upgradeable");
     bar = await smock.fake<IERC20Upgradeable>("IERC20Upgradeable");

--- a/tests/hardhat/Fork/swapTest.ts
+++ b/tests/hardhat/Fork/swapTest.ts
@@ -61,7 +61,7 @@ const initMainnetUser = async (user: string) => {
 };
 
 async function deploySimpleComptroller() {
-  oracle = await smock.fake<PriceOracle>("contracts/Oracle/PriceOracle.sol:PriceOracle");
+  oracle = await smock.fake<PriceOracle>("PriceOracle");
   accessControl = await smock.fake<IAccessControlManager>("IAccessControlManager");
   accessControl.isAllowedToCall.returns(true);
   const ComptrollerLensFactory = await smock.mock<ComptrollerLens__factory>("ComptrollerLens");

--- a/tests/hardhat/Lens/Rewards.ts
+++ b/tests/hardhat/Lens/Rewards.ts
@@ -27,8 +27,8 @@ type RewardsFixtire = {
 };
 
 const rewardsFixture = async (): Promise<RewardsFixtire> => {
-  vBUSD = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
-  vWBTC = await smock.fake<VToken>("contracts/Tokens/VTokens/VToken.sol:VToken");
+  vBUSD = await smock.fake<VToken>("VToken");
+  vWBTC = await smock.fake<VToken>("VToken");
   XVS = await smock.fake<MockToken>("MockToken");
   const venusLensFactory = await smock.mock<VenusLens__factory>("VenusLens");
   venusLens = await venusLensFactory.deploy();


### PR DESCRIPTION
## Description

This PR implements the following changes:
1. Remove `oracleAddress` dependency and adds `comptroller` so that everytime PSM will get `oracleAddress` via `comptroller.oracle()`.
2. Adds some unit tests to address the change above
3. Renames the `PricaOracle` and `VToken` Interfaces in PSM contract so that interface names do not clash, and also removing the relative path to the artifacts in some of the other tests, simulations that are not related to the PSM ( e.g `tests/hardhat/Fork/swapTest.ts`)
4. Locks the pragma of PSM

To run only PSM tests you can execute `npx hardhat test --grep "Peg Stability Module"`


Resolves # N/A

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
