### PR TITLE
[VEN-1577]: forbid zero alloc points in XVSVault

### DIFF
--- a/contracts/XVSVault/XVSVault.sol
+++ b/contracts/XVSVault/XVSVault.sol
@@ -161,6 +161,7 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
         _ensureNonzeroAddress(_rewardToken);
         _ensureNonzeroAddress(address(_token));
         require(address(xvsStore) != address(0), "Store contract address is empty");
+        require(_allocPoint > 0, "Alloc points must not be zero");
 
         massUpdatePools(_rewardToken);
 
@@ -204,12 +205,16 @@ contract XVSVault is XVSVaultStorage, ECDSA, AccessControlledV5 {
     function set(address _rewardToken, uint256 _pid, uint256 _allocPoint) external {
         _checkAccessAllowed("set(address,uint256,uint256)");
         _ensureValidPool(_rewardToken, _pid);
+
         massUpdatePools(_rewardToken);
 
         PoolInfo[] storage poolInfo = poolInfos[_rewardToken];
-        totalAllocPoints[_rewardToken] = totalAllocPoints[_rewardToken].sub(poolInfo[_pid].allocPoint).add(_allocPoint);
+        uint256 newTotalAllocPoints = totalAllocPoints[_rewardToken].sub(poolInfo[_pid].allocPoint).add(_allocPoint);
+        require(newTotalAllocPoints > 0, "Alloc points per reward token must not be zero");
+
         uint256 oldAllocPoints = poolInfo[_pid].allocPoint;
         poolInfo[_pid].allocPoint = _allocPoint;
+        totalAllocPoints[_rewardToken] = newTotalAllocPoints;
 
         emit PoolUpdated(_rewardToken, _pid, oldAllocPoints, _allocPoint);
     }


### PR DESCRIPTION
**Problem:** If a pool is added with alloc points equal to zero, and it is the only pool per reward token, total alloc points would be zero, leading to division by zero error in massUpdatePools. It is not possible to recover by calling `set()` with a different alloc points parameter because `set()` calls massUpdatePools under the hood. This can lead to denial of service because deposits, withdrawals and claims will not be possible either. Misconfiguring a pool using `set()` call can have the same impact if there is no other pool for this reward token.

**Solution:**

1. Forbid adding a pool with zero alloc points. This should never happen because it does not make sense from the business point of view.
2. **Allow** setting zero alloc points for existing pools **if** there is another pool with nonzero alloc points configured for this reward token; **forbid otherwise**. Although it is an unlikely use case, it's still valid from the business perspective, e.g. if we decide to discontinue rewarding XVS stakers with XVS but reward VAI stakers with XVS instead.