### PR TITLE
 [VEN-1571]: Fix openZeppelin swap router audit

### DIFF
--- a/contracts/Swap/RouterHelper.sol
+++ b/contracts/Swap/RouterHelper.sol
@@ -290,6 +290,11 @@ abstract contract RouterHelper is IRouterHelper {
         return PancakeLibrary.getAmountIn(amountOut, reserveIn, reserveOut);
     }
 
+    /**
+     * @notice performs chained getAmountOut calculations on any number of pairs.
+     * @param amountIn The amount of tokens to swap.
+     * @param path Array with addresses of the underlying assets to be swapped.
+     */
     function getAmountsOut(
         uint256 amountIn,
         address[] memory path
@@ -297,6 +302,11 @@ abstract contract RouterHelper is IRouterHelper {
         return PancakeLibrary.getAmountsOut(factory, amountIn, path);
     }
 
+    /**
+     * @notice performs chained getAmountIn calculations on any number of pairs.
+     * @param amountOut amountOut The amount of the tokens needs to be as output token.
+     * @param path Array with addresses of the underlying assets to be swapped.
+     */
     function getAmountsIn(
         uint256 amountOut,
         address[] memory path

--- a/contracts/Swap/RouterHelper.sol
+++ b/contracts/Swap/RouterHelper.sol
@@ -12,6 +12,7 @@ import "./interfaces/CustomErrors.sol";
 import "./IRouterHelper.sol";
 
 abstract contract RouterHelper is IRouterHelper {
+    /// @notice Select the type of Token for which either a supporting fee would be deducted or not at the time of transfer.
     enum TypesOfTokens {
         NON_SUPPORTING_FEE,
         SUPPORTING_FEE
@@ -55,7 +56,12 @@ abstract contract RouterHelper is IRouterHelper {
         factory = factory_;
     }
 
-    // requires the initial amount to have already been sent to the first pair
+    /**
+     * @notice Perform swap on the path(pairs)
+     * @param amounts Araay of amounts of tokens after performing the swap
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @param _to Recipient of the output tokens.
+     */
     function _swap(uint256[] memory amounts, address[] memory path, address _to) internal virtual {
         for (uint256 i; i < path.length - 1; ) {
             (address input, address output) = (path[i], path[i + 1]);
@@ -73,7 +79,13 @@ abstract contract RouterHelper is IRouterHelper {
     }
 
     // **** SWAP (supporting fee-on-transfer tokens) ****
-    // requires the initial amount to have already been sent to the first pair
+
+    /**
+     * @notice Perform swap on the path(pairs) for supporting fee
+     * @dev requires the initial amount to have already been sent to the first pair
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @param _to Recipient of the output tokens.
+     */
     function _swapSupportingFeeOnTransferTokens(address[] memory path, address _to) internal virtual {
         for (uint256 i; i < path.length - 1; ) {
             (address input, address output) = (path[i], path[i + 1]);
@@ -103,6 +115,15 @@ abstract contract RouterHelper is IRouterHelper {
         }
     }
 
+    /**
+     * @notice Swap token A for token B
+     * @param amountIn The amount of tokens to swap.
+     * @param amountOutMin Minimum amount of tokens to receive.
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @param to Recipient of the output tokens.
+     * @param swapFor TypesOfTokens, either supporing fee or non supporting fee
+     * @return amounts Array of amounts after performing swap for respective pairs in path
+     */
     function _swapExactTokensForTokens(
         uint256 amountIn,
         uint256 amountOutMin,
@@ -126,6 +147,14 @@ abstract contract RouterHelper is IRouterHelper {
         }
     }
 
+    /**
+     * @notice Swap exact BNB for token
+     * @param amountOutMin Minimum amount of tokens to receive.
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @param to Recipient of the output tokens.
+     * @param swapFor TypesOfTokens, either supporing fee or non supporting fee
+     * @return amounts Array of amounts after performing swap for respective pairs in path
+     */
     function _swapExactBNBForTokens(
         uint256 amountOutMin,
         address[] calldata path,
@@ -151,6 +180,15 @@ abstract contract RouterHelper is IRouterHelper {
         }
     }
 
+    /**
+     * @notice Swap token A for BNB
+     * @param amountIn The amount of tokens to swap.
+     * @param amountOutMin Minimum amount of BNB to receive.
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @param to Recipient of the output tokens.
+     * @param swapFor TypesOfTokens, either supporing fee or non supporting fee
+     * @return amounts Array of amounts after performing swap for respective pairs in path
+     */
     function _swapExactTokensForBNB(
         uint256 amountIn,
         uint256 amountOutMin,
@@ -189,7 +227,7 @@ abstract contract RouterHelper is IRouterHelper {
         }
         IWBNB(WBNB).withdraw(WBNBAmount);
         if (to != address(this)) {
-            TransferHelper.safeTransferETH(to, WBNBAmount);
+            TransferHelper.safeTransferBNB(to, WBNBAmount);
         }
         if (swapFor == TypesOfTokens.NON_SUPPORTING_FEE) {
             emit SwapTokensForBnb(msg.sender, path, amounts);
@@ -198,6 +236,14 @@ abstract contract RouterHelper is IRouterHelper {
         }
     }
 
+    /**
+     * @notice Swap token A for exact amount of token B
+     * @param amountOut The amount of the tokens needs to be as output token.
+     * @param amountInMax The maximum amount of input tokens that can be taken for the transaction not to revert.
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @param to Recipient of the output tokens.
+     * @return amounts Array of amounts after performing swap for respective pairs in path
+     **/
     function _swapTokensForExactTokens(
         uint256 amountOut,
         uint256 amountInMax,
@@ -218,6 +264,13 @@ abstract contract RouterHelper is IRouterHelper {
         emit SwapTokensForTokens(msg.sender, path, amounts);
     }
 
+    /**
+     * @notice Swap BNB for exact amount of token B
+     * @param amountOut The amount of the tokens needs to be as output token.
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @param to Recipient of the output tokens.
+     * @return amounts Array of amounts after performing swap for respective pairs in path
+     **/
     function _swapBNBForExactTokens(
         uint256 amountOut,
         address[] calldata path,
@@ -234,10 +287,18 @@ abstract contract RouterHelper is IRouterHelper {
         TransferHelper.safeTransfer(WBNB, PancakeLibrary.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, to);
         // refund dust eth, if any
-        if (msg.value > amounts[0]) TransferHelper.safeTransferETH(msg.sender, msg.value - amounts[0]);
+        if (msg.value > amounts[0]) TransferHelper.safeTransferBNB(msg.sender, msg.value - amounts[0]);
         emit SwapBnbForTokens(msg.sender, path, amounts);
     }
 
+    /**
+     * @notice Swap token A for exact BNB
+     * @param amountOut The amount of the tokens needs to be as output token.
+     * @param amountInMax The maximum amount of input tokens that can be taken for the transaction not to revert.
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @param to Recipient of the output tokens.
+     * @return amounts Array of amounts after performing swap for respective pairs in path
+     **/
     function _swapTokensForExactBNB(
         uint256 amountOut,
         uint256 amountInMax,
@@ -260,12 +321,20 @@ abstract contract RouterHelper is IRouterHelper {
         _swap(amounts, path, address(this));
         IWBNB(WBNB).withdraw(amounts[amounts.length - 1]);
         if (to != address(this)) {
-            TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+            TransferHelper.safeTransferBNB(to, amounts[amounts.length - 1]);
         }
         emit SwapTokensForBnb(msg.sender, path, amounts);
     }
 
     // **** LIBRARY FUNCTIONS ****
+
+    /**
+     * @notice Given some amount of an asset and pair reserves, returns an equivalent amount of the other asset
+     * @param amountA The amount of token A
+     * @param reserveA The amount of reserves for token A before swap
+     * @param reserveB The amount of reserves for token B before swap
+     * @return amountB An equivalent amount of the token B
+     **/
     function quote(
         uint256 amountA,
         uint256 reserveA,
@@ -274,6 +343,13 @@ abstract contract RouterHelper is IRouterHelper {
         return PancakeLibrary.quote(amountA, reserveA, reserveB);
     }
 
+    /**
+     * @notice Given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+     * @param amountIn The amount of token A need to swap
+     * @param reserveIn The amount of reserves for token A before swap
+     * @param reserveOut The amount of reserves for token B after swap
+     * @return amountOut The maximum output amount of the token B
+     **/
     function getAmountOut(
         uint256 amountIn,
         uint256 reserveIn,
@@ -282,6 +358,13 @@ abstract contract RouterHelper is IRouterHelper {
         return PancakeLibrary.getAmountOut(amountIn, reserveIn, reserveOut);
     }
 
+    /**
+     * @notice Given an output amount of an asset and pair reserves, returns a required input amount of the other asset
+     * @param amountOut The amount of token B after swap
+     * @param reserveIn The amount of reserves for token A before swap
+     * @param reserveOut The amount of reserves for token B after swap
+     * @return amountIn Required input amount of the token A
+     **/
     function getAmountIn(
         uint256 amountOut,
         uint256 reserveIn,

--- a/contracts/Swap/RouterHelper.sol
+++ b/contracts/Swap/RouterHelper.sol
@@ -286,7 +286,7 @@ abstract contract RouterHelper is IRouterHelper {
         IWBNB(WBNB).deposit{ value: amounts[0] }();
         TransferHelper.safeTransfer(WBNB, PancakeLibrary.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, to);
-        // refund dust eth, if any
+        // refund dust BNB, if any
         if (msg.value > amounts[0]) TransferHelper.safeTransferBNB(msg.sender, msg.value - amounts[0]);
         emit SwapBnbForTokens(msg.sender, path, amounts);
     }

--- a/contracts/Swap/RouterHelper.sol
+++ b/contracts/Swap/RouterHelper.sol
@@ -126,7 +126,7 @@ abstract contract RouterHelper is IRouterHelper {
         }
     }
 
-    function _swapExactETHForTokens(
+    function _swapExactBNBForTokens(
         uint256 amountOutMin,
         address[] calldata path,
         address to,
@@ -151,7 +151,7 @@ abstract contract RouterHelper is IRouterHelper {
         }
     }
 
-    function _swapExactTokensForETH(
+    function _swapExactTokensForBNB(
         uint256 amountIn,
         uint256 amountOutMin,
         address[] calldata path,
@@ -218,7 +218,7 @@ abstract contract RouterHelper is IRouterHelper {
         emit SwapTokensForTokens(msg.sender, path, amounts);
     }
 
-    function _swapETHForExactTokens(
+    function _swapBNBForExactTokens(
         uint256 amountOut,
         address[] calldata path,
         address to
@@ -238,7 +238,7 @@ abstract contract RouterHelper is IRouterHelper {
         emit SwapBnbForTokens(msg.sender, path, amounts);
     }
 
-    function _swapTokensForExactETH(
+    function _swapTokensForExactBNB(
         uint256 amountOut,
         uint256 amountInMax,
         address[] calldata path,

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -460,7 +460,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 amountOutMin,
         address[] calldata path,
         uint256 deadline
-    ) external payable override nonReentrant ensure(deadline) ensurePath(path) {
+    ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         _swapExactTokensForETH(amountIn, amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
         uint256 balanceAfter = address(this).balance;
@@ -482,7 +482,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 amountOutMin,
         address[] calldata path,
         uint256 deadline
-    ) external payable override nonReentrant ensure(deadline) ensurePath(path) {
+    ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         _swapExactTokensForETH(amountIn, amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
         uint256 balanceAfter = address(this).balance;
@@ -507,7 +507,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 amountInMax,
         address[] calldata path,
         uint256 deadline
-    ) external payable override nonReentrant ensure(deadline) ensurePath(path) {
+    ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         _swapTokensForExactETH(amountOut, amountInMax, path, address(this));
         uint256 balanceAfter = address(this).balance;
@@ -527,7 +527,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 amountInMax,
         address[] calldata path,
         uint256 deadline
-    ) external payable override nonReentrant ensure(deadline) ensurePath(path) {
+    ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         uint256 amountOut = IVToken(vBNBAddress).borrowBalanceCurrent(msg.sender);
         _swapTokensForExactETH(amountOut, amountInMax, path, address(this));

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -812,7 +812,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
     }
 
     /**
-     * @notice Check if the balance of to minus the balanceBefore is greater than the amountOutMin.
+     * @notice Check if the balance of to minus the balanceBefore is greater or equal to the amountOutMin.
      * @param asset The address of the underlying token
      * @param balanceBefore Balance before the swap.
      * @param amountOutMin Min amount out threshold.

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -267,7 +267,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
      * @param deadline Unix timestamp after which the transaction will revert.
      * @dev Addresses of underlying assets should be ordered that first asset is the token we are swapping and second asset is the token we receive (and repay)
      */
-    function swapAndRepay(
+    function swapExactTokensForTokensAndRepay(
         address vTokenAddress,
         uint256 amountIn,
         uint256 amountOutMin,
@@ -291,7 +291,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
      * @param deadline Unix timestamp after which the transaction will revert.
      * @dev Addresses of underlying assets should be ordered that first asset is the token we are swapping and second asset is the token we receive (and repay)
      */
-    function swapAndRepayAtSupportingFee(
+    function swapExactTokensForTokensAndRepayAtSupportingFee(
         address vTokenAddress,
         uint256 amountIn,
         uint256 amountOutMin,

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -654,7 +654,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
     }
 
     /**
-     * @notice Swaps an exact amount of ETH for as many output tokens as possible,
+     * @notice Swaps an exact amount of BNB for as many output tokens as possible,
      *         along the route determined by the path. The first element of path must be WBNB,
      *         the last is the output token, and any intermediate elements represent
      *         intermediate pairs to trade through (if, for example, a direct pair does not exist).

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -181,7 +181,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapExactETHForTokens(amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _supply(lastAsset, vTokenAddress, swapAmount);
     }
@@ -205,7 +205,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapExactETHForTokens(amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
         uint256 swapAmount = _checkForAmountOut(lastAsset, balanceBefore, amountOutMin, address(this));
         _supply(lastAsset, vTokenAddress, swapAmount);
     }
@@ -253,7 +253,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapETHForExactTokens(amountOut, path, address(this));
+        _swapBNBForExactTokens(amountOut, path, address(this));
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _supply(lastAsset, vTokenAddress, swapAmount);
     }
@@ -324,7 +324,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapExactETHForTokens(amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _repay(lastAsset, vTokenAddress, swapAmount);
     }
@@ -347,7 +347,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapExactETHForTokens(amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
         uint256 swapAmount = _checkForAmountOut(lastAsset, balanceBefore, amountOutMin, address(this));
         _repay(lastAsset, vTokenAddress, swapAmount);
     }
@@ -419,7 +419,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         _ensureVTokenChecks(vTokenAddress, path[path.length - 1]);
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
-        _swapETHForExactTokens(amountOut, path, address(this));
+        _swapBNBForExactTokens(amountOut, path, address(this));
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _repay(lastAsset, vTokenAddress, swapAmount);
     }
@@ -441,7 +441,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(address(this));
         uint256 amountOut = IVToken(vTokenAddress).borrowBalanceCurrent(msg.sender);
-        _swapETHForExactTokens(amountOut, path, address(this));
+        _swapBNBForExactTokens(amountOut, path, address(this));
         uint256 swapAmount = _getSwapAmount(lastAsset, balanceBefore);
         _repay(lastAsset, vTokenAddress, swapAmount);
     }
@@ -462,7 +462,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
-        _swapExactTokensForETH(amountIn, amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
+        _swapExactTokensForBNB(amountIn, amountOutMin, path, address(this), TypesOfTokens.NON_SUPPORTING_FEE);
         uint256 balanceAfter = address(this).balance;
         uint256 swapAmount = balanceAfter - balanceBefore;
         IVBNB(vBNBAddress).repayBorrowBehalf{ value: swapAmount }(msg.sender);
@@ -484,7 +484,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
-        _swapExactTokensForETH(amountIn, amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
+        _swapExactTokensForBNB(amountIn, amountOutMin, path, address(this), TypesOfTokens.SUPPORTING_FEE);
         uint256 balanceAfter = address(this).balance;
         uint256 swapAmount = balanceAfter - balanceBefore;
         if (swapAmount < amountOutMin) {
@@ -509,7 +509,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
-        _swapTokensForExactETH(amountOut, amountInMax, path, address(this));
+        _swapTokensForExactBNB(amountOut, amountInMax, path, address(this));
         uint256 balanceAfter = address(this).balance;
         uint256 swapAmount = balanceAfter - balanceBefore;
         IVBNB(vBNBAddress).repayBorrowBehalf{ value: swapAmount }(msg.sender);
@@ -530,7 +530,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
     ) external override nonReentrant ensure(deadline) ensurePath(path) {
         uint256 balanceBefore = address(this).balance;
         uint256 amountOut = IVToken(vBNBAddress).borrowBalanceCurrent(msg.sender);
-        _swapTokensForExactETH(amountOut, amountInMax, path, address(this));
+        _swapTokensForExactBNB(amountOut, amountInMax, path, address(this));
         uint256 balanceAfter = address(this).balance;
         uint256 swapAmount = balanceAfter - balanceBefore;
         IVBNB(vBNBAddress).repayBorrowBehalf{ value: swapAmount }(msg.sender);
@@ -610,7 +610,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         ensurePath(path)
         returns (uint256[] memory amounts)
     {
-        amounts = _swapExactETHForTokens(amountOutMin, path, to, TypesOfTokens.NON_SUPPORTING_FEE);
+        amounts = _swapExactBNBForTokens(amountOutMin, path, to, TypesOfTokens.NON_SUPPORTING_FEE);
     }
 
     /**
@@ -633,7 +633,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
     ) external payable virtual override nonReentrant ensure(deadline) ensurePath(path) returns (uint256 swapAmount) {
         address lastAsset = path[path.length - 1];
         uint256 balanceBefore = IERC20(lastAsset).balanceOf(to);
-        _swapExactETHForTokens(amountOutMin, path, to, TypesOfTokens.SUPPORTING_FEE);
+        _swapExactBNBForTokens(amountOutMin, path, to, TypesOfTokens.SUPPORTING_FEE);
         swapAmount = _checkForAmountOut(lastAsset, balanceBefore, amountOutMin, to);
     }
 
@@ -656,7 +656,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         address to,
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) returns (uint256[] memory amounts) {
-        amounts = _swapExactTokensForETH(amountIn, amountOutMin, path, to, TypesOfTokens.NON_SUPPORTING_FEE);
+        amounts = _swapExactTokensForBNB(amountIn, amountOutMin, path, to, TypesOfTokens.NON_SUPPORTING_FEE);
     }
 
     /**
@@ -680,7 +680,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 deadline
     ) external override nonReentrant ensure(deadline) ensurePath(path) returns (uint256 swapAmount) {
         uint256 balanceBefore = to.balance;
-        _swapExactTokensForETH(amountIn, amountOutMin, path, to, TypesOfTokens.SUPPORTING_FEE);
+        _swapExactTokensForBNB(amountIn, amountOutMin, path, to, TypesOfTokens.SUPPORTING_FEE);
         uint256 balanceAfter = to.balance;
         swapAmount = balanceAfter - balanceBefore;
         if (swapAmount < amountOutMin) {
@@ -736,7 +736,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         ensurePath(path)
         returns (uint256[] memory amounts)
     {
-        amounts = _swapETHForExactTokens(amountOut, path, to);
+        amounts = _swapBNBForExactTokens(amountOut, path, to);
     }
 
     /**
@@ -758,7 +758,7 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         address to,
         uint256 deadline
     ) external virtual override nonReentrant ensure(deadline) ensurePath(path) returns (uint256[] memory amounts) {
-        amounts = _swapTokensForExactETH(amountOut, amountInMax, path, to);
+        amounts = _swapTokensForExactBNB(amountOut, amountInMax, path, to);
     }
 
     /**

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -941,6 +941,6 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
         uint256 vBNBBalanceBefore = IVBNB(vBNBAddress).balanceOf(address(this));
         IVBNB(vBNBAddress).mint{ value: swapAmount }();
         uint256 vBNBBalanceAfter = IVBNB(vBNBAddress).balanceOf(address(this));
-        IVBNB(vBNBAddress).transfer(msg.sender, (vBNBBalanceAfter - vBNBBalanceBefore));
+        IERC20(vBNBAddress).safeTransfer(msg.sender, (vBNBBalanceAfter - vBNBBalanceBefore));
     }
 }

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -267,7 +267,6 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
      * @dev Addresses of underlying assets should be ordered that first asset is the token we are swapping and second asset is the token we receive
      * @dev In case of swapping native BNB the first asset in path array should be the wBNB address
      */
-
     function swapExactTokensForBNBAndSupply(
         uint256 amountIn,
         uint256 amountOutMin,
@@ -290,7 +289,6 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
      * @dev Addresses of underlying assets should be ordered that first asset is the token we are swapping and second asset is the token we receive
      * @dev In case of swapping native BNB the first asset in path array should be the wBNB address
      */
-
     function swapExactTokensForBNBAndSupplyAtSupportingFee(
         uint256 amountIn,
         uint256 amountOutMin,
@@ -316,7 +314,6 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
      * @dev Addresses of underlying assets should be ordered that first asset is the token we are swapping and second asset is the token we receive
      * @dev In case of swapping native BNB the first asset in path array should be the wBNB address
      */
-
     function swapTokensForExactBNBAndSupply(
         uint256 amountOut,
         uint256 amountInMax,
@@ -940,7 +937,6 @@ contract SwapRouter is Ownable2Step, RouterHelper, IPancakeSwapV2Router {
      * @notice Mint vBNB tokens to the market then transfer them to user
      * @param swapAmount Swapped BNB amount
      */
-
     function _mintVBNBandTransfer(uint256 swapAmount) internal {
         uint256 vBNBBalanceBefore = IVBNB(vBNBAddress).balanceOf(address(this));
         IVBNB(vBNBAddress).mint{ value: swapAmount }();

--- a/contracts/Swap/interfaces/CustomErrors.sol
+++ b/contracts/Swap/interfaces/CustomErrors.sol
@@ -64,8 +64,8 @@ error SafeTransferFailed();
 ///@notice Error thrown when transferFrom failed
 error SafeTransferFromFailed();
 
-///@notice Error thrown when safeTransferETH failed
-error SafeTransferETHFailed();
+///@notice Error thrown when safeTransferBNB failed
+error SafeTransferBNBFailed();
 
 ///@notice Error thrown when reentrant check fails
 error ReentrantCheck();

--- a/contracts/Swap/interfaces/CustomErrors.sol
+++ b/contracts/Swap/interfaces/CustomErrors.sol
@@ -14,7 +14,7 @@ error RepayError(address repayer, address vToken, uint256 errorCode);
 error WrongAddress(address expectedAdddress, address passedAddress);
 
 ///@notice Error thrown when deadline for swap has expired
-error SwapDeadlineExpire(uint256 deadline, uint256 currentBlock);
+error SwapDeadlineExpire(uint256 deadline, uint256 timestemp);
 
 ///@notice Error thrown where the input amount parameter for a token is 0
 error InsufficientInputAmount();
@@ -62,7 +62,7 @@ error SafeApproveFailed();
 error SafeTransferFailed();
 
 ///@notice Error thrown when transferFrom failed
-error TransferFromFailed();
+error SafeTransferFromFailed();
 
 ///@notice Error thrown when safeTransferETH failed
 error SafeTransferETHFailed();

--- a/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
+++ b/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
@@ -122,7 +122,7 @@ interface IPancakeSwapV2Router {
         uint256 deadline
     ) external payable;
 
-    function swapAndRepay(
+    function swapExactTokensForTokensAndRepay(
         address vTokenAddress,
         uint256 amountIn,
         uint256 amountOutMin,
@@ -130,7 +130,7 @@ interface IPancakeSwapV2Router {
         uint256 deadline
     ) external;
 
-    function swapAndRepayAtSupportingFee(
+    function swapExactTokensForTokensAndRepayAtSupportingFee(
         address vTokenAddress,
         uint256 amountIn,
         uint256 amountOutMin,

--- a/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
+++ b/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
@@ -116,6 +116,27 @@ interface IPancakeSwapV2Router {
         uint256 deadline
     ) external payable;
 
+    function swapExactTokensForBNBAndSupply(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        uint256 deadline
+    ) external;
+
+    function swapExactTokensForBNBAndSupplyAtSupportingFee(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        uint256 deadline
+    ) external;
+
+    function swapTokensForExactBNBAndSupply(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        uint256 deadline
+    ) external;
+
     function swapBNBForFullTokenDebtAndRepay(
         address vTokenAddress,
         address[] calldata path,

--- a/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
+++ b/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
@@ -179,25 +179,21 @@ interface IPancakeSwapV2Router {
         uint256 amountOutMin,
         address[] calldata path,
         uint256 deadline
-    ) external payable;
+    ) external;
 
     function swapExactTokensForBNBAndRepayAtSupportingFee(
         uint256 amountIn,
         uint256 amountOutMin,
         address[] calldata path,
         uint256 deadline
-    ) external payable;
+    ) external;
 
     function swapTokensForExactBNBAndRepay(
         uint256 amountOut,
         uint256 amountInMax,
         address[] calldata path,
         uint256 deadline
-    ) external payable;
+    ) external;
 
-    function swapTokensForFullBNBDebtAndRepay(
-        uint256 amountInMax,
-        address[] calldata path,
-        uint256 deadline
-    ) external payable;
+    function swapTokensForFullBNBDebtAndRepay(uint256 amountInMax, address[] calldata path, uint256 deadline) external;
 }

--- a/contracts/Swap/interfaces/IVBNB.sol
+++ b/contracts/Swap/interfaces/IVBNB.sol
@@ -7,6 +7,4 @@ interface IVBNB {
     function mint() external payable;
 
     function balanceOf(address owner) external view returns (uint256);
-
-    function transfer(address dst, uint256 amount) external returns (bool);
 }

--- a/contracts/Swap/interfaces/IVBNB.sol
+++ b/contracts/Swap/interfaces/IVBNB.sol
@@ -3,4 +3,10 @@ pragma solidity 0.8.13;
 
 interface IVBNB {
     function repayBorrowBehalf(address borrower) external payable;
+
+    function mint() external payable;
+
+    function balanceOf(address owner) external view returns (uint256);
+
+    function transfer(address dst, uint256 amount) external returns (bool);
 }

--- a/contracts/Swap/lib/PancakeLibrary.sol
+++ b/contracts/Swap/lib/PancakeLibrary.sol
@@ -5,7 +5,12 @@ import "../interfaces/IPancakePair.sol";
 import "../interfaces/CustomErrors.sol";
 
 library PancakeLibrary {
-    // returns sorted token addresses, used to handle return values from pairs sorted in this order
+    /**
+     * @notice Used to handle return values from pairs sorted in this order
+     * @param tokenA The address of token A
+     * @param tokenB The address of token B
+     * @return token0 token1 Sorted token addresses
+     **/
     function sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
         if (tokenA == tokenB) {
             revert IdenticalAddresses();
@@ -16,7 +21,13 @@ library PancakeLibrary {
         }
     }
 
-    // calculates the CREATE2 address for a pair without making any external calls
+    /**
+     * @notice Calculates the CREATE2 address for a pair without making any external calls
+     * @param factory Address of the pancake swap factory
+     * @param tokenA The address of token A
+     * @param tokenB The address of token B
+     * @return pair Address for a pair
+     **/
     function pairFor(address factory, address tokenA, address tokenB) internal pure returns (address pair) {
         (address token0, address token1) = sortTokens(tokenA, tokenB);
         pair = address(
@@ -35,7 +46,13 @@ library PancakeLibrary {
         );
     }
 
-    // fetches and sorts the reserves for a pair
+    /**
+     * @notice Fetches and sorts the reserves for a pair
+     * @param factory Address of the pancake swap factory
+     * @param tokenA The address of token A
+     * @param tokenB The address of token B
+     * @return reserveA reserveB Reserves for the token A and token B
+     **/
     function getReserves(
         address factory,
         address tokenA,
@@ -47,7 +64,13 @@ library PancakeLibrary {
         (reserveA, reserveB) = tokenA == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
     }
 
-    // given some amount of an asset and pair reserves, returns an equivalent amount of the other asset
+    /**
+     * @notice Given some amount of an asset and pair reserves, returns an equivalent amount of the other asset
+     * @param amountA The amount of token A
+     * @param reserveA The amount of reserves for token A before swap
+     * @param reserveB The amount of reserves for token B before swap
+     * @return amountB An equivalent amount of the token B
+     **/
     function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) internal pure returns (uint256 amountB) {
         if (amountA == 0) {
             revert InsufficientInputAmount();
@@ -57,7 +80,13 @@ library PancakeLibrary {
         amountB = (amountA * reserveB) / reserveA;
     }
 
-    // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+    /**
+     * @notice Given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+     * @param amountIn The amount of token A need to swap
+     * @param reserveIn The amount of reserves for token A before swap
+     * @param reserveOut The amount of reserves for token B after swap
+     * @return amountOut The maximum output amount of the token B
+     **/
     function getAmountOut(
         uint256 amountIn,
         uint256 reserveIn,
@@ -74,7 +103,13 @@ library PancakeLibrary {
         amountOut = numerator / denominator;
     }
 
-    // given an output amount of an asset and pair reserves, returns a required input amount of the other asset
+    /**
+     * @notice Given an output amount of an asset and pair reserves, returns a required input amount of the other asset
+     * @param amountOut The amount of token B after swap
+     * @param reserveIn The amount of reserves for token A before swap
+     * @param reserveOut The amount of reserves for token B after swap
+     * @return amountIn Required input amount of the token A
+     **/
     function getAmountIn(
         uint256 amountOut,
         uint256 reserveIn,
@@ -90,7 +125,13 @@ library PancakeLibrary {
         amountIn = (numerator / denominator) + 1;
     }
 
-    // performs chained getAmountOut calculations on any number of pairs
+    /**
+     * @notice Performs chained getAmountOut calculations on any number of pairs
+     * @param factory Address of the pancake swap factory
+     * @param amountIn The amount of tokens to swap.
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @return amounts Array of amounts after performing swap for respective pairs in path
+     **/
     function getAmountsOut(
         address factory,
         uint256 amountIn,
@@ -110,7 +151,13 @@ library PancakeLibrary {
         }
     }
 
-    // performs chained getAmountIn calculations on any number of pairs
+    /**
+     * @notice Performs chained getAmountIn calculations on any number of pairs
+     * @param factory Address of the pancake swap factory
+     * @param amountOut The amount of the tokens needs to be as output token.
+     * @param path Array with addresses of the underlying assets to be swapped
+     * @return amounts Array of amounts after performing swap for respective pairs in path
+     **/
     function getAmountsIn(
         address factory,
         uint256 amountOut,

--- a/contracts/Swap/lib/TransferHelper.sol
+++ b/contracts/Swap/lib/TransferHelper.sol
@@ -26,7 +26,7 @@ library TransferHelper {
         // bytes4(keccak256(bytes('transferFrom(address,address,uint256)')));
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x23b872dd, from, to, value));
         if (!(success && (data.length == 0 || abi.decode(data, (bool))))) {
-            revert TransferFromFailed();
+            revert SafeTransferFromFailed();
         }
     }
 

--- a/contracts/Swap/lib/TransferHelper.sol
+++ b/contracts/Swap/lib/TransferHelper.sol
@@ -6,6 +6,12 @@ import "../interfaces/CustomErrors.sol";
 
 // helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false
 library TransferHelper {
+    /**
+     * @dev `value` as the allowance of `spender` over the caller's tokens.
+     * @param token Address of the token
+     * @param to Address of the spender
+     * @param value Amount as allowance
+     */
     function safeApprove(address token, address to, uint256 value) internal {
         // bytes4(keccak256(bytes('approve(address,uint256)')));
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x095ea7b3, to, value));
@@ -14,6 +20,13 @@ library TransferHelper {
         }
     }
 
+    /**
+     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     * @param token Address of the token
+     * @param to Address of the receiver
+     * @param value Amount need to transfer
+     */
     function safeTransfer(address token, address to, uint256 value) internal {
         // bytes4(keccak256(bytes('transfer(address,uint256)')));
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0xa9059cbb, to, value));
@@ -22,6 +35,14 @@ library TransferHelper {
         }
     }
 
+    /**
+     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the
+     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.
+     * @param token Address of the token
+     * @param from Address of the asset'sowner
+     * @param to Address of the receiver
+     * @param value Amount need to transfer
+     */
     function safeTransferFrom(address token, address from, address to, uint256 value) internal {
         // bytes4(keccak256(bytes('transferFrom(address,address,uint256)')));
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x23b872dd, from, to, value));
@@ -30,10 +51,16 @@ library TransferHelper {
         }
     }
 
-    function safeTransferETH(address to, uint256 value) internal {
+    /**
+     * @dev Transfer `value` amount of `BNB` from the calling contract to `to`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     * @param to Address of the receiver
+     * @param value Amount need to transfer
+     */
+    function safeTransferBNB(address to, uint256 value) internal {
         (bool success, ) = to.call{ value: value }(new bytes(0));
         if (!success) {
-            revert SafeTransferETHFailed();
+            revert SafeTransferBNBFailed();
         }
     }
 }

--- a/script/deploy/swapRouter.js
+++ b/script/deploy/swapRouter.js
@@ -1,0 +1,28 @@
+const hre = require("hardhat");
+const ethers = hre.ethers;
+
+const Mainnet = require("../../networks/mainnet.json");
+const Testnet = require("../../networks/testnet.json");
+
+const main = async () => {
+  const signers = await ethers.getSigners();
+  const deployer = await signers[0].getAddress();
+  const swapRouterContractFactory = await ethers.getContractFactory("SwapRouter");
+
+  const network = process.env.FORK_MAINNET === "true" ? Mainnet : Testnet;
+
+  const WBNB = network.Contracts.WBNB;
+  const FACTORY = network.Contracts.pancakeFactory;
+  const COMPTROLLER = network.Contracts.Unitroller;
+  const VBNB = network.Contracts.vBNB;
+
+  const swapRouterDeploy = await swapRouterContractFactory.deploy(WBNB, FACTORY, COMPTROLLER, VBNB);
+  await swapRouterDeploy.deployed();
+
+  console.log(`deployer: ${deployer} deployed ComptrollerLens at address: ${swapRouterDeploy.address}`);
+};
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/hardhat/Fork/swapTest.ts
+++ b/tests/hardhat/Fork/swapTest.ts
@@ -377,7 +377,13 @@ if (FORK_MAINNET) {
             expect(borrowBalance).equal(BORROW_AMOUNT);
             await swapRouter
               .connect(busdUser)
-              .swapExactTokensForTokensAndRepay(vUSDT.address, BORROW_AMOUNT + 1, BORROW_AMOUNT, [BUSD.address, USDT.address], deadline);
+              .swapExactTokensForTokensAndRepay(
+                vUSDT.address,
+                BORROW_AMOUNT + 1,
+                BORROW_AMOUNT,
+                [BUSD.address, USDT.address],
+                deadline,
+              );
             [, , borrowBalance] = await vUSDT.getAccountSnapshot(busdUser.address);
             expect(borrowBalance).equal(0);
           });

--- a/tests/hardhat/Fork/swapTest.ts
+++ b/tests/hardhat/Fork/swapTest.ts
@@ -328,6 +328,42 @@ if (FORK_MAINNET) {
             expect(currBalance).greaterThan(prevBalance);
           });
 
+          it("swap exact tokenA -> BNB --> supply", async () => {
+            const prevBalance = await vBNB.balanceOf(busdUser.address);
+            const deadline = await getValidDeadline();
+            await swapRouter
+              .connect(busdUser)
+              .swapTokensForExactBNBAndSupply(SWAP_BNB_AMOUNT, 277, [BUSD.address, wBNB.address], deadline);
+            const currBalance = await vBNB.balanceOf(busdUser.address);
+            expect(currBalance).greaterThan(prevBalance);
+          });
+
+          it("should swap Exact token -> BNB --> supply", async () => {
+            await USDT.connect(usdtUser).transfer(vUSDT.address, 1000);
+            const deadline = await getValidDeadline();
+            await swapRouter
+              .connect(busdUser)
+              .swapExactTokensForTokensAndSupply(
+                vBUSD.address,
+                SWAP_AMOUNT,
+                MIN_AMOUNT_OUT,
+                [USDT.address, BUSD.address],
+                deadline,
+              );
+            await vBNB.connect(busdUser).borrow(parseUnits("5", 0));
+            const borrowBalancePrev = await vBNB.balanceOf(busdUser.address);
+            await swapRouter
+              .connect(busdUser)
+              .swapExactTokensForBNBAndSupply(
+                parseUnits("1500", 0),
+                parseUnits("4", 0),
+                [USDT.address, wBNB.address],
+                deadline,
+              );
+            const borrowBalanceAfter = await vBNB.balanceOf(busdUser.address);
+            expect(borrowBalanceAfter).greaterThan(borrowBalancePrev);
+          });
+
           it("swap BNB -> token --> supply token", async () => {
             const prevBalance = await vBUSD.balanceOf(usdtUser.address);
             const deadline = await getValidDeadline();
@@ -779,6 +815,26 @@ if (FORK_MAINNET) {
 
             const currBalance = await vSFM.balanceOf(wBNBUser.address);
             expect(currBalance).greaterThan(prevBalance);
+          });
+
+          it("swap ExactTokens -> BNB and supply at supportingFee", async () => {
+            const deadline = await getValidDeadline();
+            await swapRouter
+              .connect(BabyDogeUser)
+              .swapExactTokensForTokensAndSupplyAtSupportingFee(
+                vSFM.address,
+                10000000000000,
+                1000,
+                [BabyDoge.address, SFM.address],
+                deadline,
+              );
+            await expect(vBNB.connect(BabyDogeUser).borrow(2)).to.emit(vBNB, "Borrow");
+            const borrowBalancePrev = await vBNB.balanceOf(BabyDogeUser.address);
+            await swapRouter
+              .connect(BabyDogeUser)
+              .swapExactTokensForBNBAndSupplyAtSupportingFee(500, 2, [BabyDoge.address, wBNB.address], deadline);
+            const borrowBalanceAfter = await vBNB.balanceOf(BabyDogeUser.address);
+            expect(borrowBalanceAfter).greaterThan(borrowBalancePrev);
           });
 
           it("swap tokenA -> tokenB --> repay tokenB at supporting fee", async () => {

--- a/tests/hardhat/Fork/swapTest.ts
+++ b/tests/hardhat/Fork/swapTest.ts
@@ -377,7 +377,7 @@ if (FORK_MAINNET) {
             expect(borrowBalance).equal(BORROW_AMOUNT);
             await swapRouter
               .connect(busdUser)
-              .swapAndRepay(vUSDT.address, BORROW_AMOUNT + 1, BORROW_AMOUNT, [BUSD.address, USDT.address], deadline);
+              .swapExactTokensForTokensAndRepay(vUSDT.address, BORROW_AMOUNT + 1, BORROW_AMOUNT, [BUSD.address, USDT.address], deadline);
             [, , borrowBalance] = await vUSDT.getAccountSnapshot(busdUser.address);
             expect(borrowBalance).equal(0);
           });
@@ -795,7 +795,7 @@ if (FORK_MAINNET) {
 
             await swapRouter
               .connect(SFMUser)
-              .swapAndRepayAtSupportingFee(
+              .swapExactTokensForTokensAndRepayAtSupportingFee(
                 vBabyDoge.address,
                 100,
                 MIN_AMOUNT_OUT,

--- a/tests/hardhat/Swap/swapTest.ts
+++ b/tests/hardhat/Swap/swapTest.ts
@@ -580,6 +580,33 @@ describe("Swap Contract", () => {
           }),
       ).to.emit(swapRouter, "SwapBnbForTokens");
     });
+
+    it("Exact tokens -> BNB and supply", async () => {
+      const deadline = await getValidDeadline();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      vToken.underlying.returns(wBNB.address);
+      await expect(
+        swapRouter
+          .connect(user)
+          .swapExactTokensForBNBAndSupply(SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, wBNB.address], deadline),
+      );
+    });
+
+    it("Exact tokens -> BNB and supply at supporting fee", async () => {
+      const deadline = await getValidDeadline();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      vToken.underlying.returns(wBNB.address);
+      expect(
+        await swapRouter
+          .connect(user)
+          .swapExactTokensForBNBAndSupplyAtSupportingFee(
+            SWAP_AMOUNT,
+            parseUnits("0", 18),
+            [dToken.address, wBNB.address],
+            deadline,
+          ),
+      );
+    });
   });
 
   describe("Repay", () => {
@@ -641,7 +668,7 @@ describe("Swap Contract", () => {
       ).to.be.revertedWithCustomError(swapRouter, "SwapDeadlineExpire");
     });
 
-    it("swap tokenA -> tokenB --> supply tokenB at supporting fee", async () => {
+    it("swap tokenA -> tokenB --> reapy tokenB at supporting fee", async () => {
       const deadline = await getValidDeadline();
       vToken.underlying.returns(tokenB.address);
       expect(
@@ -657,7 +684,7 @@ describe("Swap Contract", () => {
       );
     });
 
-    it("swap BNB -> token --> supply token at supporting fee", async () => {
+    it("swap BNB -> token --> repay token at supporting fee", async () => {
       const deadline = await getValidDeadline();
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       vToken.underlying.returns(dToken.address);
@@ -766,6 +793,15 @@ describe("Swap Contract", () => {
           .connect(user)
           .swapTokensForExactBNBAndRepay(MIN_AMOUNT_OUT, SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline),
       ).to.emit(swapRouter, "SwapTokensForBnb");
+    });
+
+    it("Tokens -> Exact BNB and supply", async () => {
+      const deadline = await getValidDeadline();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      vToken.underlying.returns(wBNB.address);
+      await swapRouter
+        .connect(user)
+        .swapTokensForExactBNBAndSupply(MIN_AMOUNT_OUT, SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline);
     });
 
     it("Tokens -> full debt of BNB", async () => {

--- a/tests/hardhat/Swap/swapTest.ts
+++ b/tests/hardhat/Swap/swapTest.ts
@@ -596,8 +596,8 @@ describe("Swap Contract", () => {
       const deadline = await getValidDeadline();
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       vToken.underlying.returns(wBNB.address);
-      expect(
-        await swapRouter
+      await expect(
+        swapRouter
           .connect(user)
           .swapExactTokensForBNBAndSupplyAtSupportingFee(
             SWAP_AMOUNT,
@@ -799,9 +799,11 @@ describe("Swap Contract", () => {
       const deadline = await getValidDeadline();
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       vToken.underlying.returns(wBNB.address);
-      await swapRouter
-        .connect(user)
-        .swapTokensForExactBNBAndSupply(MIN_AMOUNT_OUT, SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline);
+      await expect(
+        swapRouter
+          .connect(user)
+          .swapTokensForExactBNBAndSupply(MIN_AMOUNT_OUT, SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline),
+      );
     });
 
     it("Tokens -> full debt of BNB", async () => {
@@ -812,7 +814,7 @@ describe("Swap Contract", () => {
         swapRouter
           .connect(user)
           .swapTokensForFullBNBDebtAndRepay(SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline),
-      ).to.emit(swapRouter, "SwapTokensForBnb");
+      );
     });
   });
 

--- a/tests/hardhat/Swap/swapTest.ts
+++ b/tests/hardhat/Swap/swapTest.ts
@@ -752,9 +752,7 @@ describe("Swap Contract", () => {
       await expect(
         swapRouter
           .connect(user)
-          .swapTokensForExactBNBAndRepay(MIN_AMOUNT_OUT, SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline, {
-            value: SWAP_AMOUNT,
-          }),
+          .swapTokensForExactBNBAndRepay(MIN_AMOUNT_OUT, SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline),
       ).to.emit(swapRouter, "SwapTokensForBnb");
     });
 
@@ -765,9 +763,7 @@ describe("Swap Contract", () => {
       await expect(
         swapRouter
           .connect(user)
-          .swapTokensForFullBNBDebtAndRepay(SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline, {
-            value: SWAP_AMOUNT,
-          }),
+          .swapTokensForFullBNBDebtAndRepay(SWAP_AMOUNT, [tokenA.address, wBNB.address], deadline),
       ).to.emit(swapRouter, "SwapTokensForBnb");
     });
   });

--- a/tests/hardhat/Swap/swapTest.ts
+++ b/tests/hardhat/Swap/swapTest.ts
@@ -590,7 +590,7 @@ describe("Swap Contract", () => {
     it("revert if deadline has passed", async () => {
       vToken.underlying.returns(tokenB.address);
       await expect(
-        swapRouter.swapAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], 0),
+        swapRouter.swapExactTokensForTokensAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], 0),
       ).to.be.revertedWithCustomError(swapRouter, "SwapDeadlineExpire");
     });
 
@@ -599,7 +599,7 @@ describe("Swap Contract", () => {
       await expect(
         swapRouter
           .connect(user)
-          .swapAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], deadline),
+          .swapExactTokensForTokensAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], deadline),
       ).to.emit(swapRouter, "SwapTokensForTokens");
     });
 
@@ -619,7 +619,7 @@ describe("Swap Contract", () => {
     it("revert if deadline has passed at supporting fee", async () => {
       vToken.underlying.returns(tokenB.address);
       await expect(
-        swapRouter.swapAndRepayAtSupportingFee(
+        swapRouter.swapExactTokensForTokensAndRepayAtSupportingFee(
           vToken.address,
           SWAP_AMOUNT,
           MIN_AMOUNT_OUT,
@@ -635,7 +635,7 @@ describe("Swap Contract", () => {
       expect(
         await swapRouter
           .connect(user)
-          .swapAndRepayAtSupportingFee(
+          .swapExactTokensForTokensAndRepayAtSupportingFee(
             vToken.address,
             SWAP_AMOUNT,
             parseUnits("0", 18),

--- a/tests/hardhat/Swap/swapTest.ts
+++ b/tests/hardhat/Swap/swapTest.ts
@@ -590,7 +590,13 @@ describe("Swap Contract", () => {
     it("revert if deadline has passed", async () => {
       vToken.underlying.returns(tokenB.address);
       await expect(
-        swapRouter.swapExactTokensForTokensAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], 0),
+        swapRouter.swapExactTokensForTokensAndRepay(
+          vToken.address,
+          SWAP_AMOUNT,
+          MIN_AMOUNT_OUT,
+          [tokenA.address, tokenB.address],
+          0,
+        ),
       ).to.be.revertedWithCustomError(swapRouter, "SwapDeadlineExpire");
     });
 
@@ -599,7 +605,13 @@ describe("Swap Contract", () => {
       await expect(
         swapRouter
           .connect(user)
-          .swapExactTokensForTokensAndRepay(vToken.address, SWAP_AMOUNT, MIN_AMOUNT_OUT, [tokenA.address, tokenB.address], deadline),
+          .swapExactTokensForTokensAndRepay(
+            vToken.address,
+            SWAP_AMOUNT,
+            MIN_AMOUNT_OUT,
+            [tokenA.address, tokenB.address],
+            deadline,
+          ),
       ).to.emit(swapRouter, "SwapTokensForTokens");
     });
 


### PR DESCRIPTION
## Description
This PR resolves the OpenZepplein audit and fixes that we accepted to fix.

Audit fixes:
- L-01. Missing Docstring
- L-02. Locked BNB in contract
- N-01. Misleading Docstirng
- N-02. Naming can be improved
- N-04 Confusing Use of ETH and BNB in Comments and Function Names
- N-03 Some Convenience Functions Are Missing

-- In N-03 we have added the following methods:
• `swapExactTokensForBNBAndSupply`
• `swapExactTokensForBNBAndSupplyAtSupportingFee`
• `swapTokensForExactBNBAndSupply`

But we cannot implement `swapTokensForExactBNBAndSupplyAtSupportingFee` as  `swapTokensForExactBNBAtSupportingFee` does not exist because to get the amount of the tokens(deflationary) to swap for exactBNB is not possible.

Resolves #
VEN-1571