### PR TITLE
[VEN-1483]: handle insufficient rewards in the vault

### DIFF
--- a/contracts/XVSVault/XVSVaultStorage.sol
+++ b/contracts/XVSVault/XVSVaultStorage.sol
@@ -119,6 +119,9 @@ contract XVSVaultStorage is XVSVaultStorageV1 {
     /// @notice if the token is added to any of the pools
     mapping(address => bool) public isStakedToken;
 
+    /// @notice Amount we owe to users because of failed transfer attempts
+    mapping(address => mapping(address => uint256)) public pendingRewardTransfers;
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.

--- a/contracts/test/XVSVaultScenario.sol
+++ b/contracts/test/XVSVaultScenario.sol
@@ -41,4 +41,8 @@ contract XVSVaultScenario is XVSVault {
 
         emit RequestedWithdrawal(msg.sender, _rewardToken, _pid, _amount);
     }
+
+    function transferReward(address rewardToken, address user, uint256 amount) external {
+        _transferReward(rewardToken, user, amount);
+    }
 }


### PR DESCRIPTION
This PR adds some safeguards against erasing the information about the users' rewards in case of insufficient reward token amounts in XVSStore.

Due to how the vault works, we have to distribute the accumulated rewards upon every deposit and withdrawal request. This way we make sure that the shares we apply the rewards to are the same. However, if it turns out we don't have enugh funds to pay out due to some reason, we just _erase_ the information about the rewards. This has caused some pain in the past, and (hopefully unlikely) may cause pain in future.

As a simplest mitigation, we could revert the transaction in case of insufficient funding. However, this is a denial of service vector – if Venus fails to deliver rewards, users would not be able to withdraw their funds (the requestWithdrawal transaction would fail).

Taking these considerations into account, I propose we keep track of the money we owe to the users in a separate storage mapping. This way we could avoid DoS and preserve the information about the rewards.