### PR TITLE
Setter for Prime Token in PrimeLiquidityProvider

### DIFF
--- a/contracts/Tokens/Prime/PrimeLiquidityProvider.sol
+++ b/contracts/Tokens/Prime/PrimeLiquidityProvider.sol
@@ -15,7 +15,7 @@ contract PrimeLiquidityProvider is AccessControlledV8, PausableUpgradeable {
     uint256 internal constant EXP_SCALE = 1e18;
 
     /// @notice Address of the Prime contract
-    address public immutable prime;
+    address public prime;
 
     /// @notice The rate at which token is distributed (per block)
     mapping(address => uint256) public tokenDistributionSpeeds;
@@ -31,6 +31,9 @@ contract PrimeLiquidityProvider is AccessControlledV8, PausableUpgradeable {
 
     /// @notice Emitted when a new token distribution speed is set
     event TokenDistributionSpeedUpdated(address indexed token, uint256 newSpeed);
+
+    /// @notice Emitted when prime token contract address is changed
+    event PrimeTokenUpdated(address oldPrimeToken, address newPrimeToken);
 
     /// @notice Emitted when distribution state(Index and block) is updated
     event TokensAccrued(address indexed token, uint256 amount);
@@ -64,17 +67,6 @@ contract PrimeLiquidityProvider is AccessControlledV8, PausableUpgradeable {
 
     /// @notice Emitted when funds transfer is paused
     error FundsTransferIsPaused();
-
-    /**
-     * @param prime_ Address of the Prime contract
-     */
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address prime_) {
-        _ensureZeroAddress(prime_);
-        prime = prime_;
-
-        _disableInitializers();
-    }
 
     /**
      * @notice RewardsDistributor initializer
@@ -164,6 +156,17 @@ contract PrimeLiquidityProvider is AccessControlledV8, PausableUpgradeable {
                 ++i;
             }
         }
+    }
+
+    /**
+     * @notice Set the prime token contract address
+     * @param prime_ The new address of the prime token contract
+     */
+    function setPrimeToken(address prime_) external onlyOwner {
+        _ensureZeroAddress(prime_);
+
+        emit PrimeTokenUpdated(prime, prime_);
+        prime = prime_;
     }
 
     /**

--- a/tests/hardhat/Prime/Prime.ts
+++ b/tests/hardhat/Prime/Prime.ts
@@ -181,21 +181,24 @@ async function deployProtocol(): Promise<SetupProtocolFixture> {
   await xvsVault.add(xvs.address, allocPoint, xvs.address, rewardPerBlock, lockPeriod);
 
   const primeFactory = await ethers.getContractFactory("PrimeScenario");
-  const prime:PrimeScenario = await upgrades.deployProxy(primeFactory, [
-    xvsVault.address,
-    xvs.address,
-    0,
-    1,
-    2,
-    accessControl.address,
-    protocolShareReserve.address,
-    primeLiquidityProvider.address,
-    comptroller.address,
-    oracle.address
-  ], {
-    constructorArgs: [wbnb.address,vbnb.address, 10512000],
-  });
-
+  const prime: PrimeScenario = await upgrades.deployProxy(
+    primeFactory,
+    [
+      xvsVault.address,
+      xvs.address,
+      0,
+      1,
+      2,
+      accessControl.address,
+      protocolShareReserve.address,
+      primeLiquidityProvider.address,
+      comptroller.address,
+      oracle.address,
+    ],
+    {
+      constructorArgs: [wbnb.address, vbnb.address, 10512000],
+    },
+  );
 
   await xvsVault.setPrimeToken(prime.address, xvs.address, poolId);
 
@@ -206,7 +209,7 @@ async function deployProtocol(): Promise<SetupProtocolFixture> {
   await prime.addMarket(veth.address, bigNumber18.mul("1"), bigNumber18.mul("1"));
 
   await comptroller._setPrimeToken(prime.address);
-  
+
   await prime.togglePause();
 
   return {
@@ -418,7 +421,6 @@ describe("PrimeScenario Token", () => {
 
       await protocolShareReserve.getUnreleasedFunds.returns("0");
       await protocolShareReserve.getPercentageDistribution.returns("100");
-      
 
       await xvs.connect(user1).approve(xvsVault.address, bigNumber18.mul(10000));
       await xvsVault.connect(user1).deposit(xvs.address, 0, bigNumber18.mul(10000));

--- a/tests/hardhat/Prime/PrimeLiquidityProvider.ts
+++ b/tests/hardhat/Prime/PrimeLiquidityProvider.ts
@@ -20,6 +20,7 @@ let tokenC: MockContract<FaucetToken>;
 let prime: FakeContract<Prime>;
 let accessControl: FakeContract<IAccessControlManager>;
 let signer: ethers.signer;
+let signers: ethers.signers;
 
 const tokenASpeed = parseUnits("1", 16);
 const tokenBSpeed = parseUnits("2", 16);
@@ -28,7 +29,7 @@ const tokenAInitialFund = parseUnits("100", 18);
 const tokenBInitialFund = parseUnits("200", 18);
 
 const fixture = async () => {
-  const signers = await ethers.getSigners();
+  signers = await ethers.getSigners();
   signer = signers[0];
 
   const FaucetToken = await smock.mock<FaucetToken__factory>("FaucetToken");
@@ -40,14 +41,13 @@ const fixture = async () => {
   tokenC = await FaucetToken.deploy(parseUnits("10000", 18), "TOKENC", 18, "C");
 
   const PrimeLiquidityProvider = await ethers.getContractFactory("PrimeLiquidityProvider");
-  primeLiquidityProvider = await upgrades.deployProxy(
-    PrimeLiquidityProvider,
-    [accessControl.address, [tokenA.address, tokenB.address], [tokenASpeed, tokenBSpeed]],
-    {
-      constructorArgs: [prime.address],
-      unsafeAllow: ["state-variable-immutable"],
-    },
-  );
+  primeLiquidityProvider = await upgrades.deployProxy(PrimeLiquidityProvider, [
+    accessControl.address,
+    [tokenA.address, tokenB.address],
+    [tokenASpeed, tokenBSpeed],
+  ]);
+
+  await primeLiquidityProvider.setPrimeToken(prime.address);
 };
 
 describe("PrimeLiquidityProvider: tests", () => {
@@ -141,6 +141,25 @@ describe("PrimeLiquidityProvider: tests", () => {
       await expect(tx)
         .to.emit(primeLiquidityProvider, "TokenDistributionSpeedUpdated")
         .withArgs(tokenC.address, tokenCSpeed);
+    });
+
+    it("Revert on invalid prime token address", async () => {
+      const tx = primeLiquidityProvider.setPrimeToken(ethers.constants.AddressZero);
+
+      await expect(tx).to.be.revertedWithCustomError(primeLiquidityProvider, "InvalidArguments");
+    });
+
+    it("Revert when prime token setter is called by non-owner", async () => {
+      const tx = primeLiquidityProvider.connect(signers[1]).setPrimeToken(prime.address);
+
+      await expect(tx).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("setPrimeToken success", async () => {
+      const tx = await primeLiquidityProvider.setPrimeToken(signers[2].address);
+      tx.wait();
+
+      await expect(tx).to.emit(primeLiquidityProvider, "PrimeTokenUpdated").withArgs(prime.address, signers[2].address);
     });
   });
 

--- a/tests/hardhat/Prime/PrimeLiquidityProvider.ts
+++ b/tests/hardhat/Prime/PrimeLiquidityProvider.ts
@@ -270,12 +270,18 @@ describe("PrimeLiquidityProvider: tests", () => {
     });
 
     it("Release funds success", async () => {
+      const lastAccruedBlockTokenA = await primeLiquidityProvider.lastAccruedBlock(tokenB.address);
+
       const tx = await primeLiquidityProvider.releaseFunds(tokenA.address);
       tx.wait();
 
+      const currentBlockTokenA = await primeLiquidityProvider.getBlockNumber();
+      const deltaBlocksTokenA = Number(currentBlockTokenA) - Number(lastAccruedBlockTokenA);
+      const accruedTokenA = deltaBlocksTokenA * Number(tokenASpeed);
+
       await expect(tx)
         .to.emit(primeLiquidityProvider, "TokenTransferredToPrime")
-        .withArgs(tokenA.address, convertToUnit("13", 16));
+        .withArgs(tokenA.address, BigInt(accruedTokenA));
 
       expect(await primeLiquidityProvider.tokenAmountAccrued(tokenA.address)).to.equal(0);
     });


### PR DESCRIPTION
This PR includes setter functionality for prime token in **PrimeLiquidityProvider**, as both **Prime** and **PrimeLiquidityProvider** takes eachother address as constructor input. So we need to have a setter in one of the contract.
And also the fixed test for **PrimeLiquidityProvider** regarding **releaseFunds**.