### PR TITLE
 [VEN-1571]: Fix openZeppelin swap router audit 

### DIFF
--- a/contracts/Swap/RouterHelper.sol
+++ b/contracts/Swap/RouterHelper.sol
@@ -290,6 +290,11 @@ abstract contract RouterHelper is IRouterHelper {
         return PancakeLibrary.getAmountIn(amountOut, reserveIn, reserveOut);
     }
 
+    /**
+     * @notice performs chained getAmountOut calculations on any number of pairs.
+     * @param amountIn The amount of tokens to swap.
+     * @param path Array with addresses of the underlying assets to be swapped.
+     */
     function getAmountsOut(
         uint256 amountIn,
         address[] memory path
@@ -297,6 +302,11 @@ abstract contract RouterHelper is IRouterHelper {
         return PancakeLibrary.getAmountsOut(factory, amountIn, path);
     }
 
+    /**
+     * @notice performs chained getAmountIn calculations on any number of pairs.
+     * @param amountOut amountOut The amount of the tokens needs to be as output token.
+     * @param path Array with addresses of the underlying assets to be swapped.
+     */
     function getAmountsIn(
         uint256 amountOut,
         address[] memory path

--- a/contracts/Swap/RouterHelper.sol
+++ b/contracts/Swap/RouterHelper.sol
@@ -126,7 +126,7 @@ abstract contract RouterHelper is IRouterHelper {
         }
     }
 
-    function _swapExactETHForTokens(
+    function _swapExactBNBForTokens(
         uint256 amountOutMin,
         address[] calldata path,
         address to,
@@ -151,7 +151,7 @@ abstract contract RouterHelper is IRouterHelper {
         }
     }
 
-    function _swapExactTokensForETH(
+    function _swapExactTokensForBNB(
         uint256 amountIn,
         uint256 amountOutMin,
         address[] calldata path,
@@ -218,7 +218,7 @@ abstract contract RouterHelper is IRouterHelper {
         emit SwapTokensForTokens(msg.sender, path, amounts);
     }
 
-    function _swapETHForExactTokens(
+    function _swapBNBForExactTokens(
         uint256 amountOut,
         address[] calldata path,
         address to
@@ -238,7 +238,7 @@ abstract contract RouterHelper is IRouterHelper {
         emit SwapBnbForTokens(msg.sender, path, amounts);
     }
 
-    function _swapTokensForExactETH(
+    function _swapTokensForExactBNB(
         uint256 amountOut,
         uint256 amountInMax,
         address[] calldata path,

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -460,7 +460,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 amountOutMin,
         address[] calldata path,
         uint256 deadline
-    ) external payable override nonReentrant ensure(deadline) ensurePath(path) {
+    ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         _swapExactTokensForETH(amountIn, amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
         uint256 balanceAfter = address(this).balance;
@@ -482,7 +482,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 amountOutMin,
         address[] calldata path,
         uint256 deadline
-    ) external payable override nonReentrant ensure(deadline) ensurePath(path) {
+    ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         _swapExactTokensForETH(amountIn, amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
         uint256 balanceAfter = address(this).balance;
@@ -507,7 +507,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 amountInMax,
         address[] calldata path,
         uint256 deadline
-    ) external payable override nonReentrant ensure(deadline) ensurePath(path) {
+    ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         _swapTokensForExactETH(amountOut, amountInMax, path, address(this));
         uint256 balanceAfter = address(this).balance;
@@ -527,7 +527,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 amountInMax,
         address[] calldata path,
         uint256 deadline
-    ) external payable override nonReentrant ensure(deadline) ensurePath(path) {
+    ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         uint256 amountOut = IVToken(vBNBAddress).borrowBalanceCurrent(msg.sender);
         _swapTokensForExactETH(amountOut, amountInMax, path, address(this));

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -812,7 +812,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
     }
 
     /**
-     * @notice Check if the balance of to minus the balanceBefore is greater than the amountOutMin.
+     * @notice Check if the balance of to minus the balanceBefore is greater or equal to the amountOutMin.
      * @param asset The address of the underlying token
      * @param balanceBefore Balance before the swap.
      * @param amountOutMin Min amount out threshold.

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -267,7 +267,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
      * @param deadline Unix timestamp after which the transaction will revert.
      * @dev Addresses of underlying assets should be ordered that first asset is the token we are swapping and second asset is the token we receive (and repay)
      */
-    function swapAndRepay(
+    function swapExactTokensForTokensAndRepay(
         address vTokenAddress,
         uint256 amountIn,
         uint256 amountOutMin,
@@ -291,7 +291,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
      * @param deadline Unix timestamp after which the transaction will revert.
      * @dev Addresses of underlying assets should be ordered that first asset is the token we are swapping and second asset is the token we receive (and repay)
      */
-    function swapAndRepayAtSupportingFee(
+    function swapExactTokensForTokensAndRepayAtSupportingFee(
         address vTokenAddress,
         uint256 amountIn,
         uint256 amountOutMin,

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -181,7 +181,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapExactETHForTokens(amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _supply(lastAsset, vTokenAddress, swapAmount);
     }
@@ -205,7 +205,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapExactETHForTokens(amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
         uint256 swapAmount = _checkForAmountOut(lastAsset, balanceBefore, amountOutMin, address(this));
         _supply(lastAsset, vTokenAddress, swapAmount);
     }
@@ -253,7 +253,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapETHForExactTokens(amountOut, path, address(this));
+        _swapBNBForExactTokens(amountOut, path, address(this));
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _supply(lastAsset, vTokenAddress, swapAmount);
     }
@@ -324,7 +324,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapExactETHForTokens(amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _repay(lastAsset, vTokenAddress, swapAmount);
     }
@@ -347,7 +347,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapExactETHForTokens(amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
         uint256 swapAmount = _checkForAmountOut(lastAsset, balanceBefore, amountOutMin, address(this));
         _repay(lastAsset, vTokenAddress, swapAmount);
     }
@@ -419,7 +419,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapETHForExactTokens(amountOut, path, address(this));
+        _swapBNBForExactTokens(amountOut, path, address(this));
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _repay(lastAsset, vTokenAddress, swapAmount);
     }
@@ -441,7 +441,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
         uint256 amountOut = IVToken(vTokenAddress).borrowBalanceCurrent(msg.sender);
-        _swapETHForExactTokens(amountOut, path, address(this));
+        _swapBNBForExactTokens(amountOut, path, address(this));
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _repay(lastAsset, vTokenAddress, swapAmount);
     }
@@ -462,7 +462,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
-        _swapExactTokensForETH(amountIn, amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
+        _swapExactTokensForBNB(amountIn, amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
         uint256 balanceAfter = address(this).balance;
         uint256 swapAmount = balanceAfter - balanceBefore;
         IVBNB(vBNBAddress).repayBorrowBehalf{ value: swapAmount }(msg.sender);
@@ -484,7 +484,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
-        _swapExactTokensForETH(amountIn, amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
+        _swapExactTokensForBNB(amountIn, amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
         uint256 balanceAfter = address(this).balance;
         uint256 swapAmount = balanceAfter - balanceBefore;
         if (swapAmount < amountOutMin) {
@@ -509,7 +509,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
-        _swapTokensForExactETH(amountOut, amountInMax, path, address(this));
+        _swapTokensForExactBNB(amountOut, amountInMax, path, address(this));
         uint256 balanceAfter = address(this).balance;
         uint256 swapAmount = balanceAfter - balanceBefore;
         IVBNB(vBNBAddress).repayBorrowBehalf{ value: swapAmount }(msg.sender);
@@ -530,7 +530,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
     ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         uint256 amountOut = IVToken(vBNBAddress).borrowBalanceCurrent(msg.sender);
-        _swapTokensForExactETH(amountOut, amountInMax, path, address(this));
+        _swapTokensForExactBNB(amountOut, amountInMax, path, address(this));
         uint256 balanceAfter = address(this).balance;
         uint256 swapAmount = balanceAfter - balanceBefore;
         IVBNB(vBNBAddress).repayBorrowBehalf{ value: swapAmount }(msg.sender);
@@ -610,7 +610,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         ensurePath(path)
         returns (uint256[] memory amounts)
     {
-        amounts = _swapExactETHForTokens(amountOutMin, path, to, TypesOfTokens.NON_SUPPORTING_FEE);
+        amounts = _swapExactBNBForTokens(amountOutMin, path, to, TypesOfTokens.NON_SUPPORTING_FEE);
     }
 
     /**
@@ -633,7 +633,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
     ) external payable virtual override nonReentrant ensure(deadline) ensurePath(path) returns (uint256 swapAmount) {
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(to);
-        _swapExactETHForTokens(amountOutMin, path, to, TypesOfTokens.SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, to, TypesOfTokens.SUPPORTING_FEE);
         swapAmount = _checkForAmountOut(lastAsset, balanceBefore, amountOutMin, to);
     }
 
@@ -656,7 +656,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         address to,
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) returns (uint256[] memory amounts) {
-        amounts = _swapExactTokensForETH(amountIn, amountOutMin, path, to, TypesOfTokens.NON_SUPPORTING_FEE);
+        amounts = _swapExactTokensForBNB(amountIn, amountOutMin, path, to, TypesOfTokens.NON_SUPPORTING_FEE);
     }
 
     /**
@@ -680,7 +680,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) returns (uint256 swapAmount) {
         uint256 balanceBefore = to.balance;
-        _swapExactTokensForETH(amountIn, amountOutMin, path, to, TypesOfTokens.SUPPORTING_FEE);
+        _swapExactTokensForBNB(amountIn, amountOutMin, path, to, TypesOfTokens.SUPPORTING_FEE);
         uint256 balanceAfter = to.balance;
         swapAmount = balanceAfter - balanceBefore;
         if (swapAmount < amountOutMin) {
@@ -736,7 +736,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         ensurePath(path)
         returns (uint256[] memory amounts)
     {
-        amounts = _swapETHForExactTokens(amountOut, path, to);
+        amounts = _swapBNBForExactTokens(amountOut, path, to);
     }
 
     /**
@@ -758,7 +758,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         address to,
         uint256 deadline
     ) external virtual override nonReentrant ensure(deadline) ensurePath(path) returns (uint256[] memory amounts) {
-        amounts = _swapTokensForExactETH(amountOut, amountInMax, path, to);
+        amounts = _swapTokensForExactBNB(amountOut, amountInMax, path, to);
     }
 
     /**

--- a/contracts/Swap/interfaces/CustomErrors.sol
+++ b/contracts/Swap/interfaces/CustomErrors.sol
@@ -14,7 +14,7 @@ error RepayError(address repayer, address vToken, uint256 errorCode);
 error WrongAddress(address expectedAdddress, address passedAddress);
 
 ///@notice Error thrown when deadline for swap has expired
-error SwapDeadlineExpire(uint256 deadline, uint256 currentBlock);
+error SwapDeadlineExpire(uint256 deadline, uint256 timestemp);
 
 ///@notice Error thrown where the input amount parameter for a token is 0
 error InsufficientInputAmount();
@@ -62,7 +62,7 @@ error SafeApproveFailed();
 error SafeTransferFailed();
 
 ///@notice Error thrown when transferFrom failed
-error TransferFromFailed();
+error SafeTransferFromFailed();
 
 ///@notice Error thrown when safeTransferETH failed
 error SafeTransferETHFailed();

--- a/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
+++ b/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
@@ -122,7 +122,7 @@ interface IPancakeSwapV2Router {
         uint256 deadline
     ) external payable;
 
-    function swapAndRepay(
+    function swapExactTokensForTokensAndRepay(
         address vTokenAddress,
         uint256 amountIn,
         uint256 amountOutMin,
@@ -130,7 +130,7 @@ interface IPancakeSwapV2Router {
         uint256 deadline
     ) external;
 
-    function swapAndRepayAtSupportingFee(
+    function swapExactTokensForTokensAndRepayAtSupportingFee(
         address vTokenAddress,
         uint256 amountIn,
         uint256 amountOutMin,

--- a/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
+++ b/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
@@ -179,25 +179,21 @@ interface IPancakeSwapV2Router {
         uint256 amountOutMin,
         address[] calldata path,
         uint256 deadline
-    ) external payable;
+    ) external;
 
     function swapExactTokensForBNBAndRepayAtSupportingFee(
         uint256 amountIn,
         uint256 amountOutMin,
         address[] calldata path,
         uint256 deadline
-    ) external payable;
+    ) external;
 
     function swapTokensForExactBNBAndRepay(
         uint256 amountOut,
         uint256 amountInMax,
         address[] calldata path,
         uint256 deadline
-    ) external payable;
+    ) external;
 
-    function swapTokensForFullBNBDebtAndRepay(
-        uint256 amountInMax,
-        address[] calldata path,
-        uint256 deadline
-    ) external payable;
+    function swapTokensForFullBNBDebtAndRepay(uint256 amountInMax, address[] calldata path, uint256 deadline) external;
 }

--- a/contracts/Swap/lib/TransferHelper.sol
+++ b/contracts/Swap/lib/TransferHelper.sol
@@ -26,7 +26,7 @@ library TransferHelper {
         // bytes4(keccak256(bytes('transferFrom(address,address,uint256)')));
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x23b872dd, from, to, value));
         if (!(success && (data.length == 0 || abi.decode(data, (bool))))) {
-            revert TransferFromFailed();
+            revert SafeTransferFromFailed();
         }
     }
 

--- a/tests/hardhat/Fork/swapTest.ts
+++ b/tests/hardhat/Fork/swapTest.ts
@@ -377,7 +377,13 @@ if (FORK_MAINNET) {
             expect(borrowBalance).equal(BORROW_AMOUNT);
             await swapRouter
               .connect(busdUser)
-              .swapExactTokensForTokensAndRepay(vUSDT.address, BORROW_AMOUNT + 1, BORROW_AMOUNT, [BUSD.address, USDT.address], deadline);
+              .swapExactTokensForTokensAndRepay(
+                vUSDT.address,
+                BORROW_AMOUNT + 1,
+                BORROW_AMOUNT,
+                [BUSD.address, USDT.address],
+                deadline,
+              );
             [, , borrowBalance] = await vUSDT.getAccountSnapshot(busdUser.address);
             expect(borrowBalance).equal(0);
           });

--- a/tests/hardhat/Fork/swapTest.ts
+++ b/tests/hardhat/Fork/swapTest.ts
@@ -377,7 +377,7 @@ if (FORK_MAINNET) {
             expect(borrowBalance).equal(BORROW_AMOUNT);
             await swapRouter
               .connect(busdUser)
-              .swapAndRepay(vUSDT.address, BORROW_AMOUNT + 1, BORROW_AMOUNT, [BUSD.address, USDT.address], deadline);
+              .swapExactTokensForTokensAndRepay(vUSDT.address, BORROW_AMOUNT + 1, BORROW_AMOUNT, [BUSD.address, USDT.address], deadline);
             [, , borrowBalance] = await vUSDT.getAccountSnapshot(busdUser.address);
             expect(borrowBalance).equal(0);
           });
@@ -795,7 +795,7 @@ if (FORK_MAINNET) {
 
             await swapRouter
               .connect(SFMUser)
-              .swapAndRepayAtSupportingFee(
+              .swapExactTokensForTokensAndRepayAtSupportingFee(
                 vBabyDoge.address,
                 100,
                 MIN_AMOUNT_OUT,

--- a/tests/hardhat/Swap/swapTest.ts
+++ b/tests/hardhat/Swap/swapTest.ts
@@ -752,9 +752,7 @@ describe("Swap Contract", () => {
       await expect(
         swapRouter
           .connect(user)
-          .swapTokensForExactBNBAndRepay(MIN_AMOUNT_OUT, SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline, {
-            value: SWAP_AMOUNT,
-          }),
+          .swapTokensForExactBNBAndRepay(MIN_AMOUNT_OUT, SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline),
       ).to.emit(swapRouter, "SwapTokensForBnb");
     });
 
@@ -765,9 +763,7 @@ describe("Swap Contract", () => {
       await expect(
         swapRouter
           .connect(user)
-          .swapTokensForFullBNBDebtAndRepay(SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline, {
-            value: SWAP_AMOUNT,
-          }),
+          .swapTokensForFullBNBDebtAndRepay(SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline),
       ).to.emit(swapRouter, "SwapTokensForBnb");
     });
   });

--- a/tests/hardhat/Swap/swapTest.ts
+++ b/tests/hardhat/Swap/swapTest.ts
@@ -590,7 +590,7 @@ describe("Swap Contract", () => {
     it("revert if deadline has passed", async () => {
       vToken.underlying.returns(tokenB.address);
       await expect(
-        swapRouter.swapAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], 0),
+        swapRouter.swapExactTokensForTokensAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], 0),
       ).to.be.revertedWithCustomError(swapRouter, "SwapDeadlineExpire");
     });
 
@@ -599,7 +599,7 @@ describe("Swap Contract", () => {
       await expect(
         swapRouter
           .connect(user)
-          .swapAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], deadline),
+          .swapExactTokensForTokensAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], deadline),
       ).to.emit(swapRouter, "SwapTokensForTokens");
     });
 
@@ -619,7 +619,7 @@ describe("Swap Contract", () => {
     it("revert if deadline has passed at supporting fee", async () => {
       vToken.underlying.returns(tokenB.address);
       await expect(
-        swapRouter.swapAndRepayAtSupportingFee(
+        swapRouter.swapExactTokensForTokensAndRepayAtSupportingFee(
           vToken.address,
           SWAP_AMOUNT,
           MIN_AMOUNT_OUT,
@@ -635,7 +635,7 @@ describe("Swap Contract", () => {
       expect(
         await swapRouter
           .connect(user)
-          .swapAndRepayAtSupportingFee(
+          .swapExactTokensForTokensAndRepayAtSupportingFee(
             vToken.address,
             SWAP_AMOUNT,
             parseUnits("0", 18),

--- a/tests/hardhat/Swap/swapTest.ts
+++ b/tests/hardhat/Swap/swapTest.ts
@@ -590,7 +590,13 @@ describe("Swap Contract", () => {
     it("revert if deadline has passed", async () => {
       vToken.underlying.returns(tokenB.address);
       await expect(
-        swapRouter.swapExactTokensForTokensAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], 0),
+        swapRouter.swapExactTokensForTokensAndRepay(
+          vToken.address,
+          SWAP_AMOUNT,
+          MIN_AMOUNT_OUT,
+          [tokenA.address, tokenB.address],
+          0,
+        ),
       ).to.be.revertedWithCustomError(swapRouter, "SwapDeadlineExpire");
     });
 
@@ -599,7 +605,13 @@ describe("Swap Contract", () => {
       await expect(
         swapRouter
           .connect(user)
-          .swapExactTokensForTokensAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], deadline),
+          .swapExactTokensForTokensAndRepay(
+            vToken.address,
+            SWAP_AMOUNT,
+            MIN_AMOUNT_OUT,
+            [tokenA.address, tokenB.address],
+            deadline,
+          ),
       ).to.emit(swapRouter, "SwapTokensForTokens");
     });
 


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->
This PR resolves OpenZepplein audit and fixes that we accepted to fix.

Audit fixes:
L-01. Missing Docstring
L-02. Locked BNB in contract
N-01. Misleading Docstirng
N-02. Naming can be improved
N-04 Confusing Use of ETH and BNB in Comments and Function Names
Resolves #<!-- issue id -->
VEN-1571

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
