### PR TITLE
[VEN-1690]: Fix OpenZeppelin audit comments

### DIFF
--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -519,7 +519,7 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
     }
 
     /**
-     * @notice Pause Force Liquidation of VAI
+     * @notice Resume Force Liquidation of VAI
      */
     function resumeForceVAILiquidate() external {
         _checkAccessAllowed("resumeForceVAILiquidate()");

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -380,7 +380,6 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
                 _reduceVTokenReserves(address(vTokenCollateral));
             }
         }
-        return (ours, theirs);
     }
 
     /// @dev Wrap BNB to wBNB and sends to protocol share reserve
@@ -428,7 +427,7 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
         address from,
         address to,
         uint256 amount
-    ) internal returns (uint256 actualAmount) {
+    ) internal returns (uint256) {
         uint256 prevBalance = token.balanceOf(to);
         token.safeTransferFrom(from, to, amount);
         return token.balanceOf(to) - prevBalance;
@@ -439,7 +438,6 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
         uint256 totalIncentive = comptroller.liquidationIncentiveMantissa();
         ours = (seizedAmount * treasuryPercentMantissa) / totalIncentive;
         theirs = seizedAmount - ours;
-        return (ours, theirs);
     }
 
     function requireNoError(uint errCode) internal pure {

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -345,7 +345,7 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
         vai.safeApprove(address(vaiController), 0);
         vai.safeApprove(address(vaiController), repayAmount);
 
-        (uint err, ) = vaiController.liquidateVAI(borrower, repayAmount, vTokenCollateral);
+        (uint256 err, ) = vaiController.liquidateVAI(borrower, repayAmount, vTokenCollateral);
         requireNoError(err);
     }
 
@@ -440,8 +440,8 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
         theirs = seizedAmount - ours;
     }
 
-    function requireNoError(uint errCode) internal pure {
-        if (errCode == uint(0)) {
+    function requireNoError(uint256 errCode) internal pure {
+        if (errCode == uint256(0)) {
             return;
         }
 


### PR DESCRIPTION
## Description
N-01 Incorrect Docstring
N-02 Improper Use of Named Return Variable
N-03 Using int/uint Instead of int256/uint256

Resolves [VEN-1690]

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
