### PR TITLE
[VEN-2005]: BUSD Liquidator

### DIFF
--- a/contracts/Liquidator/BUSDLiquidator.sol
+++ b/contracts/Liquidator/BUSDLiquidator.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import { SafeERC20Upgradeable, IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+
+import { MANTISSA_ONE } from "./constants.sol";
+import { ensureNonzeroAddress } from "./zeroAddress.sol";
+import { approveOrRevert } from "./approveOrRevert.sol";
+import { ILiquidator, IComptroller, IVToken, IVBep20, IVBNB, IVAIController } from "./Interfaces.sol";
+
+/**
+ * @title BUSDLiquidator
+ * @author Venus
+ * @notice A custom contract for force-liquidating BUSD debts
+ */
+contract BUSDLiquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using SafeERC20Upgradeable for IVToken;
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    IVBep20 public immutable vBUSD;
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    IComptroller public immutable comptroller;
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address public immutable treasury;
+
+    /// @notice The liquidator's share, scaled by 1e18 (e.g. 1.02 * 1e18 for 102% of the debt covered)
+    uint256 public liquidatorShareMantissa;
+
+    /// @notice Thrown if trying to set liquidator's share lower than 100% of the debt covered
+    error LiquidatorShareTooLow(uint256 liquidatorShareMantissa_);
+
+    /// @notice Thrown if trying to set liquidator's share larger than this contract can receive from a liquidation
+    error LiquidatorShareTooHigh(uint256 maxLiquidatorShareMantissa, uint256 liquidatorShareMantissa_);
+
+    /// @notice Emitted when the liquidator's share is set
+    event NewLiquidatorShare(uint256 oldLiquidatorShareMantissa, uint256 newLiquidatorShareMantissa);
+
+    /// @notice Constructor for the implementation contract. Sets immutable variables.
+    /// @param comptroller_ The address of the Comptroller contract
+    /// @param vBUSD_ The address of the VBNB
+    /// @param treasury_ The address of Venus treasury
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address comptroller_, address vBUSD_, address treasury_) {
+        ensureNonzeroAddress(vBUSD_);
+        ensureNonzeroAddress(comptroller_);
+        ensureNonzeroAddress(treasury_);
+        vBUSD = IVBep20(vBUSD_);
+        comptroller = IComptroller(comptroller_);
+        treasury = treasury_;
+        _disableInitializers();
+    }
+
+    /// @notice Initializer for the implementation contract.
+    /// @param liquidatorShareMantissa_ Liquidator's share, scaled by 1e18 (e.g. 1.01 * 1e18 for 101%)
+    /// @custom:error LiquidatorShareTooHigh is thrown if trying to set liquidator percent larger than the liquidation profit
+    function initialize(uint256 liquidatorShareMantissa_) external virtual initializer {
+        __Ownable2Step_init();
+        __ReentrancyGuard_init();
+        _validateLiquidatorShareMantissa(liquidatorShareMantissa_);
+        liquidatorShareMantissa = liquidatorShareMantissa_;
+    }
+
+    /// @notice Liquidate the entire BUSD debt of a borrower, seizing vTokenCollateral
+    /// @param borrower The borrower whose debt should be liquidated
+    /// @param vTokenCollateral The collateral to seize from the borrower
+    function liquidateEntireBorrow(address borrower, IVToken vTokenCollateral) external nonReentrant {
+        uint256 repayAmount = vBUSD.borrowBalanceCurrent(borrower);
+        _unpauseAndLiquidate(borrower, repayAmount, vTokenCollateral);
+    }
+
+    /// @notice Liquidate a BUSD borrow, repaying the repayAmount of BUSD
+    /// @param borrower The borrower whose debt should be liquidated
+    /// @param repayAmount The amount to repay
+    /// @param vTokenCollateral The collateral to seize from the borrower
+    function liquidateBorrow(address borrower, uint256 repayAmount, IVToken vTokenCollateral) external nonReentrant {
+        _unpauseAndLiquidate(borrower, repayAmount, vTokenCollateral);
+    }
+
+    /// @notice Allows Governance to set the liquidator's share
+    /// @param liquidatorShareMantissa_ Liquidator's share, scaled by 1e18 (e.g. 1.01 * 1e18 for 101%)
+    /// @custom:access Only Governance
+    function setLiquidatorShare(uint256 liquidatorShareMantissa_) external onlyOwner {
+        _validateLiquidatorShareMantissa(liquidatorShareMantissa_);
+        uint256 oldLiquidatorShareMantissa = liquidatorShareMantissa;
+        liquidatorShareMantissa = liquidatorShareMantissa_;
+        emit NewLiquidatorShare(oldLiquidatorShareMantissa, liquidatorShareMantissa_);
+    }
+
+    /// @notice Allows to recover token accidentally sent to this contract by sending the entire balance to Governance
+    /// @param token The address of the token to recover
+    /// @custom:access Only Governance
+    function sweepToken(IERC20Upgradeable token) external onlyOwner {
+        token.safeTransfer(msg.sender, token.balanceOf(address(this)));
+    }
+
+    /// @dev Unpauses the liquidation on the BUSD market, liquidates the borrower's debt,
+    /// and pauses the liquidations back
+    /// @param borrower The borrower whose debt should be liquidated
+    /// @param repayAmount The amount to repay
+    /// @param vTokenCollateral The collateral to seize from the borrower
+    function _unpauseAndLiquidate(address borrower, uint256 repayAmount, IVToken vTokenCollateral) internal {
+        address[] memory vTokens = new address[](1);
+        vTokens[0] = address(vBUSD);
+        IComptroller.Action[] memory actions = new IComptroller.Action[](1);
+        actions[0] = IComptroller.Action.LIQUIDATE;
+
+        comptroller._setActionsPaused(vTokens, actions, false);
+        _liquidateBorrow(borrower, repayAmount, vTokenCollateral);
+        comptroller._setActionsPaused(vTokens, actions, true);
+    }
+
+    /// @dev Performs the actual liquidation, transferring BUSD from the sender to this contract,
+    /// repaying the debt, and transferring the seized collateral to the sender and the treasury
+    /// @param borrower The borrower whose debt should be liquidated
+    /// @param repayAmount The amount to repay
+    /// @param vTokenCollateral The collateral to seize from the borrower
+    function _liquidateBorrow(address borrower, uint256 repayAmount, IVToken vTokenCollateral) internal {
+        ILiquidator liquidatorContract = ILiquidator(comptroller.liquidatorContract());
+        IERC20Upgradeable busd = IERC20Upgradeable(vBUSD.underlying());
+
+        uint256 actualRepayAmount = _transferIn(busd, msg.sender, repayAmount);
+        approveOrRevert(busd, address(liquidatorContract), 0);
+        approveOrRevert(busd, address(liquidatorContract), actualRepayAmount);
+        uint256 balanceBefore = vTokenCollateral.balanceOf(address(this));
+        liquidatorContract.liquidateBorrow(address(vBUSD), borrower, actualRepayAmount, vTokenCollateral);
+        uint256 receivedAmount = vTokenCollateral.balanceOf(address(this)) - balanceBefore;
+        approveOrRevert(busd, address(liquidatorContract), 0);
+
+        (uint256 liquidatorAmount, uint256 treasuryAmount) = _computeShares(receivedAmount);
+        vTokenCollateral.safeTransfer(msg.sender, liquidatorAmount);
+        vTokenCollateral.safeTransfer(treasury, treasuryAmount);
+    }
+
+    /// @dev Transfers tokens to this contract and returns the actual transfer amount
+    /// @param token The token to transfer
+    /// @param from The account to transfer from
+    /// @param amount The amount to transfer
+    /// @return actualAmount The actual amount transferred
+    function _transferIn(
+        IERC20Upgradeable token,
+        address from,
+        uint256 amount
+    ) internal returns (uint256 actualAmount) {
+        uint256 prevBalance = token.balanceOf(address(this));
+        token.safeTransferFrom(from, address(this), amount);
+        return token.balanceOf(address(this)) - prevBalance;
+    }
+
+    /// @dev Computes the liquidator's and treasury's shares of the received amount
+    /// @param receivedAmount The amount received from the liquidation
+    /// @return liquidatorAmount The liquidator's share
+    /// @return treasuryAmount The treasury's share
+    function _computeShares(
+        uint256 receivedAmount
+    ) internal view returns (uint256 liquidatorAmount, uint256 treasuryAmount) {
+        uint256 denominator = _getDenominator();
+        liquidatorAmount = (receivedAmount * liquidatorShareMantissa) / denominator;
+        treasuryAmount = receivedAmount - liquidatorAmount;
+    }
+
+    /// @dev Returns (liquidation incentive - treasury percent), the value used as the denominator
+    /// when calculating the liquidator's share
+    /// @return The denominator for the seized amount used when calculating the liquidator's share
+    function _getDenominator() internal view returns (uint256) {
+        uint256 totalPercentageToDistribute = comptroller.liquidationIncentiveMantissa();
+        uint256 regularTreasuryPercent = ILiquidator(comptroller.liquidatorContract()).treasuryPercentMantissa();
+        uint256 denominator = totalPercentageToDistribute - regularTreasuryPercent;
+        return denominator;
+    }
+
+    /// @dev Checks if the liquidator's share is more than 100% of the debt covered and less
+    /// than (liquidation incentive - treasury percent)
+    /// @param liquidatorShareMantissa_ Liquidator's share, scaled by 1e18 (e.g. 1.01 * 1e18 for 101%)
+    function _validateLiquidatorShareMantissa(uint256 liquidatorShareMantissa_) internal view {
+        uint256 maxLiquidatorShareMantissa = _getDenominator();
+        if (liquidatorShareMantissa_ < MANTISSA_ONE) {
+            revert LiquidatorShareTooLow(liquidatorShareMantissa_);
+        }
+
+        if (liquidatorShareMantissa_ > maxLiquidatorShareMantissa) {
+            revert LiquidatorShareTooHigh(maxLiquidatorShareMantissa, liquidatorShareMantissa_);
+        }
+    }
+}

--- a/contracts/Liquidator/BUSDLiquidator.sol
+++ b/contracts/Liquidator/BUSDLiquidator.sol
@@ -139,12 +139,8 @@ contract BUSDLiquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /// @param token The token to transfer
     /// @param from The account to transfer from
     /// @param amount The amount to transfer
-    /// @return actualAmount The actual amount transferred
-    function _transferIn(
-        IERC20Upgradeable token,
-        address from,
-        uint256 amount
-    ) internal returns (uint256 actualAmount) {
+    /// @return The actual amount transferred
+    function _transferIn(IERC20Upgradeable token, address from, uint256 amount) internal returns (uint256) {
         uint256 prevBalance = token.balanceOf(address(this));
         token.safeTransferFrom(from, address(this), amount);
         return token.balanceOf(address(this)) - prevBalance;

--- a/contracts/Liquidator/BUSDLiquidator.sol
+++ b/contracts/Liquidator/BUSDLiquidator.sol
@@ -124,7 +124,6 @@ contract BUSDLiquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
         IERC20Upgradeable busd = IERC20Upgradeable(vBUSD.underlying());
 
         uint256 actualRepayAmount = _transferIn(busd, msg.sender, repayAmount);
-        approveOrRevert(busd, address(liquidatorContract), 0);
         approveOrRevert(busd, address(liquidatorContract), actualRepayAmount);
         uint256 balanceBefore = vTokenCollateral.balanceOf(address(this));
         liquidatorContract.liquidateBorrow(address(vBUSD), borrower, actualRepayAmount, vTokenCollateral);

--- a/contracts/Liquidator/Interfaces.sol
+++ b/contracts/Liquidator/Interfaces.sol
@@ -1,8 +1,13 @@
+// SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
-interface IVToken is IERC20Upgradeable {}
+interface IVToken is IERC20Upgradeable {
+    function borrowBalanceCurrent(address borrower) external returns (uint256);
+
+    function transfer(address dst, uint256 amount) external returns (bool);
+}
 
 interface IVBep20 is IVToken {
     function underlying() external view returns (address);
@@ -29,7 +34,44 @@ interface IVAIController {
 }
 
 interface IComptroller {
+    enum Action {
+        MINT,
+        REDEEM,
+        BORROW,
+        REPAY,
+        SEIZE,
+        LIQUIDATE,
+        TRANSFER,
+        ENTER_MARKET,
+        EXIT_MARKET
+    }
+
+    function _setActionsPaused(address[] calldata markets_, Action[] calldata actions_, bool paused_) external;
+
     function liquidationIncentiveMantissa() external view returns (uint256);
 
     function vaiController() external view returns (IVAIController);
+
+    function liquidatorContract() external view returns (address);
+}
+
+interface ILiquidator {
+    function restrictLiquidation(address borrower) external;
+
+    function unrestrictLiquidation(address borrower) external;
+
+    function addToAllowlist(address borrower, address liquidator) external;
+
+    function removeFromAllowlist(address borrower, address liquidator) external;
+
+    function liquidateBorrow(
+        address vToken,
+        address borrower,
+        uint256 repayAmount,
+        IVToken vTokenCollateral
+    ) external payable;
+
+    function setTreasuryPercent(uint256 newTreasuryPercentMantissa) external;
+
+    function treasuryPercentMantissa() external view returns (uint256);
 }

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -5,14 +5,15 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
-import { IComptroller, IVToken, IVBep20, IVBNB, IVAIController } from "./Interfaces.sol";
+import { ensureNonzeroAddress } from "./zeroAddress.sol";
+import { ILiquidator, IComptroller, IVToken, IVBep20, IVBNB, IVAIController } from "./Interfaces.sol";
 
 /**
  * @title Liquidator
  * @author Venus
  * @notice The Liquidator contract is responsible for liquidating underwater accounts.
  */
-contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
+contract Liquidator is ILiquidator, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice Address of vBNB contract.
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IVBNB public immutable vBnb;
@@ -94,9 +95,6 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice Thrown if BNB amount sent with the transaction doesn't correspond to the
     ///         intended BNB repayment
     error WrongTransactionAmount(uint256 expected, uint256 actual);
-
-    /// @notice Thrown if the argument is a zero address because probably it is a mistake
-    error UnexpectedZeroAddress();
 
     /// @notice Thrown if trying to set treasury percent larger than the liquidation profit
     error TreasuryPercentTooHigh(uint256 maxTreasuryPercentMantissa, uint256 treasuryPercentMantissa_);
@@ -305,12 +303,6 @@ contract Liquidator is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
         }
 
         revert LiquidationFailed(errCode);
-    }
-
-    function ensureNonzeroAddress(address address_) internal pure {
-        if (address_ == address(0)) {
-            revert UnexpectedZeroAddress();
-        }
     }
 
     function checkRestrictions(address borrower, address liquidator) internal view {

--- a/contracts/Liquidator/approveOrRevert.sol
+++ b/contracts/Liquidator/approveOrRevert.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+
+/// @notice Thrown if a contract is unable to approve a transfer
+error ApproveFailed();
+
+/// @notice Approves a transfer, ensuring that it is successful. This function supports non-compliant
+/// tokens like the ones that don't return a boolean value on success. Thus, such approve call supports
+/// three different kinds of tokens:
+///   * Compliant tokens that revert on failure
+///   * Compliant tokens that return false on failure
+///   * Non-compliant tokens that don't return a value
+/// @param token The contract address of the token which will be transferred
+/// @param spender The spender contract address
+/// @param amount The value of the transfer
+function approveOrRevert(IERC20Upgradeable token, address spender, uint256 amount) {
+    bytes memory callData = abi.encodeCall(token.approve, (spender, amount));
+
+    // solhint-disable-next-line avoid-low-level-calls
+    (bool success, bytes memory result) = address(token).call(callData);
+
+    if (!success || (result.length != 0 && !abi.decode(result, (bool)))) {
+        revert ApproveFailed();
+    }
+}

--- a/contracts/Liquidator/constants.sol
+++ b/contracts/Liquidator/constants.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+uint256 constant MANTISSA_ONE = 1e18;

--- a/contracts/Liquidator/zeroAddress.sol
+++ b/contracts/Liquidator/zeroAddress.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+/// @notice Thrown if the argument is a zero address because probably it is a mistake
+error UnexpectedZeroAddress();
+
+function ensureNonzeroAddress(address address_) pure {
+    if (address_ == address(0)) {
+        revert UnexpectedZeroAddress();
+    }
+}

--- a/tests/hardhat/Fork/BUSDLiquidator.ts
+++ b/tests/hardhat/Fork/BUSDLiquidator.ts
@@ -6,7 +6,13 @@ import { BigNumberish } from "ethers";
 import { parseEther, parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
-import { BUSDLiquidator, ComptrollerMock, FaucetToken, VBep20 } from "../../../typechain";
+import {
+  BUSDLiquidator,
+  ComptrollerMock,
+  FaucetToken,
+  IAccessControlManagerV8__factory,
+  VBep20,
+} from "../../../typechain";
 import {
   deployComptrollerWithMarkets,
   deployJumpRateModel,
@@ -107,7 +113,7 @@ const setupLocal = async (): Promise<BUSDLiquidatorFixture> => {
 };
 
 const setupFork = async (): Promise<BUSDLiquidatorFixture> => {
-  const [, , borrower, someone] = await ethers.getSigners();
+  const [admin, , borrower, someone] = await ethers.getSigners();
 
   const zeroRateModel = await deployJumpRateModel({
     baseRatePerYear: 0,
@@ -121,7 +127,7 @@ const setupFork = async (): Promise<BUSDLiquidatorFixture> => {
   const busd = await ethers.getContractAt("contracts/Utils/IBEP20.sol:IBEP20", await vBUSD.underlying());
   const collateral = await ethers.getContractAt("contracts/Utils/IBEP20.sol:IBEP20", await vCollateral.underlying());
   const treasuryAddress = await comptroller.treasuryAddress();
-  const acm = await ethers.getContractAt("IAccessControlManager", addresses.bscmainnet.ACCESS_CONTROL_MANAGER);
+  const acm = IAccessControlManagerV8__factory.connect(addresses.bscmainnet.ACCESS_CONTROL_MANAGER, admin);
 
   const busdLiquidator = await deployBUSDLiquidator({
     comptroller,

--- a/tests/hardhat/Fork/BUSDLiquidator.ts
+++ b/tests/hardhat/Fork/BUSDLiquidator.ts
@@ -1,0 +1,294 @@
+import { smock } from "@defi-wonderland/smock";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import chai from "chai";
+import { BigNumberish } from "ethers";
+import { parseEther, parseUnits } from "ethers/lib/utils";
+import { ethers, upgrades } from "hardhat";
+
+import { BUSDLiquidator, ComptrollerMock, FaucetToken, VBep20 } from "../../../typechain";
+import {
+  deployComptrollerWithMarkets,
+  deployJumpRateModel,
+  deployLiquidatorContract,
+} from "../fixtures/ComptrollerWithMarkets";
+import { FORK_MAINNET, forking, initMainnetUser } from "./utils";
+
+const { expect } = chai;
+chai.use(smock.matchers);
+
+const TOTAL_LIQUIDATION_INCENTIVE = parseUnits("1.1", 18);
+const TREASURY_PERCENT = parseUnits("0.05", 18);
+const LIQUIDATOR_PERCENT = parseUnits("1.01", 18);
+
+const addresses = {
+  bscmainnet: {
+    COMPTROLLER: "0xfD36E2c2a6789Db23113685031d7F16329158384",
+    VBUSD: "0x95c78222B3D6e262426483D42CfA53685A67Ab9D",
+    VUSDT: "0xfD5840Cd36d94D7229439859C0112a4185BC0255",
+    USDT_HOLDER: "0xF977814e90dA44bFA03b6295A0616a897441aceC",
+    BUSD_HOLDER: "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+    TIMELOCK: "0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396",
+    ACCESS_CONTROL_MANAGER: "0x4788629ABc6cFCA10F9f969efdEAa1cF70c23555",
+  },
+};
+
+const deployBUSDLiquidator = async ({
+  comptroller,
+  vBUSD,
+  treasuryAddress,
+  liquidatorShareMantissa,
+}: {
+  comptroller: ComptrollerMock;
+  vBUSD: VBep20;
+  treasuryAddress: string;
+  liquidatorShareMantissa: BigNumberish;
+}) => {
+  const busdLiquidatorFactory = await ethers.getContractFactory("BUSDLiquidator");
+  const busdLiquidator = (await upgrades.deployProxy(busdLiquidatorFactory, [liquidatorShareMantissa], {
+    constructorArgs: [comptroller.address, vBUSD.address, treasuryAddress],
+  })) as BUSDLiquidator;
+  await busdLiquidator.deployed();
+  return busdLiquidator;
+};
+
+interface BUSDLiquidatorFixture {
+  comptroller: ComptrollerMock;
+  busdLiquidator: BUSDLiquidator;
+  vCollateral: VBep20;
+  vBUSD: VBep20;
+  busd: FaucetToken;
+  treasuryAddress: string;
+}
+
+const setupLocal = async (): Promise<BUSDLiquidatorFixture> => {
+  const [, supplier, borrower, someone, treasury] = await ethers.getSigners();
+  const { comptroller, vTokens, vBNB } = await deployComptrollerWithMarkets({ numBep20Tokens: 2 });
+  const [vBUSD, vCollateral] = vTokens;
+  await deployLiquidatorContract({
+    comptroller,
+    vBNB,
+    treasuryAddress: treasury.address,
+    treasuryPercentMantissa: TREASURY_PERCENT,
+  });
+  const busdLiquidator = await deployBUSDLiquidator({
+    comptroller,
+    vBUSD,
+    treasuryAddress: treasury.address,
+    liquidatorShareMantissa: LIQUIDATOR_PERCENT,
+  });
+  await comptroller._setCollateralFactor(vCollateral.address, parseUnits("0.5", 18));
+  await comptroller._setMarketSupplyCaps(
+    [vBUSD.address, vCollateral.address],
+    [ethers.constants.MaxUint256, ethers.constants.MaxUint256],
+  );
+  await comptroller._setMarketBorrowCaps(
+    [vBUSD.address, vCollateral.address],
+    [ethers.constants.MaxUint256, ethers.constants.MaxUint256],
+  );
+  const busd = await ethers.getContractAt("FaucetToken", await vBUSD.underlying());
+  const collateral = await ethers.getContractAt("FaucetToken", await vCollateral.underlying());
+
+  await busd.allocateTo(supplier.address, parseUnits("5000", 18));
+  await busd.connect(supplier).approve(vBUSD.address, parseUnits("5000", 18));
+  await vBUSD.connect(supplier).mint(parseUnits("5000", 18));
+
+  await collateral.allocateTo(borrower.address, parseUnits("10000", 18));
+  await collateral.connect(borrower).approve(vCollateral.address, parseUnits("10000", 18));
+  await vCollateral.connect(borrower).mint(parseUnits("10000", 18));
+  await comptroller.connect(borrower).enterMarkets([vCollateral.address]);
+  await vBUSD.connect(borrower).borrow(parseUnits("1000", 18));
+
+  await busd.allocateTo(someone.address, parseUnits("10000", 18));
+  await busd.connect(someone).approve(busdLiquidator.address, parseUnits("10000", 18));
+
+  await comptroller._setForcedLiquidation(vBUSD.address, true);
+  return { comptroller, busdLiquidator, vCollateral, vBUSD, busd, treasuryAddress: treasury.address };
+};
+
+const setupFork = async (): Promise<BUSDLiquidatorFixture> => {
+  const [, , borrower, someone] = await ethers.getSigners();
+
+  const zeroRateModel = await deployJumpRateModel({
+    baseRatePerYear: 0,
+    multiplierPerYear: 0,
+    jumpMultiplierPerYear: 0,
+  });
+
+  const comptroller = await ethers.getContractAt("ComptrollerMock", addresses.bscmainnet.COMPTROLLER);
+  const vBUSD = await ethers.getContractAt("VBep20", addresses.bscmainnet.VBUSD);
+  const vCollateral = await ethers.getContractAt("VBep20", addresses.bscmainnet.VUSDT);
+  const busd = await ethers.getContractAt("contracts/Utils/IBEP20.sol:IBEP20", await vBUSD.underlying());
+  const collateral = await ethers.getContractAt("contracts/Utils/IBEP20.sol:IBEP20", await vCollateral.underlying());
+  const treasuryAddress = await comptroller.treasuryAddress();
+  const acm = await ethers.getContractAt("IAccessControlManager", addresses.bscmainnet.ACCESS_CONTROL_MANAGER);
+
+  const busdLiquidator = await deployBUSDLiquidator({
+    comptroller,
+    vBUSD,
+    treasuryAddress: await comptroller.treasuryAddress(),
+    liquidatorShareMantissa: LIQUIDATOR_PERCENT,
+  });
+
+  const timelock = await initMainnetUser(addresses.bscmainnet.TIMELOCK, parseEther("1"));
+  await acm
+    .connect(timelock)
+    .giveCallPermission(comptroller.address, "_setActionsPaused(address[],uint8[],bool)", busdLiquidator.address);
+  await comptroller.connect(timelock)._setMarketSupplyCaps([vBUSD.address], [ethers.constants.MaxUint256]);
+  await comptroller.connect(timelock)._setMarketBorrowCaps([vBUSD.address], [ethers.constants.MaxUint256]);
+  await comptroller.connect(timelock)._setForcedLiquidation(vBUSD.address, true);
+  const actions = {
+    MINT: 0,
+    BORROW: 2,
+    ENTER_MARKETS: 7,
+  };
+  await comptroller
+    .connect(timelock)
+    ._setActionsPaused([vBUSD.address], [actions.MINT, actions.BORROW, actions.ENTER_MARKETS], false);
+  await vBUSD.connect(timelock)._setInterestRateModel(zeroRateModel.address);
+  await vCollateral.connect(timelock)._setInterestRateModel(zeroRateModel.address);
+
+  const busdHolder = await initMainnetUser(addresses.bscmainnet.BUSD_HOLDER, parseEther("1"));
+  await busd.connect(busdHolder).approve(vBUSD.address, parseUnits("10000000", 18));
+  await vBUSD.connect(busdHolder).mint(parseUnits("10000000", 18)); // inject liquidity
+
+  const usdtHolder = await initMainnetUser(addresses.bscmainnet.USDT_HOLDER, parseEther("1"));
+  await collateral.connect(usdtHolder).transfer(borrower.address, parseUnits("10000", 18));
+  await collateral.connect(borrower).approve(vCollateral.address, parseUnits("10000", 18));
+  await vCollateral.connect(borrower).mint(parseUnits("10000", 18));
+  await comptroller.connect(borrower).enterMarkets([vCollateral.address]);
+  await vBUSD.connect(borrower).borrow(parseUnits("1000", 18));
+
+  await busd.connect(busdHolder).transfer(someone.address, parseUnits("10000", 18));
+  await busd.connect(someone).approve(busdLiquidator.address, parseUnits("10000", 18));
+
+  return { comptroller, busdLiquidator, vCollateral, vBUSD, busd, treasuryAddress };
+};
+
+const test = (setup: () => Promise<BUSDLiquidatorFixture>) => () => {
+  describe("BUSDLiquidator", () => {
+    let comptroller: ComptrollerMock;
+    let busdLiquidator: BUSDLiquidator;
+    let vCollateral: VBep20;
+    let vBUSD: VBep20;
+    let busd: FaucetToken;
+    let borrower: SignerWithAddress;
+    let someone: SignerWithAddress;
+    let treasuryAddress: string;
+
+    beforeEach(async () => {
+      ({ comptroller, busdLiquidator, vCollateral, vBUSD, busd, treasuryAddress } = await loadFixture(setup));
+      [, , borrower, someone] = await ethers.getSigners();
+    });
+
+    describe("setLiquidatorShare", () => {
+      it("should set liquidator share", async () => {
+        const newLiquidatorShareMantissa = parseUnits("1.0", 18);
+        await busdLiquidator.setLiquidatorShare(newLiquidatorShareMantissa);
+        expect(await busdLiquidator.liquidatorShareMantissa()).to.equal(newLiquidatorShareMantissa);
+      });
+
+      it("should emit NewLiquidatorShare event", async () => {
+        const oldLiquidatorShareMantissa = parseUnits("1.01", 18);
+        const newLiquidatorShareMantissa = parseUnits("1.03", 18);
+        const tx = await busdLiquidator.setLiquidatorShare(newLiquidatorShareMantissa);
+        await expect(tx)
+          .to.emit(busdLiquidator, "NewLiquidatorShare")
+          .withArgs(oldLiquidatorShareMantissa, newLiquidatorShareMantissa);
+      });
+
+      it("should revert if caller is not owner", async () => {
+        const newLiquidatorShareMantissa = parseUnits("1.02", 18);
+        await expect(busdLiquidator.connect(someone).setLiquidatorShare(newLiquidatorShareMantissa)).to.be.revertedWith(
+          "Ownable: caller is not the owner",
+        );
+      });
+
+      it("should revert if new liquidator share is < 1", async () => {
+        const newLiquidatorShareMantissa = parseUnits("1.0", 18).sub(1);
+        await expect(busdLiquidator.setLiquidatorShare(newLiquidatorShareMantissa))
+          .to.be.revertedWithCustomError(busdLiquidator, "LiquidatorShareTooLow")
+          .withArgs(newLiquidatorShareMantissa);
+      });
+
+      it("should revert if new liquidator share is > (liquidation incentive - treasury percent)", async () => {
+        const newLiquidatorShareMantissa = TOTAL_LIQUIDATION_INCENTIVE.sub(TREASURY_PERCENT).add(1);
+        await expect(busdLiquidator.setLiquidatorShare(newLiquidatorShareMantissa))
+          .to.be.revertedWithCustomError(busdLiquidator, "LiquidatorShareTooHigh")
+          .withArgs(TOTAL_LIQUIDATION_INCENTIVE.sub(TREASURY_PERCENT), newLiquidatorShareMantissa);
+      });
+
+      it("should succeed if new liquidator share is = (liquidation incentive - treasury percent)", async () => {
+        const newLiquidatorShareMantissa = TOTAL_LIQUIDATION_INCENTIVE.sub(TREASURY_PERCENT);
+        await busdLiquidator.setLiquidatorShare(newLiquidatorShareMantissa);
+        expect(await busdLiquidator.liquidatorShareMantissa()).to.equal(newLiquidatorShareMantissa);
+      });
+    });
+
+    describe("liquidateEntireBorrow", async () => {
+      it("should repay entire borrow", async () => {
+        const repayAmount = parseUnits("1000", 18);
+        const tx = await busdLiquidator.connect(someone).liquidateEntireBorrow(borrower.address, vCollateral.address);
+        await expect(tx).to.changeTokenBalances(busd, [someone, vBUSD], [repayAmount.mul(-1), repayAmount]);
+        expect(await vBUSD.callStatic.borrowBalanceCurrent(borrower.address)).to.equal(0);
+      });
+
+      it("should seize collateral", async () => {
+        const repayAmount = parseUnits("1000", 18);
+        const treasuryBalanceBefore = await vCollateral.callStatic.balanceOf(treasuryAddress);
+        const liquidatorBalanceBefore = await vCollateral.callStatic.balanceOf(someone.address);
+        const tx = await busdLiquidator.connect(someone).liquidateEntireBorrow(borrower.address, vCollateral.address);
+        const treasuryBalanceAfter = await vCollateral.callStatic.balanceOf(treasuryAddress);
+        const liquidatorBalanceAfter = await vCollateral.callStatic.balanceOf(someone.address);
+
+        const [, seizedCollateral] = await comptroller.callStatic.liquidateCalculateSeizeTokens(
+          vBUSD.address,
+          vCollateral.address,
+          repayAmount,
+        ); // 110%
+        const liquidatorShare = seizedCollateral.mul(101).div(110); // 101%
+        const treasuryShare = seizedCollateral.sub(liquidatorShare); // 110% - 101% = 9%
+        await expect(tx).to.changeTokenBalance(vCollateral, borrower, seizedCollateral.mul(-1));
+        expect(treasuryBalanceAfter.sub(treasuryBalanceBefore)).to.be.closeTo(treasuryShare, 1);
+        expect(liquidatorBalanceAfter.sub(liquidatorBalanceBefore)).to.be.closeTo(liquidatorShare, 1);
+      });
+    });
+
+    describe("liquidateBorrow", async () => {
+      it("should repay a part of the borrow", async () => {
+        const repayAmount = parseUnits("100", 18);
+        const tx = await busdLiquidator
+          .connect(someone)
+          .liquidateBorrow(borrower.address, repayAmount, vCollateral.address);
+        await expect(tx).to.changeTokenBalances(busd, [someone, vBUSD], [repayAmount.mul(-1), repayAmount]);
+        expect(await vBUSD.callStatic.borrowBalanceCurrent(borrower.address)).to.equal(parseUnits("900", 18));
+      });
+
+      it("should seize collateral", async () => {
+        const repayAmount = parseUnits("100", 18);
+        const tx = await busdLiquidator
+          .connect(someone)
+          .liquidateBorrow(borrower.address, repayAmount, vCollateral.address);
+        const [, seizedCollateral] = await comptroller.callStatic.liquidateCalculateSeizeTokens(
+          vBUSD.address,
+          vCollateral.address,
+          repayAmount,
+        ); // 110%
+        const liquidatorShare = seizedCollateral.mul(101).div(110); // 101%
+        const treasuryShare = seizedCollateral.sub(liquidatorShare); // 110% - 101% = 9%
+        await expect(tx).to.changeTokenBalances(
+          vCollateral,
+          [borrower, someone, treasuryAddress],
+          [seizedCollateral.mul(-1), liquidatorShare, treasuryShare],
+        );
+      });
+    });
+  });
+};
+
+if (FORK_MAINNET) {
+  const blockNumber = 32275000;
+  forking(blockNumber, test(setupFork));
+} else {
+  test(setupLocal)();
+}

--- a/tests/hardhat/Fork/utils.ts
+++ b/tests/hardhat/Fork/utils.ts
@@ -1,4 +1,5 @@
-import { impersonateAccount } from "@nomicfoundation/hardhat-network-helpers";
+import { impersonateAccount, setBalance } from "@nomicfoundation/hardhat-network-helpers";
+import { NumberLike } from "@nomicfoundation/hardhat-network-helpers/dist/src/types";
 import { ethers } from "hardhat";
 import { network } from "hardhat";
 
@@ -25,8 +26,11 @@ export const forking = (blockNumber: number, fn: () => void) => {
   });
 };
 
-export const initMainnetUser = async (user: string) => {
+export const initMainnetUser = async (user: string, balance?: NumberLike) => {
   await impersonateAccount(user);
+  if (balance) {
+    await setBalance(user, balance);
+  }
   return ethers.getSigner(user);
 };
 

--- a/tests/hardhat/Fork/utils.ts
+++ b/tests/hardhat/Fork/utils.ts
@@ -28,7 +28,7 @@ export const forking = (blockNumber: number, fn: () => void) => {
 
 export const initMainnetUser = async (user: string, balance?: NumberLike) => {
   await impersonateAccount(user);
-  if (balance) {
+  if (balance !== undefined) {
     await setBalance(user, balance);
   }
   return ethers.getSigner(user);

--- a/tests/hardhat/fixtures/ComptrollerWithMarkets.ts
+++ b/tests/hardhat/fixtures/ComptrollerWithMarkets.ts
@@ -9,7 +9,7 @@ import {
   ComptrollerMock,
   ComptrollerMock__factory,
   FaucetToken,
-  IAccessControlManager,
+  IAccessControlManagerV5,
   IERC20,
   InterestRateModel,
   JumpRateModel,
@@ -24,7 +24,7 @@ import { PriceOracle } from "../../../typechain/contracts/Oracle/PriceOracle";
 type MaybeFake<T extends BaseContract> = T | FakeContract<T>;
 
 interface ComptrollerFixture {
-  accessControlManager: FakeContract<IAccessControlManager>;
+  accessControlManager: FakeContract<IAccessControlManagerV5>;
   oracle: FakeContract<PriceOracle>;
   vaiController: FakeContract<VAIController>;
   comptroller: ComptrollerMock;
@@ -87,10 +87,8 @@ export const deployLiquidatorContract = async ({
   return liquidator;
 };
 
-export const deployFakeAccessControlManager = async (): Promise<FakeContract<IAccessControlManager>> => {
-  const acm = await smock.fake<IAccessControlManager>(
-    "contracts/Governance/IAccessControlManager.sol:IAccessControlManager",
-  );
+export const deployFakeAccessControlManager = async (): Promise<FakeContract<IAccessControlManagerV5>> => {
+  const acm = await smock.fake<IAccessControlManagerV5>("IAccessControlManagerV5");
   acm.isAllowedToCall.returns(true);
   return acm;
 };
@@ -103,7 +101,7 @@ export const deployFakeOracle = async (): Promise<FakeContract<PriceOracle>> => 
 
 export const deployComptroller = async (
   opts: Partial<{
-    accessControlManager: MaybeFake<IAccessControlManager>;
+    accessControlManager: MaybeFake<IAccessControlManagerV5>;
     oracle: MaybeFake<PriceOracle>;
     liquidationIncentiveMantissa: BigNumberish;
     closeFactorMantissa: BigNumberish;

--- a/tests/hardhat/fixtures/ComptrollerWithMarkets.ts
+++ b/tests/hardhat/fixtures/ComptrollerWithMarkets.ts
@@ -1,0 +1,248 @@
+import { FakeContract, smock } from "@defi-wonderland/smock";
+import { BaseContract, BigNumberish } from "ethers";
+import { parseUnits } from "ethers/lib/utils";
+import { ethers, upgrades } from "hardhat";
+
+import {
+  ComptrollerLens,
+  ComptrollerLens__factory,
+  ComptrollerMock,
+  ComptrollerMock__factory,
+  FaucetToken,
+  IAccessControlManager,
+  IERC20,
+  InterestRateModel,
+  JumpRateModel,
+  Liquidator,
+  MockVBNB,
+  VAIController,
+  VBep20,
+  VBep20Harness,
+} from "../../../typechain";
+import { PriceOracle } from "../../../typechain/contracts/Oracle/PriceOracle";
+
+type MaybeFake<T extends BaseContract> = T | FakeContract<T>;
+
+interface ComptrollerFixture {
+  accessControlManager: FakeContract<IAccessControlManager>;
+  oracle: FakeContract<PriceOracle>;
+  vaiController: FakeContract<VAIController>;
+  comptroller: ComptrollerMock;
+  comptrollerLens: ComptrollerLens;
+  vTokens: VBep20[];
+  vBNB: MockVBNB;
+}
+
+export const deployComptrollerWithMarkets = async ({
+  numBep20Tokens,
+}: {
+  numBep20Tokens: number;
+}): Promise<ComptrollerFixture> => {
+  const accessControlManager = await deployFakeAccessControlManager();
+  const oracle = await deployFakeOracle();
+  const comptrollerLens = await deployComptrollerLens();
+  const comptroller = await deployComptroller({ accessControlManager, comptrollerLens });
+
+  const vTokens: VBep20[] = [];
+  for (let i = 0; i < numBep20Tokens; i++) {
+    const vToken = await deployVToken({ comptroller });
+    await comptroller._supportMarket(vToken.address);
+    vTokens.push(vToken);
+  }
+  const vBNB = await deployVBNB({ comptroller });
+  await comptroller._supportMarket(vBNB.address);
+
+  const vaiController = await deployFakeVAIController();
+  await comptroller._setVAIController(vaiController.address);
+  return { accessControlManager, oracle, comptroller, comptrollerLens, vTokens, vBNB, vaiController };
+};
+
+export const deployFakeVAIController = async (
+  opts: Partial<{ vai: FaucetToken }> = {},
+): Promise<FakeContract<VAIController>> => {
+  const vai = opts.vai ?? (await deployMockToken({ name: "VAI", symbol: "VAI", decimals: 18 }));
+  const vaiController = await smock.fake<VAIController>("VAIController");
+  vaiController.getVAIAddress.returns(vai.address);
+  return vaiController;
+};
+
+export const deployLiquidatorContract = async ({
+  comptroller,
+  vBNB,
+  treasuryAddress,
+  treasuryPercentMantissa,
+}: {
+  comptroller: ComptrollerMock;
+  vBNB: MockVBNB;
+  treasuryAddress: string;
+  treasuryPercentMantissa: BigNumberish;
+}): Promise<Liquidator> => {
+  const liquidatorFactory = await ethers.getContractFactory("Liquidator");
+  const liquidator = (await upgrades.deployProxy(liquidatorFactory, [treasuryPercentMantissa], {
+    constructorArgs: [comptroller.address, vBNB.address, treasuryAddress],
+  })) as Liquidator;
+  await liquidator.setTreasuryPercent(treasuryPercentMantissa);
+  await liquidator.deployed();
+  await comptroller._setLiquidatorContract(liquidator.address);
+  return liquidator;
+};
+
+export const deployFakeAccessControlManager = async (): Promise<FakeContract<IAccessControlManager>> => {
+  const acm = await smock.fake<IAccessControlManager>(
+    "contracts/Governance/IAccessControlManager.sol:IAccessControlManager",
+  );
+  acm.isAllowedToCall.returns(true);
+  return acm;
+};
+
+export const deployFakeOracle = async (): Promise<FakeContract<PriceOracle>> => {
+  const oracle = await smock.fake<PriceOracle>("contracts/Oracle/PriceOracle.sol:PriceOracle");
+  oracle.getUnderlyingPrice.returns(parseUnits("1", 18));
+  return oracle;
+};
+
+export const deployComptroller = async (
+  opts: Partial<{
+    accessControlManager: MaybeFake<IAccessControlManager>;
+    oracle: MaybeFake<PriceOracle>;
+    liquidationIncentiveMantissa: BigNumberish;
+    closeFactorMantissa: BigNumberish;
+    comptrollerLens: MaybeFake<ComptrollerLens>;
+  }> = {},
+): Promise<ComptrollerMock> => {
+  const acm = opts.accessControlManager ?? (await deployFakeAccessControlManager());
+  const oracle = opts.oracle ?? (await deployFakeOracle());
+  const liquidationIncentiveMantissa = opts.liquidationIncentiveMantissa ?? parseUnits("1.1", 18);
+  const closeFactorMantissa = opts.closeFactorMantissa ?? parseUnits("0.5", 18);
+  const comptrollerLens = opts.comptrollerLens ?? (await deployComptrollerLens());
+
+  const comptrollerFactory: ComptrollerMock__factory = await ethers.getContractFactory("ComptrollerMock");
+  const comptroller = await comptrollerFactory.deploy();
+  await comptroller.deployed();
+  await comptroller._setComptrollerLens(comptrollerLens.address);
+  await comptroller._setAccessControl(acm.address);
+  await comptroller._setPriceOracle(oracle.address);
+  await comptroller._setLiquidationIncentive(liquidationIncentiveMantissa);
+  await comptroller._setCloseFactor(closeFactorMantissa);
+  return comptroller;
+};
+
+export const deployComptrollerLens = async (): Promise<ComptrollerLens> => {
+  const comptrollerLensFactory: ComptrollerLens__factory = await ethers.getContractFactory("ComptrollerLens");
+  const comptrollerLens = await comptrollerLensFactory.deploy();
+  await comptrollerLens.deployed();
+  return comptrollerLens;
+};
+
+export const deployJumpRateModel = async ({
+  baseRatePerYear,
+  multiplierPerYear,
+  jumpMultiplierPerYear,
+  kink,
+}: Partial<{
+  baseRatePerYear: BigNumberish;
+  multiplierPerYear: BigNumberish;
+  jumpMultiplierPerYear: BigNumberish;
+  kink: BigNumberish;
+}> = {}): Promise<JumpRateModel> => {
+  const jumpRateModelFactory = await ethers.getContractFactory("JumpRateModel");
+  const jumpRateModel = await jumpRateModelFactory.deploy(
+    baseRatePerYear ?? parseUnits("0.05", 18),
+    multiplierPerYear ?? parseUnits("0.8", 18),
+    jumpMultiplierPerYear ?? parseUnits("3", 18),
+    kink ?? parseUnits("0.7", 18),
+  );
+  await jumpRateModel.deployed();
+  return jumpRateModel;
+};
+
+export const deployMockToken = async ({
+  name,
+  symbol,
+  decimals,
+  initialSupply,
+}: Partial<{
+  name: string;
+  symbol: string;
+  decimals: number;
+  initialSupply: BigNumberish;
+  owner: string;
+}> = {}): Promise<FaucetToken> => {
+  const faucetTokenFactory = await ethers.getContractFactory("FaucetToken");
+  const faucetToken: FaucetToken = await faucetTokenFactory.deploy(
+    initialSupply ?? parseUnits("1000000", 18),
+    name ?? "FaucetToken",
+    decimals ?? 18,
+    symbol ?? "FAU",
+  );
+  await faucetToken.deployed();
+  return faucetToken;
+};
+
+export const deployVToken = async (
+  opts: Partial<{
+    underlying: IERC20;
+    comptroller: ComptrollerMock;
+    interestRateModel: InterestRateModel;
+    initialExchangeRateMantissa: BigNumberish;
+    name: string;
+    symbol: string;
+    decimals: number;
+    admin: string;
+  }> = {},
+): Promise<VBep20Harness> => {
+  const underlying = opts.underlying ?? (await deployMockToken());
+  const comptroller = opts.comptroller ?? (await deployComptroller());
+  const interestRateModel = opts.interestRateModel ?? (await deployJumpRateModel());
+  const initialExchangeRateMantissa = opts.initialExchangeRateMantissa ?? parseUnits("1", 18);
+  const name = opts.name ?? "VToken";
+  const symbol = opts.symbol ?? "VT";
+  const decimals = opts.decimals ?? 8;
+  const admin = opts.admin ?? (await ethers.getSigners())[0].address;
+
+  const vTokenFactory = await ethers.getContractFactory("VBep20Harness");
+  const vToken: VBep20Harness = await vTokenFactory.deploy(
+    underlying.address,
+    comptroller.address,
+    interestRateModel.address,
+    initialExchangeRateMantissa,
+    name,
+    symbol,
+    decimals,
+    admin,
+  );
+  await vToken.deployed();
+  return vToken;
+};
+
+export const deployVBNB = async (
+  opts: Partial<{
+    comptroller: ComptrollerMock;
+    interestRateModel: InterestRateModel;
+    initialExchangeRateMantissa: BigNumberish;
+    name: string;
+    symbol: string;
+    decimals: number;
+    admin: string;
+  }> = {},
+) => {
+  const comptroller = opts.comptroller ?? (await deployComptroller());
+  const interestRateModel = opts.interestRateModel ?? (await deployJumpRateModel());
+  const initialExchangeRateMantissa = opts.initialExchangeRateMantissa ?? parseUnits("1", 18);
+  const name = opts.name ?? "Venus BNB";
+  const symbol = opts.symbol ?? "vBNB";
+  const decimals = opts.decimals ?? 8;
+  const admin = opts.admin ?? (await ethers.getSigners())[0].address;
+
+  const vTokenFactory = await ethers.getContractFactory("MockVBNB");
+  const vBNB: MockVBNB = await vTokenFactory.deploy(
+    comptroller.address,
+    interestRateModel.address,
+    initialExchangeRateMantissa,
+    name,
+    symbol,
+    decimals,
+    admin,
+  );
+  return vBNB;
+};


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

This PR adds a custom mechanism for BUSD liquidations. Only BUSD liquidator contract will be allowed to liquidate BUSD borrows. To reduce the potential impact of this change, we will not upgrade Comptroller or Liquidator contracts. Instead, BUSD liquidator contract will be allowed to pause and unpause liquidating BUSD debts. Between the transactions, BUSD liquidations will be paused, as far as Comptroller is concerned.

Once a liquidation is triggered in the BUSD liquidator contract, it would:

1. Unpause the liquidations in the Comptroller
1. Transfer BUSD from the sender and approve the Venus Liquidator contract
1. Perform a liquidation
1. Distribute the seized collateral, including the liquidation incentive, according to a custom distribution scheme, configured by Governance

