### PR TITLE
[VEN-1450] docs: support generating docs for contract and interfaces

### DIFF
--- a/docgen-templates/page.hbs
+++ b/docgen-templates/page.hbs
@@ -1,0 +1,11 @@
+{{h}} {{items.0.natspec.title}}
+{{items.0.natspec.notice}}
+
+# Solidity API
+
+{{#each items}}
+{{#hsection}}
+{{>item}}
+{{/hsection}}
+
+{{/each}}


### PR DESCRIPTION
## Description

Adds support for title and notice on contracts and interfaces.

Public structs, variables, and enums will appear in the generated documentation if a `@notice` is included