### PR TITLE
[VEN-1425] fix: fairyproof findings for the vaults audit 2023-05

### DIFF
--- a/contracts/Vault/VAIVault.sol
+++ b/contracts/Vault/VAIVault.sol
@@ -244,6 +244,7 @@ contract VAIVault is VAIVaultStorage, AccessControlledV5 {
 
     function setVenusInfo(address _xvs, address _vai) external onlyAdmin {
         require(_xvs != address(0) && _vai != address(0), "addresses must not be zero");
+        require(address(xvs) == address(0) && address(vai) == address(0), "addresses already set");
         xvs = IBEP20(_xvs);
         vai = IBEP20(_vai);
 

--- a/contracts/Vault/VAIVault.sol
+++ b/contracts/Vault/VAIVault.sol
@@ -219,14 +219,6 @@ contract VAIVault is VAIVaultStorage, AccessControlledV5 {
     }
 
     /**
-     * @dev Burn the current admin
-     */
-    function burnAdmin() external onlyAdmin {
-        emit AdminTransfered(admin, address(0));
-        admin = address(0);
-    }
-
-    /**
      * @dev Set the current admin to new address
      */
     function setNewAdmin(address newAdmin) external onlyAdmin {

--- a/contracts/Vault/VAIVault.sol
+++ b/contracts/Vault/VAIVault.sol
@@ -22,9 +22,6 @@ contract VAIVault is VAIVaultStorage, AccessControlledV5 {
     /// @notice Event emitted when VAI withrawal
     event Withdraw(address indexed user, uint256 amount);
 
-    /// @notice Event emitted when admin changed
-    event AdminTransfered(address indexed oldAdmin, address indexed newAdmin);
-
     /// @notice Event emitted when vault is paused
     event VaultPaused(address indexed admin);
 
@@ -216,15 +213,6 @@ contract VAIVault is VAIVaultStorage, AccessControlledV5 {
      */
     function getAdmin() external view returns (address) {
         return admin;
-    }
-
-    /**
-     * @dev Set the current admin to new address
-     */
-    function setNewAdmin(address newAdmin) external onlyAdmin {
-        require(newAdmin != address(0), "new owner is the zero address");
-        emit AdminTransfered(admin, newAdmin);
-        admin = newAdmin;
     }
 
     /*** Admin Functions ***/

--- a/contracts/Vault/VAIVault.sol
+++ b/contracts/Vault/VAIVault.sol
@@ -208,13 +208,6 @@ contract VAIVault is VAIVaultStorage, AccessControlledV5 {
         pendingRewards = 0;
     }
 
-    /**
-     * @dev Returns the address of the current admin
-     */
-    function getAdmin() external view returns (address) {
-        return admin;
-    }
-
     /*** Admin Functions ***/
 
     function _become(IVAIVaultProxy vaiVaultProxy) external {

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -149,6 +149,10 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
             require(poolInfo[pid].token != _token, "Pool already added");
         }
 
+        // We use balanceOf to get the supply amount, so shouldn't be possible to
+        // configure pools with different reward token but the same staked token
+        require(!isStakedToken[address(_token)], "Token exists in other pool");
+
         totalAllocPoints[_rewardToken] = totalAllocPoints[_rewardToken].add(_allocPoint);
 
         rewardTokenAmountsPerBlock[_rewardToken] = _rewardPerBlock;
@@ -162,6 +166,7 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
                 lockPeriod: _lockPeriod
             })
         );
+        isStakedToken[address(_token)] = true;
 
         IXVSStore(xvsStore).setRewardToken(_rewardToken, true);
 

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -35,9 +35,6 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
     /// @notice Event emitted when request withrawal
     event RequestedWithdrawal(address indexed user, address indexed rewardToken, uint256 indexed pid, uint256 amount);
 
-    /// @notice Event emitted when admin changed
-    event AdminTransferred(address indexed oldAdmin, address indexed newAdmin);
-
     /// @notice An event thats emitted when an account changes its delegate
     event DelegateChangedV2(address indexed delegator, address indexed fromDelegate, address indexed toDelegate);
 
@@ -745,21 +742,6 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
             }
         }
         return checkpoints[account][lower].votes;
-    }
-
-    /**
-     * @dev Returns the address of the current admin
-     */
-    function getAdmin() external view returns (address) {
-        return admin;
-    }
-
-    /**
-     * @dev Burn the current admin
-     */
-    function burnAdmin() external onlyAdmin {
-        emit AdminTransferred(admin, address(0));
-        admin = address(0);
     }
 
     /*** Admin Functions ***/

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -149,7 +149,7 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
 
         uint256 length = poolInfo.length;
         for (uint256 pid = 0; pid < length; ++pid) {
-            require(poolInfo[pid].token != _token, "Error pool already added");
+            require(poolInfo[pid].token != _token, "Pool already added");
         }
 
         totalAllocPoints[_rewardToken] = totalAllocPoints[_rewardToken].add(_allocPoint);

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -13,6 +13,8 @@ interface IXVSStore {
     function safeRewardTransfer(address _token, address _to, uint256 _amount) external;
 
     function setRewardToken(address _tokenAddress, bool status) external;
+
+    function rewardTokens(address _tokenAddress) external view returns (bool);
 }
 
 interface IXVSVaultProxy {
@@ -190,6 +192,7 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
     // Update the given reward token's amount per block
     function setRewardAmountPerBlock(address _rewardToken, uint256 _rewardAmount) external {
         _checkAccessAllowed("setRewardAmountPerBlock(address,uint256)");
+        require(IXVSStore(xvsStore).rewardTokens(_rewardToken), "Invalid reward token");
         massUpdatePools(_rewardToken);
         uint256 oldReward = rewardTokenAmountsPerBlock[_rewardToken];
         rewardTokenAmountsPerBlock[_rewardToken] = _rewardAmount;

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -360,6 +360,9 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
         (beforeUpgradeWithdrawalAmount, afterUpgradeWithdrawalAmount) = popEligibleWithdrawalRequests(user, requests);
         require(beforeUpgradeWithdrawalAmount > 0 || afterUpgradeWithdrawalAmount > 0, "nothing to withdraw");
 
+        // Having both old-style and new-style requests is not allowed and shouldn't be possible
+        require(beforeUpgradeWithdrawalAmount == 0 || afterUpgradeWithdrawalAmount == 0, "inconsistent state");
+
         if (beforeUpgradeWithdrawalAmount > 0) {
             _updatePool(_rewardToken, _pid);
             uint256 pending = user.amount.mul(pool.accRewardPerShare).div(1e12).sub(user.rewardDebt);

--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -229,10 +229,12 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
             uint256 pending = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12).sub(
                 user.rewardDebt
             );
-            IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, msg.sender, pending);
-            emit Claim(msg.sender, _rewardToken, _pid, pending);
+            if (pending > 0) {
+                IXVSStore(xvsStore).safeRewardTransfer(_rewardToken, msg.sender, pending);
+                emit Claim(msg.sender, _rewardToken, _pid, pending);
+            }
         }
-        pool.token.safeTransferFrom(address(msg.sender), address(this), _amount);
+        pool.token.safeTransferFrom(msg.sender, address(this), _amount);
         user.amount = user.amount.add(_amount);
         user.rewardDebt = user.amount.sub(user.pendingWithdrawals).mul(pool.accRewardPerShare).div(1e12);
 

--- a/contracts/XVSVault/XVSVaultStorage.sol
+++ b/contracts/XVSVault/XVSVaultStorage.sol
@@ -116,6 +116,9 @@ contract XVSVaultStorage is XVSVaultStorageV1 {
     /// @notice pause indicator for Vault
     bool public vaultPaused;
 
+    /// @notice if the token is added to any of the pools
+    mapping(address => bool) public isStakedToken;
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -88,6 +88,12 @@ describe("XVSVault", async () => {
       );
     });
 
+    it("reverts if staked token exists in another pool", async () => {
+      await expect(xvsVault.add(token.address, 100, xvs.address, rewardPerBlock, lockPeriod)).to.be.revertedWith(
+        "Token exists in other pool",
+      );
+    });
+
     it("emits PoolAdded event", async () => {
       const tx = await xvsVault.add(token.address, 100, token.address, rewardPerBlock, lockPeriod);
       await expect(tx)

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -125,6 +125,29 @@ describe("XVSVault", async () => {
     });
   });
 
+  describe("setRewardAmountPerBlock", async () => {
+    it("reverts if ACM does not allow the call", async () => {
+      accessControl.isAllowedToCall.returns(false);
+      await expect(xvsVault.setRewardAmountPerBlock(xvs.address, 100)).to.be.revertedWith("Unauthorized");
+      accessControl.isAllowedToCall.returns(true);
+    });
+
+    it("reverts if the token is not configured in XVSStore", async () => {
+      await xvsStore.setRewardToken(xvs.address, false);
+      await expect(xvsVault.setRewardAmountPerBlock(xvs.address, 100)).to.be.revertedWith("Invalid reward token");
+    });
+
+    it("emits RewardAmountPerBlockUpdated event", async () => {
+      const tx = await xvsVault.setRewardAmountPerBlock(xvs.address, 111);
+      await expect(tx).to.emit(xvsVault, "RewardAmountUpdated").withArgs(xvs.address, rewardPerBlock, 111);
+    });
+
+    it("updates reward amount per block", async () => {
+      await xvsVault.setRewardAmountPerBlock(xvs.address, 111);
+      expect(await xvsVault.rewardTokenAmountsPerBlock(xvs.address)).to.equal(111);
+    });
+  });
+
   it("check xvs balance", async () => {
     expect(await xvs.balanceOf(xvsStore.address)).to.eq(bigNumber18.mul(10000));
   });

--- a/tests/hardhat/XVS/XVSVault.ts
+++ b/tests/hardhat/XVS/XVSVault.ts
@@ -1,10 +1,10 @@
-import { smock } from "@defi-wonderland/smock";
+import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture, mine } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
-import { BigNumber, Wallet } from "ethers";
+import { BigNumber, BigNumberish, Wallet } from "ethers";
 import { ethers } from "hardhat";
 
-import { XVS, XVSStore, XVSVaultScenario } from "../../../typechain";
+import { IERC20Upgradeable, XVS, XVSStore, XVSVaultScenario, XVSVaultScenario__factory } from "../../../typechain";
 import { IAccessControlManager } from "../../../typechain/contracts/Governance";
 
 const bigNumber18 = BigNumber.from("1000000000000000000"); // 1e18
@@ -14,16 +14,18 @@ const allocPoint = 100;
 const poolId = 0;
 
 interface XVSVaultFixture {
-  xvsVault: XVSVaultScenario;
+  xvsVault: MockContract<XVSVaultScenario>;
   xvs: XVS;
+  accessControl: FakeContract<IAccessControlManager>;
   xvsStore: XVSStore;
 }
 
 describe("XVSVault", async () => {
   let deployer: Wallet;
   let user: Wallet;
+  let xvsVault: MockContract<XVSVaultScenario>;
   let xvs: XVS;
-  let xvsVault: XVSVaultScenario;
+  let accessControl: FakeContract<IAccessControlManager>;
   let xvsStore: XVSStore;
 
   before("get signers", async () => {
@@ -37,18 +39,18 @@ describe("XVSVault", async () => {
     const xvsStoreFactory = await ethers.getContractFactory("XVSStore");
     xvsStore = (await xvsStoreFactory.deploy()) as XVSStore;
 
-    const xvsVaultFactory = await ethers.getContractFactory("XVSVaultScenario");
-    xvsVault = (await xvsVaultFactory.deploy()) as XVSVaultScenario;
+    const xvsVaultFactory = await smock.mock<XVSVaultScenario__factory>("XVSVaultScenario");
+    xvsVault = await xvsVaultFactory.deploy();
 
-    const accessControlMock = await smock.fake<IAccessControlManager>("AccessControlManager");
-    accessControlMock.isAllowedToCall.returns(true);
-    await xvsVault.connect(deployer).setAccessControl(accessControlMock.address);
+    const accessControl = await smock.fake<IAccessControlManager>("AccessControlManager");
+    accessControl.isAllowedToCall.returns(true);
+    await xvsVault.connect(deployer).setAccessControl(accessControl.address);
 
-    return { xvsVault, xvs, xvsStore };
+    return { xvsVault, accessControl, xvs, xvsStore };
   }
 
   beforeEach("deploy and configure XVSVault contracts", async () => {
-    ({ xvsVault, xvs, xvsStore } = await loadFixture(deployXVSVaultFixture));
+    ({ xvsVault, xvs, accessControl, xvsStore } = await loadFixture(deployXVSVaultFixture));
 
     await xvsStore.setNewOwner(xvsVault.address);
     await xvsVault.setXvsStore(xvs.address, xvsStore.address);
@@ -58,6 +60,63 @@ describe("XVSVault", async () => {
     await xvsStore.setRewardToken(xvs.address, true);
 
     await xvsVault.add(xvs.address, allocPoint, xvs.address, rewardPerBlock, lockPeriod);
+  });
+
+  describe("add", async () => {
+    let token: FakeContract<IERC20Upgradeable>;
+    let poolParams: [string, BigNumberish, string, BigNumberish, BigNumberish];
+
+    beforeEach(async () => {
+      token = await smock.fake<IERC20Upgradeable>("IERC20Upgradeable");
+      poolParams = [token.address, 100, token.address, rewardPerBlock, lockPeriod];
+    });
+
+    it("reverts if ACM does not allow the call", async () => {
+      accessControl.isAllowedToCall.returns(false);
+      await expect(xvsVault.add(...poolParams)).to.be.revertedWith("Unauthorized");
+      accessControl.isAllowedToCall.returns(true);
+    });
+
+    it("reverts if xvsStore is not set", async () => {
+      xvsVault.setVariable("xvsStore", ethers.constants.AddressZero);
+      await expect(xvsVault.add(...poolParams)).to.be.revertedWith("Store contract addres is empty");
+    });
+
+    it("reverts if a pool with this (staked token, reward token) combination already exists", async () => {
+      await expect(xvsVault.add(xvs.address, 100, xvs.address, rewardPerBlock, lockPeriod)).to.be.revertedWith(
+        "Pool already added",
+      );
+    });
+
+    it("emits PoolAdded event", async () => {
+      const tx = await xvsVault.add(token.address, 100, token.address, rewardPerBlock, lockPeriod);
+      await expect(tx)
+        .to.emit(xvsVault, "PoolAdded")
+        .withArgs(token.address, 0, token.address, 100, rewardPerBlock, lockPeriod);
+    });
+
+    it("adds a second pool to an existing rewardToken", async () => {
+      const tx = await xvsVault.add(xvs.address, 100, token.address, rewardPerBlock, lockPeriod);
+      const expectedPoolId = 1;
+      await expect(tx)
+        .to.emit(xvsVault, "PoolAdded")
+        .withArgs(xvs.address, expectedPoolId, token.address, 100, rewardPerBlock, lockPeriod);
+    });
+
+    it("sets pool info", async () => {
+      await xvsVault.add(token.address, 100, token.address, rewardPerBlock, lockPeriod);
+
+      const poolInfo = await xvsVault.poolInfos(token.address, 0);
+      expect(poolInfo.token).to.equal(token.address);
+      expect(poolInfo.allocPoint).to.equal("100");
+      expect(poolInfo.accRewardPerShare).to.equal("0");
+      expect(poolInfo.lockPeriod).to.equal(lockPeriod);
+    });
+
+    it("configures reward token in XVSStore", async () => {
+      await xvsVault.add(token.address, 100, token.address, rewardPerBlock, lockPeriod);
+      expect(await xvsStore.rewardTokens(token.address)).to.equal(true);
+    });
   });
 
   it("check xvs balance", async () => {


### PR DESCRIPTION
This PR fixes the findings from the Fairyproof audit report. Here's the breakdown of the issues and resolutions:

### VAIVault
1. Different txs for transferring the xvs token to the contract and calling updatePendingRewards
Resolution: Won't fix
Rationale: The rewards are distributed in an automated fashion in the Comptroller contract, so it is currently not possible that updatePendingRewards is not called. The provided recommendation sounds reasonable and it could help to prevent "reward swallowing" in case Comptroller code is modified to remove this call. However, it is important to limit the scope of the changes for the upgrade, so we will postpone fixing this for now.

2. Admin's Access Control Can be Recovered
Resolution: Fix provided (burnAdmin function has been removed)

3. Front-running (deposit just before the reward transfer, withdraw after)
Resolution: Won't fix
Rationale: This is a legtimate issue: the reward is sent to VAIVault once 4 XVS is accumulated (approx. 31 times per day), so technically it's possible to monitor the transactions and stake/unstake VAI. However, we don't consider it worth fixing at this point since we expect to gradually sunset VAI vault in favor of other use-cases for VAI.

4. setVenusInfo function can be called repeatedly
Resolution: Fix provided

5. Redundant function (setNewAdmin)
Resolution: Fix provided

6. Lack of Emergency Withdrawal Function
Resolution: Won't fix
Rationale: We can pause the vault and then upgrade it to perform emergency withdrawal

7. Redundant function (getAdmin)
Resolution: Fix provided

### VRTVault	
1. Admin can withdraw users' assets
Resolution: Won't fix
Rationale: Unreasonably hard to fix in the already deployed contract

2. Staked asset and reward asset are not separated
Resolution: Won't fix
Rationale: Unreasonably hard to fix in the already deployed contract

3. Lack of Emergency Withdrawal Function
Resolution: Won't fix
Rationale: Contract upgrade or withdrawBep20 can be used for emergency withdrawals

### XVSVault
1. Admin's Access Control Can be Recovered
Resolution: Fix provided (burnAdmin function has been removed)

2. Flawed reward computation for multiple pools with the same reward token
Resolution: Fix provided
Details: The bug indeed exists. The resolution is to disallow adding pools with the same staked token. Other solutions are possible (e.g. tracking supply per pool), but they are unneeded provided how XVSVault is used currently.

3. [Explanation provided]

4. Code improvements
    1. setRewardAmountPerBlock function doesn't check whether rewardToken is effective
    Resolution: Fix provided

    2. Consider adding a if (pending >0) conditional check in the deposit function and changing
address(msg.sender) to msg.sender"
    Resolution: Fix provided	

    3. In executeWithdrawal , in the condition checks , it should be clearly state that at least one shouldn't be greater than 0 (and one should be equal to 0).
    Resolution: Fix provided	

    4. In pendingReward consider adding a block parameter rather than using msg.block . This makes testing easier.
    Resolution: Won't fix
    Rationale: This is a breaking change in a public (non-admin) interface, we prefer to not introduce breaking changes at this point.

    5. The getRequestedAmount function is redundant
    Resolution: Won't fix
    Rationale: This is a breaking change in a public (non-admin) interface, we prefer to not introduce breaking changes at this point.