### PR TITLE
[VEN-2005]: fix BUSDLiquidator tests

### DIFF
--- a/tests/hardhat/Fork/BUSDLiquidator.ts
+++ b/tests/hardhat/Fork/BUSDLiquidator.ts
@@ -71,6 +71,15 @@ const setupLocal = async (): Promise<BUSDLiquidatorFixture> => {
   const [, supplier, borrower, someone, treasury] = await ethers.getSigners();
   const { comptroller, vTokens, vBNB } = await deployComptrollerWithMarkets({ numBep20Tokens: 2 });
   const [vBUSD, vCollateral] = vTokens;
+  const zeroRateModel = await deployJumpRateModel({
+    baseRatePerYear: 0,
+    multiplierPerYear: 0,
+    jumpMultiplierPerYear: 0,
+    kink: 0,
+  });
+  await zeroRateModel.deployed();
+  await vBUSD._setInterestRateModel(zeroRateModel.address);
+
   await deployLiquidatorContract({
     comptroller,
     vBNB,

--- a/tests/hardhat/Fork/utils.ts
+++ b/tests/hardhat/Fork/utils.ts
@@ -1,4 +1,5 @@
-import { impersonateAccount } from "@nomicfoundation/hardhat-network-helpers";
+import { impersonateAccount, setBalance } from "@nomicfoundation/hardhat-network-helpers";
+import { NumberLike } from "@nomicfoundation/hardhat-network-helpers/dist/src/types";
 import { ethers } from "hardhat";
 import { network } from "hardhat";
 

--- a/tests/hardhat/fixtures/ComptrollerWithMarkets.ts
+++ b/tests/hardhat/fixtures/ComptrollerWithMarkets.ts
@@ -45,7 +45,7 @@ export const deployComptrollerWithMarkets = async ({
 
   const vTokens: VBep20[] = [];
   for (let i = 0; i < numBep20Tokens; i++) {
-    const vToken = await deployVToken({ comptroller });
+    const vToken = await deployVToken({ comptroller, accessControlManager });
     await comptroller._supportMarket(vToken.address);
     vTokens.push(vToken);
   }
@@ -179,6 +179,7 @@ export const deployMockToken = async ({
 
 export const deployVToken = async (
   opts: Partial<{
+    accessControlManager: MaybeFake<IAccessControlManagerV5>;
     underlying: IERC20;
     comptroller: ComptrollerMock;
     interestRateModel: InterestRateModel;
@@ -189,6 +190,7 @@ export const deployVToken = async (
     admin: string;
   }> = {},
 ): Promise<VBep20Harness> => {
+  const accessControlManager = opts.accessControlManager ?? (await deployFakeAccessControlManager());
   const underlying = opts.underlying ?? (await deployMockToken());
   const comptroller = opts.comptroller ?? (await deployComptroller());
   const interestRateModel = opts.interestRateModel ?? (await deployJumpRateModel());
@@ -210,6 +212,7 @@ export const deployVToken = async (
     admin,
   );
   await vToken.deployed();
+  await vToken.setAccessControlManager(accessControlManager.address);
   return vToken;
 };
 


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

Related to VEN-2005

* Recover lost imports in commit 2538f339280326423f8f1961284d9c0da5ffdb8f
* Fix local execution of the tests at `tests/hardhat/Fork/BUSDLiquidator.ts`. When FORK is disabled, three tests failed due to small differences in the expected balances after the liquidations. The fix uses zero rate model to prevent new interest accruals (regardless of the automine mode).

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
