### PR TITLE
test: fix dangling promises in tests

### DIFF
--- a/tests/hardhat/Comptroller/accessControl.ts
+++ b/tests/hardhat/Comptroller/accessControl.ts
@@ -25,15 +25,15 @@ describe("Comptroller", () => {
 
   describe("_setAccessControlManager", () => {
     it("Reverts if called by non-admin", async () => {
-      expect(comptroller.connect(user)._setAccessControl(accessControl.address)).to.be.revertedWith("only admin can");
+      await expect(comptroller.connect(user)._setAccessControl(accessControl.address)).to.be.revertedWith("only admin can");
     });
 
     it("Reverts if ACM is zero address", async () => {
-      expect(comptroller._setAccessControl(constants.AddressZero)).to.be.revertedWith("can't be zero address");
+      await expect(comptroller._setAccessControl(constants.AddressZero)).to.be.revertedWith("can't be zero address");
     });
 
     it("Sets ACM address in storage", async () => {
-      expect(await comptroller._setAccessControl(accessControl.address))
+      await expect(await comptroller._setAccessControl(accessControl.address))
         .to.emit(comptroller, "NewAccessControl")
         .withArgs(constants.AddressZero, accessControl.address);
       expect(await comptroller.getVariable("accessControl")).to.equal(accessControl.address);

--- a/tests/hardhat/Comptroller/accessControl.ts
+++ b/tests/hardhat/Comptroller/accessControl.ts
@@ -25,7 +25,9 @@ describe("Comptroller", () => {
 
   describe("_setAccessControlManager", () => {
     it("Reverts if called by non-admin", async () => {
-      await expect(comptroller.connect(user)._setAccessControl(accessControl.address)).to.be.revertedWith("only admin can");
+      await expect(comptroller.connect(user)._setAccessControl(accessControl.address)).to.be.revertedWith(
+        "only admin can",
+      );
     });
 
     it("Reverts if ACM is zero address", async () => {

--- a/tests/hardhat/Comptroller/assetListTest.ts
+++ b/tests/hardhat/Comptroller/assetListTest.ts
@@ -108,7 +108,7 @@ describe("assetListTest", () => {
       expect(tokenReply).to.equal(expectedErrors_[i]);
     });
 
-    expect(receipt).to.emit(comptroller, "MarketEntered");
+    await expect(receipt).to.emit(comptroller, "MarketEntered");
     expect(assetsIn).to.deep.equal(expectedTokens.map(t => t.address));
 
     await checkMarkets(expectedTokens);
@@ -140,7 +140,7 @@ describe("assetListTest", () => {
     it("properly emits events", async () => {
       const tx1 = await enterAndCheckMarkets([OMG], [OMG]);
       const tx2 = await enterAndCheckMarkets([OMG], [OMG]);
-      expect(tx1).to.emit(comptroller, "MarketEntered").withArgs(OMG.address, customer);
+      await expect(tx1).to.emit(comptroller, "MarketEntered").withArgs(OMG.address, customer);
       expect((await tx2.wait()).events).to.be.empty;
     });
 

--- a/tests/hardhat/Comptroller/comptrollerTest.ts
+++ b/tests/hardhat/Comptroller/comptrollerTest.ts
@@ -1,7 +1,8 @@
 import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chai from "chai";
-import { Signer, constants } from "ethers";
+import { constants } from "ethers";
 import { ethers } from "hardhat";
 
 import { convertToUnit } from "../../../helpers/utils";
@@ -11,7 +12,6 @@ import {
   ComptrollerLens__factory,
   Comptroller__factory,
   EIP20Interface,
-  EIP20Interface__factory,
   IAccessControlManager,
   PriceOracle,
   VToken,
@@ -56,8 +56,8 @@ function configureVToken(vToken: FakeContract<VToken>, comptroller: MockContract
 }
 
 describe("Comptroller", () => {
-  let root: Signer;
-  let accounts: Signer[];
+  let root: SignerWithAddress;
+  let accounts: SignerWithAddress[];
 
   before(async () => {
     [root, ...accounts] = await ethers.getSigners();
@@ -66,7 +66,7 @@ describe("Comptroller", () => {
   describe("constructor", () => {
     it("on success it sets admin to creator and pendingAdmin is unset", async () => {
       const { comptroller } = await loadFixture(deploySimpleComptroller);
-      expect(await comptroller.admin()).to.equal(await root.getAddress());
+      expect(await comptroller.admin()).to.equal(root.address);
       expect(await comptroller.pendingAdmin()).to.equal(constants.AddressZero);
     });
   });
@@ -237,6 +237,7 @@ describe("Comptroller", () => {
         .withArgs(
           ComptrollerErrorReporter.Error.PRICE_ERROR,
           ComptrollerErrorReporter.FailureInfo.SET_COLLATERAL_FACTOR_WITHOUT_PRICE,
+          0,
         );
     });
 
@@ -295,6 +296,7 @@ describe("Comptroller", () => {
         .withArgs(
           ComptrollerErrorReporter.Error.MARKET_ALREADY_LISTED,
           ComptrollerErrorReporter.FailureInfo.SUPPORT_MARKET_EXISTS,
+          0,
         );
     });
 
@@ -340,11 +342,7 @@ describe("Comptroller", () => {
         vToken.exchangeRateStored.returns(exchangeRate);
         await comptroller._setMarketSupplyCaps([vToken.address], [cap]);
         expect(
-          await comptroller.callStatic.mintAllowed(
-            vToken.address,
-            await root.getAddress(),
-            convertToUnit("0.9999", 18),
-          ),
+          await comptroller.callStatic.mintAllowed(vToken.address, root.address, convertToUnit("0.9999", 18)),
         ).to.equal(0); // 0 means "no error"
       });
 
@@ -358,29 +356,29 @@ describe("Comptroller", () => {
         vToken.exchangeRateStored.returns(exchangeRate);
         await comptroller._setMarketSupplyCaps([vToken.address], [cap]);
         await expect(
-          comptroller.mintAllowed(vToken.address, await root.getAddress(), convertToUnit("1.01", 18)),
+          comptroller.mintAllowed(vToken.address, root.address, convertToUnit("1.01", 18)),
         ).to.be.revertedWith("market supply cap reached");
       });
 
       it("reverts if market is not listed", async () => {
         const someVToken = await smock.fake<VToken>("VToken");
         await expect(
-          comptroller.mintAllowed(someVToken.address, await root.getAddress(), convertToUnit("1", 18)),
+          comptroller.mintAllowed(someVToken.address, root.address, convertToUnit("1", 18)),
         ).to.be.revertedWith("market not listed");
       });
     });
 
     describe("redeemVerify", () => {
       it("should allow you to redeem 0 underlying for 0 tokens", async () => {
-        await comptroller.redeemVerify(vToken.address, await accounts[0].getAddress(), 0, 0);
+        await comptroller.redeemVerify(vToken.address, accounts[0].address, 0, 0);
       });
 
       it("should allow you to redeem 5 underlyig for 5 tokens", async () => {
-        await comptroller.redeemVerify(vToken.address, await accounts[0].getAddress(), 5, 5);
+        await comptroller.redeemVerify(vToken.address, accounts[0].address, 5, 5);
       });
 
       it("should not allow you to redeem 5 underlying for 0 tokens", async () => {
-        await expect(comptroller.redeemVerify(vToken.address, await accounts[0].getAddress(), 5, 0)).to.be.revertedWith(
+        await expect(comptroller.redeemVerify(vToken.address, accounts[0].address, 5, 0)).to.be.revertedWith(
           "redeemTokens zero",
         );
       });

--- a/tests/hardhat/Comptroller/comptrollerTest.ts
+++ b/tests/hardhat/Comptroller/comptrollerTest.ts
@@ -91,7 +91,7 @@ describe("Comptroller", () => {
       expect(await comptroller.callStatic._setLiquidationIncentive(validIncentive)).to.equal(
         ComptrollerErrorReporter.Error.NO_ERROR,
       );
-      expect(await comptroller._setLiquidationIncentive(validIncentive))
+      await expect(await comptroller._setLiquidationIncentive(validIncentive))
         .to.emit(comptroller, "NewLiquidationIncentive")
         .withArgs(initialIncentive, validIncentive);
       expect(await comptroller.liquidationIncentiveMantissa()).to.equal(validIncentive);
@@ -149,7 +149,7 @@ describe("Comptroller", () => {
     });
 
     it("accepts a valid price oracle and emits a NewPriceOracle event", async () => {
-      expect(await comptroller._setPriceOracle(newOracle.address))
+      await expect(await comptroller._setPriceOracle(newOracle.address))
         .to.emit(comptroller, "NewPriceOracle")
         .withArgs(oracle.address, newOracle.address);
       expect(await comptroller.oracle()).to.equal(newOracle.address);
@@ -186,7 +186,7 @@ describe("Comptroller", () => {
     it("should fire an event", async () => {
       const { comptroller, comptrollerLens } = await loadFixture(deploy);
       const oldComptrollerLensAddress = await comptroller.comptrollerLens();
-      expect(await comptroller._setComptrollerLens(comptrollerLens.address))
+      await expect(await comptroller._setComptrollerLens(comptrollerLens.address))
         .to.emit(comptroller, "NewComptrollerLens")
         .withArgs(oldComptrollerLensAddress, comptrollerLens.address);
     });
@@ -232,7 +232,7 @@ describe("Comptroller", () => {
     it("fails if factor is set without an underlying price", async () => {
       await comptroller._supportMarket(vToken.address);
       oracle.getUnderlyingPrice.returns(0);
-      expect(await comptroller._setCollateralFactor(vToken.address, half))
+      await expect(await comptroller._setCollateralFactor(vToken.address, half))
         .to.emit(comptroller, "Failure")
         .withArgs(
           ComptrollerErrorReporter.Error.PRICE_ERROR,
@@ -242,7 +242,7 @@ describe("Comptroller", () => {
 
     it("succeeds and sets market", async () => {
       await comptroller._supportMarket(vToken.address);
-      expect(await comptroller._setCollateralFactor(vToken.address, half))
+      await expect(await comptroller._setCollateralFactor(vToken.address, half))
         .to.emit(comptroller, "NewCollateralFactor")
         .withArgs(vToken.address, "0", half);
     });
@@ -281,7 +281,7 @@ describe("Comptroller", () => {
     });
 
     it("succeeds and sets market", async () => {
-      expect(await comptroller._supportMarket(vToken1.address))
+      await expect(await comptroller._supportMarket(vToken1.address))
         .to.emit(comptroller, "MarketListed")
         .withArgs(vToken1.address);
     });
@@ -289,8 +289,8 @@ describe("Comptroller", () => {
     it("cannot list a market a second time", async () => {
       const tx1 = await comptroller._supportMarket(vToken1.address);
       const tx2 = await comptroller._supportMarket(vToken1.address);
-      expect(tx1).to.emit(comptroller, "MarketListed").withArgs(vToken1.address);
-      expect(tx2)
+      await expect(tx1).to.emit(comptroller, "MarketListed").withArgs(vToken1.address);
+      await expect(tx2)
         .to.emit(comptroller, "Failure")
         .withArgs(
           ComptrollerErrorReporter.Error.MARKET_ALREADY_LISTED,
@@ -301,8 +301,8 @@ describe("Comptroller", () => {
     it("can list two different markets", async () => {
       const tx1 = await comptroller._supportMarket(vToken1.address);
       const tx2 = await comptroller._supportMarket(vToken2.address);
-      expect(tx1).to.emit(comptroller, "MarketListed").withArgs(vToken1.address);
-      expect(tx2).to.emit(comptroller, "MarketListed").withArgs(vToken2.address);
+      await expect(tx1).to.emit(comptroller, "MarketListed").withArgs(vToken1.address);
+      await expect(tx2).to.emit(comptroller, "MarketListed").withArgs(vToken2.address);
     });
   });
 

--- a/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
+++ b/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
@@ -2,7 +2,6 @@ import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import chai from "chai";
 import { BigNumberish, constants } from "ethers";
-import { ethers } from "hardhat";
 
 import { convertToUnit } from "../../../helpers/utils";
 import {
@@ -50,7 +49,7 @@ describe("Comptroller", () => {
     vTokenCollateral: FakeContract<VBep20Immutable>;
   };
 
-  async function setOraclePrice(vToken: FakeContract<VBep20Immutable>, price: BigNumberish) {
+  function setOraclePrice(vToken: FakeContract<VBep20Immutable>, price: BigNumberish) {
     oracle.getUnderlyingPrice.whenCalledWith(vToken.address).returns(price);
   }
 
@@ -121,7 +120,6 @@ describe("Comptroller", () => {
 
     it("reverts if it fails to calculate the exchange rate", async () => {
       vTokenCollateral.exchangeRateStored.reverts("exchangeRateStored: exchangeRateStoredInternal failed");
-      ethers.provider.getBlockNumber();
       /// TODO: Somehow the error message does not get propagated into the resulting tx. Smock bug?
       await expect(
         comptroller.liquidateCalculateSeizeTokens(vTokenBorrowed.address, vTokenCollateral.address, repayAmount),

--- a/tests/hardhat/Governance/GovernanceBravo/proposeTest.ts
+++ b/tests/hardhat/Governance/GovernanceBravo/proposeTest.ts
@@ -224,7 +224,7 @@ describe("Governor Bravo Propose Tests", () => {
       const proposeStartBlock = currentBlockNumber + proposalConfigs[2].votingDelay;
       const proposeEndBlock = proposeStartBlock + proposalConfigs[2].votingPeriod;
 
-      expect(
+      await expect(
         await governorBravoDelegate
           .connect(customer)
           .propose(targets, values, signatures, callDatas, "second proposal", ProposalType.CRITICAL),

--- a/tests/hardhat/Governance/GovernanceBravo/stateTest.ts
+++ b/tests/hardhat/Governance/GovernanceBravo/stateTest.ts
@@ -125,7 +125,7 @@ describe("Governor Bravo State Tests", () => {
     expect(await governorBravoDelegate.state(newProposalId)).to.equal(ProposalState.Canceled);
   });
   it("Canceled by Guardian", async () => {
-    governorBravoDelegate.setVariable("guardian", rootAddress);
+    await governorBravoDelegate.setVariable("guardian", rootAddress);
     await governorBravoDelegate
       .connect(customer)
       .propose(targets, values, signatures, calldatas, "do nothing", ProposalType.CRITICAL);

--- a/tests/hardhat/Unitroller/adminTest.ts
+++ b/tests/hardhat/Unitroller/adminTest.ts
@@ -1,7 +1,8 @@
 import { MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chai from "chai";
-import { Signer, constants } from "ethers";
+import { constants } from "ethers";
 import { ethers } from "hardhat";
 
 import { Unitroller, Unitroller__factory } from "../../../typechain";
@@ -11,8 +12,8 @@ const { expect } = chai;
 chai.use(smock.matchers);
 
 describe("admin / _setPendingAdmin / _acceptAdmin", () => {
-  let root: Signer;
-  let accounts: Signer[];
+  let root: SignerWithAddress;
+  let accounts: SignerWithAddress[];
   let unitroller: MockContract<Unitroller>;
 
   async function unitrollerFixture(): Promise<MockContract<Unitroller>> {
@@ -28,7 +29,7 @@ describe("admin / _setPendingAdmin / _acceptAdmin", () => {
 
   describe("admin()", () => {
     it("should return correct admin", async () => {
-      expect(await unitroller.admin()).to.equal(await root.getAddress());
+      expect(await unitroller.admin()).to.equal(root.address);
     });
   });
 
@@ -40,38 +41,39 @@ describe("admin / _setPendingAdmin / _acceptAdmin", () => {
 
   describe("_setPendingAdmin()", () => {
     it("should only be callable by admin", async () => {
-      await expect(await unitroller.connect(accounts[0])._setPendingAdmin(await accounts[0].getAddress()))
+      await expect(await unitroller.connect(accounts[0])._setPendingAdmin(accounts[0].address))
         .to.emit(unitroller, "Failure")
         .withArgs(
           ComptrollerErrorReporter.Error.UNAUTHORIZED,
           ComptrollerErrorReporter.FailureInfo.SET_PENDING_ADMIN_OWNER_CHECK,
+          0,
         );
 
       // Check admin stays the same
-      expect(await unitroller.admin()).to.equal(await root.getAddress());
+      expect(await unitroller.admin()).to.equal(root.address);
       expect(await unitroller.pendingAdmin()).to.equal(constants.AddressZero);
     });
 
     it("should properly set pending admin", async () => {
-      expect(await unitroller._setPendingAdmin(await accounts[0].getAddress())); //.toSucceed();
+      expect(await unitroller._setPendingAdmin(accounts[0].address)); //.toSucceed();
 
       // Check admin stays the same
-      expect(await unitroller.admin()).to.equal(await root.getAddress());
-      expect(await unitroller.pendingAdmin()).to.equal(await accounts[0].getAddress());
+      expect(await unitroller.admin()).to.equal(root.address);
+      expect(await unitroller.pendingAdmin()).to.equal(accounts[0].address);
     });
 
     it("should properly set pending admin twice", async () => {
-      expect(await unitroller._setPendingAdmin(await accounts[0].getAddress())); //.toSucceed();
-      expect(await unitroller._setPendingAdmin(await accounts[1].getAddress())); //.toSucceed();
+      expect(await unitroller._setPendingAdmin(accounts[0].address)); //.toSucceed();
+      expect(await unitroller._setPendingAdmin(accounts[1].address)); //.toSucceed();
 
       // Check admin stays the same
-      expect(await unitroller.admin()).to.equal(await root.getAddress());
-      expect(await unitroller.pendingAdmin()).to.equal(await accounts[1].getAddress());
+      expect(await unitroller.admin()).to.equal(root.address);
+      expect(await unitroller.pendingAdmin()).to.equal(accounts[1].address);
     });
 
     it("should emit event", async () => {
-      const result = await unitroller._setPendingAdmin(await accounts[0].getAddress());
-      await expect(result).to.emit(unitroller, "NewPendingAdmin").withArgs(constants.AddressZero, constants.AddressZero);
+      const result = await unitroller._setPendingAdmin(accounts[0].address);
+      await expect(result).to.emit(unitroller, "NewPendingAdmin").withArgs(constants.AddressZero, accounts[0].address);
     });
   });
 
@@ -82,45 +84,43 @@ describe("admin / _setPendingAdmin / _acceptAdmin", () => {
         .withArgs(
           ComptrollerErrorReporter.Error.UNAUTHORIZED,
           ComptrollerErrorReporter.FailureInfo.ACCEPT_ADMIN_PENDING_ADMIN_CHECK,
+          0,
         );
 
       // Check admin stays the same
-      expect(await unitroller.admin()).to.equal(await root.getAddress());
+      expect(await unitroller.admin()).to.equal(root.address);
       expect(await unitroller.pendingAdmin()).to.equal(constants.AddressZero);
     });
 
     it("should fail when called by another account (e.g. root)", async () => {
-      expect(await unitroller._setPendingAdmin(await accounts[0].getAddress())); //.toSucceed();
+      expect(await unitroller._setPendingAdmin(accounts[0].address)); //.toSucceed();
       await expect(await unitroller._acceptAdmin())
         .to.emit(unitroller, "Failure")
         .withArgs(
           ComptrollerErrorReporter.Error.UNAUTHORIZED,
           ComptrollerErrorReporter.FailureInfo.ACCEPT_ADMIN_PENDING_ADMIN_CHECK,
+          0,
         );
 
       // Check admin stays the same
-      expect(await unitroller.admin()).to.equal(await root.getAddress());
-      expect(await unitroller.pendingAdmin()).to.equal(await accounts[0].getAddress());
+      expect(await unitroller.admin()).to.equal(root.address);
+      expect(await unitroller.pendingAdmin()).to.equal(accounts[0].address);
     });
 
     it("should succeed and set admin and clear pending admin", async () => {
-      await unitroller._setPendingAdmin(await accounts[0].getAddress());
+      await unitroller._setPendingAdmin(accounts[0].address);
       await unitroller.connect(accounts[0])._acceptAdmin();
 
       // Check admin stays the same
-      expect(await unitroller.admin()).to.equal(await accounts[0].getAddress());
+      expect(await unitroller.admin()).to.equal(accounts[0].address);
       expect(await unitroller.pendingAdmin()).to.equal(constants.AddressZero);
     });
 
     it("should emit log on success", async () => {
-      expect(await unitroller._setPendingAdmin(await accounts[0].getAddress())); //..toSucceed();
+      expect(await unitroller._setPendingAdmin(accounts[0].address)); //..toSucceed();
       const result = await unitroller.connect(accounts[0])._acceptAdmin();
-      await expect(result)
-        .to.emit(unitroller, "NewAdmin")
-        .withArgs(await root.getAddress(), await accounts[0].getAddress());
-      await expect(result)
-        .to.emit(unitroller, "NewPendingAdmin")
-        .withArgs(await accounts[0].getAddress(), constants.AddressZero);
+      await expect(result).to.emit(unitroller, "NewAdmin").withArgs(root.address, accounts[0].address);
+      await expect(result).to.emit(unitroller, "NewPendingAdmin").withArgs(accounts[0].address, constants.AddressZero);
     });
   });
 });

--- a/tests/hardhat/Unitroller/adminTest.ts
+++ b/tests/hardhat/Unitroller/adminTest.ts
@@ -40,7 +40,7 @@ describe("admin / _setPendingAdmin / _acceptAdmin", () => {
 
   describe("_setPendingAdmin()", () => {
     it("should only be callable by admin", async () => {
-      expect(await unitroller.connect(accounts[0])._setPendingAdmin(await accounts[0].getAddress()))
+      await expect(await unitroller.connect(accounts[0])._setPendingAdmin(await accounts[0].getAddress()))
         .to.emit(unitroller, "Failure")
         .withArgs(
           ComptrollerErrorReporter.Error.UNAUTHORIZED,
@@ -71,13 +71,13 @@ describe("admin / _setPendingAdmin / _acceptAdmin", () => {
 
     it("should emit event", async () => {
       const result = await unitroller._setPendingAdmin(await accounts[0].getAddress());
-      expect(result).to.emit(unitroller, "NewPendingAdmin").withArgs(constants.AddressZero, constants.AddressZero);
+      await expect(result).to.emit(unitroller, "NewPendingAdmin").withArgs(constants.AddressZero, constants.AddressZero);
     });
   });
 
   describe("_acceptAdmin()", () => {
     it("should fail when pending admin is zero", async () => {
-      expect(await unitroller._acceptAdmin())
+      await expect(await unitroller._acceptAdmin())
         .to.emit(unitroller, "Failure")
         .withArgs(
           ComptrollerErrorReporter.Error.UNAUTHORIZED,
@@ -91,7 +91,7 @@ describe("admin / _setPendingAdmin / _acceptAdmin", () => {
 
     it("should fail when called by another account (e.g. root)", async () => {
       expect(await unitroller._setPendingAdmin(await accounts[0].getAddress())); //.toSucceed();
-      expect(await unitroller._acceptAdmin())
+      await expect(await unitroller._acceptAdmin())
         .to.emit(unitroller, "Failure")
         .withArgs(
           ComptrollerErrorReporter.Error.UNAUTHORIZED,
@@ -115,10 +115,10 @@ describe("admin / _setPendingAdmin / _acceptAdmin", () => {
     it("should emit log on success", async () => {
       expect(await unitroller._setPendingAdmin(await accounts[0].getAddress())); //..toSucceed();
       const result = await unitroller.connect(accounts[0])._acceptAdmin();
-      expect(result)
+      await expect(result)
         .to.emit(unitroller, "NewAdmin")
         .withArgs(await root.getAddress(), await accounts[0].getAddress());
-      expect(result)
+      await expect(result)
         .to.emit(unitroller, "NewPendingAdmin")
         .withArgs(await accounts[0].getAddress(), constants.AddressZero);
     });

--- a/tests/hardhat/Unitroller/unitrollerTest.ts
+++ b/tests/hardhat/Unitroller/unitrollerTest.ts
@@ -1,7 +1,8 @@
 import { MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chai from "chai";
-import { ContractTransaction, Signer, constants } from "ethers";
+import { ContractTransaction, constants } from "ethers";
 import { ethers } from "hardhat";
 
 import {
@@ -18,8 +19,8 @@ const { expect } = chai;
 chai.use(smock.matchers);
 
 describe("Unitroller", () => {
-  let root: Signer;
-  let accounts: Signer[];
+  let root: SignerWithAddress;
+  let accounts: SignerWithAddress[];
   let unitroller: MockContract<Unitroller>;
   let brains: MockContract<Comptroller>;
 
@@ -38,14 +39,14 @@ describe("Unitroller", () => {
 
   async function setPending<Impl extends { address: string }>(
     implementation: Impl,
-    from: Signer,
+    from: SignerWithAddress,
   ): Promise<ContractTransaction> {
     return unitroller.connect(from)._setPendingImplementation(implementation.address);
   }
 
   describe("constructor", () => {
     it("sets admin to caller and addresses to 0", async () => {
-      expect(await unitroller.admin()).to.equal(await root.getAddress());
+      expect(await unitroller.admin()).to.equal(root.address);
       expect(await unitroller.pendingAdmin()).to.equal(constants.AddressZero);
       expect(await unitroller.pendingComptrollerImplementation()).to.equal(constants.AddressZero);
       expect(await unitroller.comptrollerImplementation()).to.equal(constants.AddressZero);
@@ -65,6 +66,7 @@ describe("Unitroller", () => {
           .withArgs(
             ComptrollerErrorReporter.Error.UNAUTHORIZED,
             ComptrollerErrorReporter.FailureInfo.SET_PENDING_IMPLEMENTATION_OWNER_CHECK,
+            0,
           );
       });
 
@@ -101,6 +103,7 @@ describe("Unitroller", () => {
           .withArgs(
             ComptrollerErrorReporter.Error.UNAUTHORIZED,
             ComptrollerErrorReporter.FailureInfo.ACCEPT_PENDING_IMPLEMENTATION_ADDRESS_CHECK,
+            0,
           );
       });
 
@@ -126,15 +129,13 @@ describe("Unitroller", () => {
       });
 
       it("Emit NewImplementation(oldImplementation, newImplementation)", async () => {
-        await expect(result)
-          .to.emit(unitroller, "NewImplementation")
-          .withArgs(brains.address, "0x0000000000000000000000000000000000000000");
+        await expect(result).to.emit(unitroller, "NewImplementation").withArgs(constants.AddressZero, brains.address);
       });
 
       it("Emit NewPendingImplementation(oldPendingImplementation, 0)", async () => {
         await expect(result)
           .to.emit(unitroller, "NewPendingImplementation")
-          .withArgs(brains.address, "0x0000000000000000000000000000000000000000");
+          .withArgs(brains.address, constants.AddressZero);
       });
     });
 

--- a/tests/hardhat/Unitroller/unitrollerTest.ts
+++ b/tests/hardhat/Unitroller/unitrollerTest.ts
@@ -60,7 +60,7 @@ describe("Unitroller", () => {
       });
 
       it("emits a failure log", async () => {
-        expect(result)
+        await expect(result)
           .to.emit(unitroller, "Failure")
           .withArgs(
             ComptrollerErrorReporter.Error.UNAUTHORIZED,
@@ -80,7 +80,7 @@ describe("Unitroller", () => {
       });
 
       it("emits NewPendingImplementation event", async () => {
-        expect(await unitroller._setPendingImplementation(brains.address))
+        await expect(await unitroller._setPendingImplementation(brains.address))
           .to.emit(unitroller, "NewPendingImplementation")
           .withArgs(constants.AddressZero, brains.address);
       });
@@ -96,7 +96,7 @@ describe("Unitroller", () => {
       });
 
       it("emits a failure log", async () => {
-        expect(result)
+        await expect(result)
           .to.emit(unitroller, "Failure")
           .withArgs(
             ComptrollerErrorReporter.Error.UNAUTHORIZED,
@@ -126,22 +126,13 @@ describe("Unitroller", () => {
       });
 
       it("Emit NewImplementation(oldImplementation, newImplementation)", async () => {
-        expect(result)
+        await expect(result)
           .to.emit(unitroller, "NewImplementation")
           .withArgs(brains.address, "0x0000000000000000000000000000000000000000");
-        // TODO:
-        // Does our log decoder expect it to come from the same contract?
-        // assert.toHaveLog(
-        //   result,
-        //   "NewImplementation",
-        //   {
-        //     newImplementation: brains.address,
-        //     oldImplementation: "0x0000000000000000000000000000000000000000"
-        //   });
       });
 
       it("Emit NewPendingImplementation(oldPendingImplementation, 0)", async () => {
-        expect(result)
+        await expect(result)
           .to.emit(unitroller, "NewPendingImplementation")
           .withArgs(brains.address, "0x0000000000000000000000000000000000000000");
       });

--- a/tests/hardhat/VAI/VAIController.ts
+++ b/tests/hardhat/VAI/VAIController.ts
@@ -455,7 +455,7 @@ describe("VAIController", async () => {
 
   describe("#setBaseRate", async () => {
     it("fails if access control does not allow the call", async () => {
-      accessControl.isAllowedToCall.whenCalledWith(user1.address, "setBaseRate(uint256)").returns(false);
+      accessControl.isAllowedToCall.whenCalledWith(wallet.address, "setBaseRate(uint256)").returns(false);
       await expect(vaiController.setBaseRate(42)).to.be.revertedWith("access denied");
     });
 
@@ -472,7 +472,7 @@ describe("VAIController", async () => {
 
   describe("#setFloatRate", async () => {
     it("fails if access control does not allow the call", async () => {
-      accessControl.isAllowedToCall.whenCalledWith(user1.address, "setFloatRate(uint256)").returns(false);
+      accessControl.isAllowedToCall.whenCalledWith(wallet.address, "setFloatRate(uint256)").returns(false);
       await expect(vaiController.setFloatRate(42)).to.be.revertedWith("access denied");
     });
 
@@ -489,7 +489,7 @@ describe("VAIController", async () => {
 
   describe("#setMintCap", async () => {
     it("fails if access control does not allow the call", async () => {
-      accessControl.isAllowedToCall.whenCalledWith(user1.address, "setMintCap(uint256)").returns(false);
+      accessControl.isAllowedToCall.whenCalledWith(wallet.address, "setMintCap(uint256)").returns(false);
       await expect(vaiController.setMintCap(42)).to.be.revertedWith("access denied");
     });
 
@@ -526,7 +526,9 @@ describe("VAIController", async () => {
 
   describe("#setAccessControl", async () => {
     it("reverts if called by non-admin", async () => {
-      await expect(vaiController.connect(user1).setAccessControl(accessControl.address)).to.be.revertedWith("only admin can");
+      await expect(vaiController.connect(user1).setAccessControl(accessControl.address)).to.be.revertedWith(
+        "only admin can",
+      );
     });
 
     it("reverts if ACM is zero address", async () => {

--- a/tests/hardhat/VAI/VAIController.ts
+++ b/tests/hardhat/VAI/VAIController.ts
@@ -288,7 +288,7 @@ describe("VAIController", async () => {
       await vai.connect(user2).approve(vaiController.address, ethers.constants.MaxUint256);
 
       const TEMP_BLOCKS_PER_YEAR = 100000;
-      vaiController.setBlocksPerYear(TEMP_BLOCKS_PER_YEAR);
+      await vaiController.setBlocksPerYear(TEMP_BLOCKS_PER_YEAR);
 
       await vaiController.setBaseRate(bigNumber17.mul(2));
       await vaiController.harnessSetBlockNumber(BigNumber.from(TEMP_BLOCKS_PER_YEAR));

--- a/tests/hardhat/VAI/VAIController.ts
+++ b/tests/hardhat/VAI/VAIController.ts
@@ -456,7 +456,7 @@ describe("VAIController", async () => {
   describe("#setBaseRate", async () => {
     it("fails if access control does not allow the call", async () => {
       accessControl.isAllowedToCall.whenCalledWith(user1.address, "setBaseRate(uint256)").returns(false);
-      expect(vaiController.setBaseRate(42)).to.be.revertedWith("access denied");
+      await expect(vaiController.setBaseRate(42)).to.be.revertedWith("access denied");
     });
 
     it("emits NewVAIBaseRate event", async () => {
@@ -473,7 +473,7 @@ describe("VAIController", async () => {
   describe("#setFloatRate", async () => {
     it("fails if access control does not allow the call", async () => {
       accessControl.isAllowedToCall.whenCalledWith(user1.address, "setFloatRate(uint256)").returns(false);
-      expect(vaiController.setFloatRate(42)).to.be.revertedWith("access denied");
+      await expect(vaiController.setFloatRate(42)).to.be.revertedWith("access denied");
     });
 
     it("emits NewVAIFloatRate event", async () => {
@@ -490,7 +490,7 @@ describe("VAIController", async () => {
   describe("#setMintCap", async () => {
     it("fails if access control does not allow the call", async () => {
       accessControl.isAllowedToCall.whenCalledWith(user1.address, "setMintCap(uint256)").returns(false);
-      expect(vaiController.setMintCap(42)).to.be.revertedWith("access denied");
+      await expect(vaiController.setMintCap(42)).to.be.revertedWith("access denied");
     });
 
     it("emits NewVAIMintCap event", async () => {
@@ -506,11 +506,11 @@ describe("VAIController", async () => {
 
   describe("#setReceiver", async () => {
     it("fails if called by a non-admin", async () => {
-      expect(vaiController.connect(user1).setReceiver(user1.address)).to.be.revertedWith("only admin can");
+      await expect(vaiController.connect(user1).setReceiver(user1.address)).to.be.revertedWith("only admin can");
     });
 
     it("reverts if the receiver is zero address", async () => {
-      expect(vaiController.setReceiver(constants.AddressZero)).to.be.revertedWith("invalid receiver address");
+      await expect(vaiController.setReceiver(constants.AddressZero)).to.be.revertedWith("invalid receiver address");
     });
 
     it("emits NewVAIReceiver event", async () => {
@@ -526,11 +526,11 @@ describe("VAIController", async () => {
 
   describe("#setAccessControl", async () => {
     it("reverts if called by non-admin", async () => {
-      expect(vaiController.connect(user1).setAccessControl(accessControl.address)).to.be.revertedWith("only admin can");
+      await expect(vaiController.connect(user1).setAccessControl(accessControl.address)).to.be.revertedWith("only admin can");
     });
 
     it("reverts if ACM is zero address", async () => {
-      expect(vaiController.setAccessControl(constants.AddressZero)).to.be.revertedWith("can't be zero address");
+      await expect(vaiController.setAccessControl(constants.AddressZero)).to.be.revertedWith("can't be zero address");
     });
 
     it("emits NewAccessControl event", async () => {

--- a/tests/hardhat/XVS/XVSVaultFix.ts
+++ b/tests/hardhat/XVS/XVSVaultFix.ts
@@ -150,7 +150,7 @@ describe("XVSVault", async () => {
       const withdrawalAmount = formatEther(amountDifference.add(reward));
       const balanceDifference = formatEther(BigNumber.from(balanceAfter).sub(BigNumber.from(balanceBefore)));
 
-      expect(tx)
+      await expect(tx)
         .to.emit(xvsVault, "ExecutedWithdrawal")
         .withArgs(affectedUserAddress, tokenAddress, poolId, Number(balanceDifference).toFixed(2));
       expect(Number(withdrawalAmount).toFixed(2)).equals(Number(balanceDifference).toFixed(2));


### PR DESCRIPTION
Some of our tests have missing awaits. It has been flagged by linter but as a warning, not as an error. However, dangling promises may cause test suite to succeed when it shouldn't, e.g. missing await before expecting an event would make the test succeed even if the event is not emitted. This PR adds the missing awaits where appropriate.