### PR TITLE
[VEN-1745]: Liquidator Quantstamp audit fixes

### DIFF
--- a/contracts/Liquidator/Interfaces.sol
+++ b/contracts/Liquidator/Interfaces.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 pragma solidity 0.8.13;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -526,4 +526,6 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
         forceVAILiquidate = true;
         emit ForceVAILiquidationResumed(msg.sender);
     }
+
+    function renounceOwnership() public override {}
 }

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -239,6 +239,7 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
     ) external payable nonReentrant {
         ensureNonzeroAddress(borrower);
         checkRestrictions(borrower, msg.sender);
+        validateTreasuryPercentMantissa(treasuryPercentMantissa);
         (bool isListed, , ) = IComptroller(comptroller).markets(address(vTokenCollateral));
         if (!isListed) {
             revert MarketNotListed(address(vTokenCollateral));

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -25,6 +25,9 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable wBNB;
 
+    /// @dev A unit (literal one) in EXP_SCALE, usually used in additions/subtractions
+    uint256 internal constant MANTISSA_ONE = 1e18;
+
     /* Events */
 
     /// @notice Emitted when the percent of the seized amount that goes to treasury changes.
@@ -393,7 +396,7 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
             wBNB,
             IProtocolShareReserve.IncomeType.LIQUIDATION
         );
-        emit ProtocolLiquidationIncentiveTransferred(msg.sender, address(wBNB), bnbBalance);
+        emit ProtocolLiquidationIncentiveTransferred(msg.sender, wBNB, bnbBalance);
     }
 
     /// @dev Redeem seized collateral to underlying assets
@@ -462,7 +465,7 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
     }
 
     function validateTreasuryPercentMantissa(uint256 treasuryPercentMantissa_) internal view {
-        uint256 maxTreasuryPercentMantissa = comptroller.liquidationIncentiveMantissa() - 1e18;
+        uint256 maxTreasuryPercentMantissa = comptroller.liquidationIncentiveMantissa() - MANTISSA_ONE;
         if (treasuryPercentMantissa_ > maxTreasuryPercentMantissa) {
             revert TreasuryPercentTooHigh(maxTreasuryPercentMantissa, treasuryPercentMantissa_);
         }

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -502,6 +502,7 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
      */
     function setPendingRedeemChunkLength(uint256 newLength_) external {
         _checkAccessAllowed("setPendingRedeemChunkLength(uint256)");
+        require(newLength_ > 0, "Invalid chunk size");
         emit NewPendingRedeemChunkLength(pendingRedeemChunkLength, newLength_);
         pendingRedeemChunkLength = newLength_;
     }

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -242,7 +242,6 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, Liqu
     ) external payable nonReentrant {
         ensureNonzeroAddress(borrower);
         checkRestrictions(borrower, msg.sender);
-        validateTreasuryPercentMantissa(treasuryPercentMantissa);
         (bool isListed, , ) = IComptroller(comptroller).markets(address(vTokenCollateral));
         if (!isListed) {
             revert MarketNotListed(address(vTokenCollateral));

--- a/tests/hardhat/Fork/ForceVAIDebtFirstTest.ts
+++ b/tests/hardhat/Fork/ForceVAIDebtFirstTest.ts
@@ -98,12 +98,6 @@ async function grantPermissions() {
   tx = await accessControlManager
     .connect(impersonatedTimelock)
     .giveCallPermission(LIQUIDATOR, "setPendingRedeemChunkLength(uint256)", NORMAL_TIMELOCK);
-  tx = await accessControlManager
-    .connect(impersonatedTimelock)
-    .giveCallPermission(UNITROLLER, "_setLiquidationIncentive(uint256)", NORMAL_TIMELOCK);
-  tx = await accessControlManager
-    .connect(impersonatedTimelock)
-    .giveCallPermission(LIQUIDATOR, "setTreasuryPercent(uint256)", NORMAL_TIMELOCK);
   await tx.wait();
 }
 
@@ -183,18 +177,6 @@ if (FORK_MAINNET) {
       expect(vaiDebt).to.greaterThan(minLiquidatableVAI);
 
       await liquidatorNew.connect(liquidatorSigner).liquidateBorrow(VAI_CONTROLLER, borrower, 100, VBNB);
-    });
-
-    it("Should fail if liquidation incentive is lower than treasury percentage", async () => {
-      const blockNumber = 27939619;
-      await setForkBlock(blockNumber);
-      await configure();
-      await comptroller.connect(impersonatedTimelock)._setLiquidationIncentive(convertToUnit("2.5", 18));
-      await liquidatorNew.connect(impersonatedTimelock).setTreasuryPercent(convertToUnit("1.3", 18));
-      await comptroller.connect(impersonatedTimelock)._setLiquidationIncentive(convertToUnit("1.1", 18));
-      await expect(
-        liquidatorNew.liquidateBorrow(VAI_CONTROLLER, "0x6B7a803BB85C7D1F67470C50358d11902d3169e0", 100, VBNB),
-      ).to.be.revertedWithCustomError(liquidatorNew, "TreasuryPercentTooHigh");
     });
   });
 }

--- a/tests/hardhat/Fork/ForceVAIDebtFirstTest.ts
+++ b/tests/hardhat/Fork/ForceVAIDebtFirstTest.ts
@@ -98,6 +98,12 @@ async function grantPermissions() {
   tx = await accessControlManager
     .connect(impersonatedTimelock)
     .giveCallPermission(LIQUIDATOR, "setPendingRedeemChunkLength(uint256)", NORMAL_TIMELOCK);
+  tx = await accessControlManager
+    .connect(impersonatedTimelock)
+    .giveCallPermission(UNITROLLER, "_setLiquidationIncentive(uint256)", NORMAL_TIMELOCK);
+  tx = await accessControlManager
+    .connect(impersonatedTimelock)
+    .giveCallPermission(LIQUIDATOR, "setTreasuryPercent(uint256)", NORMAL_TIMELOCK);
   await tx.wait();
 }
 
@@ -177,6 +183,18 @@ if (FORK_MAINNET) {
       expect(vaiDebt).to.greaterThan(minLiquidatableVAI);
 
       await liquidatorNew.connect(liquidatorSigner).liquidateBorrow(VAI_CONTROLLER, borrower, 100, VBNB);
+    });
+
+    it("Should fail if liquidation incentive is lower than treasury percentage", async () => {
+      const blockNumber = 27939619;
+      await setForkBlock(blockNumber);
+      await configure();
+      await comptroller.connect(impersonatedTimelock)._setLiquidationIncentive(convertToUnit("2.5", 18));
+      await liquidatorNew.connect(impersonatedTimelock).setTreasuryPercent(convertToUnit("1.3", 18));
+      await comptroller.connect(impersonatedTimelock)._setLiquidationIncentive(convertToUnit("1.1", 18));
+      await expect(
+        liquidatorNew.liquidateBorrow(VAI_CONTROLLER, "0x6B7a803BB85C7D1F67470C50358d11902d3169e0", 100, VBNB),
+      ).to.be.revertedWithCustomError(liquidatorNew, "TreasuryPercentTooHigh");
     });
   });
 }

--- a/tests/hardhat/Fork/reduceResevesTest.ts
+++ b/tests/hardhat/Fork/reduceResevesTest.ts
@@ -63,6 +63,9 @@ async function deployAndConfigureLiquidator() {
 
   accessControlManager = IAccessControlManagerV8__factory.connect(ACM, impersonatedTimelock);
   await accessControlManager.giveCallPermission(LIQUIDATOR, "setPendingRedeemChunkLength(uint256)", NORMAL_TIMELOCK);
+  await expect(liquidator.connect(impersonatedTimelock).setPendingRedeemChunkLength(0)).to.be.revertedWith(
+    "Invalid chunk size",
+  );
   await liquidator.connect(impersonatedTimelock).setPendingRedeemChunkLength(5);
 }
 


### PR DESCRIPTION
## Description

- VEN-1 : added a validation check in `liquidateBorrow()` function to make sure `liquidationIncentiveMantissa` is greater than `treasuryPercent`
- VEN-3 : added a sanity check
- VEN-8 : override the `renounceOwnership` to a empty implementation

Resolves VEN-1745

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
