### PR TITLE
[VEN-2142]: add forced liquidations for individual accounts

### DIFF
--- a/contracts/Comptroller/ComptrollerStorage.sol
+++ b/contracts/Comptroller/ComptrollerStorage.sol
@@ -8,6 +8,20 @@ import { VAIControllerInterface } from "../Tokens/VAI/VAIControllerInterface.sol
 import { ComptrollerLensInterface } from "./ComptrollerLensInterface.sol";
 import { IPrime } from "../Tokens/Prime/IPrime.sol";
 
+interface ComptrollerTypes {
+    enum Action {
+        MINT,
+        REDEEM,
+        BORROW,
+        REPAY,
+        SEIZE,
+        LIQUIDATE,
+        TRANSFER,
+        ENTER_MARKET,
+        EXIT_MARKET
+    }
+}
+
 contract UnitrollerAdminStorage {
     /**
      * @notice Administrator for this contract
@@ -30,7 +44,7 @@ contract UnitrollerAdminStorage {
     address public pendingComptrollerImplementation;
 }
 
-contract ComptrollerV1Storage is UnitrollerAdminStorage {
+contract ComptrollerV1Storage is ComptrollerTypes, UnitrollerAdminStorage {
     /**
      * @notice Oracle which gives the price of any given asset
      */
@@ -207,18 +221,6 @@ contract ComptrollerV8Storage is ComptrollerV7Storage {
 contract ComptrollerV9Storage is ComptrollerV8Storage {
     /// @notice AccessControlManager address
     address internal accessControl;
-
-    enum Action {
-        MINT,
-        REDEEM,
-        BORROW,
-        REPAY,
-        SEIZE,
-        LIQUIDATE,
-        TRANSFER,
-        ENTER_MARKET,
-        EXIT_MARKET
-    }
 
     /// @notice True if a certain action is paused on a certain market
     mapping(address => mapping(uint256 => bool)) internal _actionPaused;

--- a/contracts/Comptroller/ComptrollerStorage.sol
+++ b/contracts/Comptroller/ComptrollerStorage.sol
@@ -239,6 +239,7 @@ contract ComptrollerV11Storage is ComptrollerV10Storage {
 }
 
 contract ComptrollerV12Storage is ComptrollerV11Storage {
+    /// @notice Whether forced liquidation is enabled for all users borrowing in a certain market
     mapping(address => bool) public isForcedLiquidationEnabled;
 }
 
@@ -263,4 +264,9 @@ contract ComptrollerV13Storage is ComptrollerV12Storage {
 contract ComptrollerV14Storage is ComptrollerV13Storage {
     /// @notice Prime token address
     IPrime public prime;
+}
+
+contract ComptrollerV15Storage is ComptrollerV14Storage {
+    /// @notice Whether forced liquidation is enabled for the borrows of a user in a market
+    mapping(address /* user */ => mapping(address /* market */ => bool)) public isForcedLiquidationEnabledForUser;
 }

--- a/contracts/Comptroller/Diamond/Diamond.sol
+++ b/contracts/Comptroller/Diamond/Diamond.sol
@@ -4,14 +4,14 @@ pragma solidity 0.5.16;
 pragma experimental ABIEncoderV2;
 
 import { IDiamondCut } from "./interfaces/IDiamondCut.sol";
-import { Unitroller, ComptrollerV14Storage } from "../Unitroller.sol";
+import { Unitroller, ComptrollerV15Storage } from "../Unitroller.sol";
 
 /**
  * @title Diamond
  * @author Venus
  * @notice This contract contains functions related to facets
  */
-contract Diamond is IDiamondCut, ComptrollerV14Storage {
+contract Diamond is IDiamondCut, ComptrollerV15Storage {
     /// @notice Emitted when functions are added, replaced or removed to facets
     event DiamondCut(IDiamondCut.FacetCut[] _diamondCut);
 
@@ -72,7 +72,7 @@ contract Diamond is IDiamondCut, ComptrollerV14Storage {
      */
     function facetAddress(
         bytes4 functionSelector
-    ) external view returns (ComptrollerV14Storage.FacetAddressAndPosition memory) {
+    ) external view returns (ComptrollerV15Storage.FacetAddressAndPosition memory) {
         return _selectorToFacetAndPosition[functionSelector];
     }
 

--- a/contracts/Comptroller/Diamond/facets/FacetBase.sol
+++ b/contracts/Comptroller/Diamond/facets/FacetBase.sol
@@ -4,7 +4,7 @@ pragma solidity 0.5.16;
 
 import { VToken, ComptrollerErrorReporter, ExponentialNoError } from "../../../Tokens/VTokens/VToken.sol";
 import { IVAIVault } from "../../../Comptroller/ComptrollerInterface.sol";
-import { ComptrollerV14Storage } from "../../../Comptroller/ComptrollerStorage.sol";
+import { ComptrollerV15Storage } from "../../../Comptroller/ComptrollerStorage.sol";
 import { IAccessControlManagerV5 } from "@venusprotocol/governance-contracts/contracts/Governance/IAccessControlManagerV5.sol";
 
 import { SafeBEP20, IBEP20 } from "../../../Utils/SafeBEP20.sol";
@@ -14,13 +14,7 @@ import { SafeBEP20, IBEP20 } from "../../../Utils/SafeBEP20.sol";
  * @author Venus
  * @notice This facet contract contains functions related to access and checks
  */
-contract FacetBase is ComptrollerV14Storage, ExponentialNoError, ComptrollerErrorReporter {
-    /// @notice Emitted when an account enters a market
-    event MarketEntered(VToken indexed vToken, address indexed account);
-
-    /// @notice Emitted when XVS is distributed to VAI Vault
-    event DistributedVAIVaultVenus(uint256 amount);
-
+contract FacetBase is ComptrollerV15Storage, ExponentialNoError, ComptrollerErrorReporter {
     using SafeBEP20 for IBEP20;
 
     /// @notice The initial Venus index for a market
@@ -31,6 +25,12 @@ contract FacetBase is ComptrollerV14Storage, ExponentialNoError, ComptrollerErro
     uint256 internal constant closeFactorMaxMantissa = 0.9e18; // 0.9
     // No collateralFactorMantissa may exceed this value
     uint256 internal constant collateralFactorMaxMantissa = 0.9e18; // 0.9
+
+    /// @notice Emitted when an account enters a market
+    event MarketEntered(VToken indexed vToken, address indexed account);
+
+    /// @notice Emitted when XVS is distributed to VAI Vault
+    event DistributedVAIVaultVenus(uint256 amount);
 
     /// @notice Reverts if the protocol is paused
     function checkProtocolPauseState() internal view {

--- a/contracts/Comptroller/Diamond/facets/PolicyFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/PolicyFacet.sol
@@ -248,7 +248,7 @@ contract PolicyFacet is IPolicyFacet, XVSRewardsHelper {
             borrowBalance = vaiController.getVAIRepayAmount(borrower);
         }
 
-        if (isForcedLiquidationEnabled[vTokenBorrowed]) {
+        if (isForcedLiquidationEnabled[vTokenBorrowed] || isForcedLiquidationEnabledForUser[borrower][vTokenBorrowed]) {
             if (repayAmount > borrowBalance) {
                 return uint(Error.TOO_MUCH_REPAY);
             }

--- a/contracts/Comptroller/Diamond/facets/SetterFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/SetterFacet.sol
@@ -81,8 +81,11 @@ contract SetterFacet is ISetterFacet, FacetBase {
     /// @notice Emitted when prime token contract address is changed
     event NewPrimeToken(IPrime oldPrimeToken, IPrime newPrimeToken);
 
-    /// @notice Emitted when force liquidation enabled for a market
+    /// @notice Emitted when forced liquidation is enabled or disabled for all users in a market
     event IsForcedLiquidationEnabledUpdated(address indexed vToken, bool enable);
+
+    /// @notice Emitted when forced liquidation is enabled or disabled for a user borrowing in a market
+    event IsForcedLiquidationEnabledForUserUpdated(address indexed borrower, address indexed vToken, bool enable);
 
     /**
      * @notice Compare two addresses to ensure they are different
@@ -546,7 +549,25 @@ contract SetterFacet is ISetterFacet, FacetBase {
         if (vTokenBorrowed != address(vaiController)) {
             ensureListed(markets[vTokenBorrowed]);
         }
-        isForcedLiquidationEnabled[address(vTokenBorrowed)] = enable;
+        isForcedLiquidationEnabled[vTokenBorrowed] = enable;
         emit IsForcedLiquidationEnabledUpdated(vTokenBorrowed, enable);
+    }
+
+    /**
+     * @notice Enables forced liquidations for user's borrows in a certain market. If forced
+     * liquidation is enabled, user's borrows in the market may be liquidated regardless of
+     * the account liquidity. Forced liquidation may be enabled for a user even if it is not
+     * enabled for the entire market.
+     * @param borrower The address of the borrower
+     * @param vTokenBorrowed Borrowed vToken
+     * @param enable Whether to enable forced liquidations
+     */
+    function _setForcedLiquidationForUser(address borrower, address vTokenBorrowed, bool enable) external {
+        ensureAllowed("_setForcedLiquidationForUser(address,address,bool)");
+        if (vTokenBorrowed != address(vaiController)) {
+            ensureListed(markets[vTokenBorrowed]);
+        }
+        isForcedLiquidationEnabledForUser[borrower][vTokenBorrowed] = enable;
+        emit IsForcedLiquidationEnabledForUserUpdated(borrower, vTokenBorrowed, enable);
     }
 }

--- a/contracts/Comptroller/Diamond/interfaces/IRewardFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/IRewardFacet.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.5.16;
 
 import { VToken } from "../../../Tokens/VTokens/VToken.sol";
-import { ComptrollerV14Storage } from "../../ComptrollerStorage.sol";
+import { ComptrollerTypes } from "../../ComptrollerStorage.sol";
 
 interface IRewardFacet {
     function claimVenus(address holder) external;
@@ -20,7 +20,7 @@ interface IRewardFacet {
 
     function getXVSVTokenAddress() external pure returns (address);
 
-    function actionPaused(address market, ComptrollerV14Storage.Action action) external view returns (bool);
+    function actionPaused(address market, ComptrollerTypes.Action action) external view returns (bool);
 
     function claimVenus(
         address[] calldata holders,

--- a/contracts/Comptroller/Diamond/interfaces/ISetterFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/ISetterFacet.sol
@@ -4,7 +4,7 @@ pragma solidity 0.5.16;
 
 import { PriceOracle } from "../../../Oracle/PriceOracle.sol";
 import { VToken } from "../../../Tokens/VTokens/VToken.sol";
-import { ComptrollerV14Storage } from "../../ComptrollerStorage.sol";
+import { ComptrollerTypes } from "../../ComptrollerStorage.sol";
 import { VAIControllerInterface } from "../../../Tokens/VAI/VAIController.sol";
 import { ComptrollerLensInterface } from "../../../Comptroller/ComptrollerLensInterface.sol";
 import { IPrime } from "../../../Tokens/Prime/IPrime.sol";
@@ -32,7 +32,7 @@ interface ISetterFacet {
 
     function _setActionsPaused(
         address[] calldata markets,
-        ComptrollerV14Storage.Action[] calldata actions,
+        ComptrollerTypes.Action[] calldata actions,
         bool paused
     ) external;
 

--- a/contracts/Comptroller/Diamond/interfaces/ISetterFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/ISetterFacet.sol
@@ -57,4 +57,6 @@ interface ISetterFacet {
     function _setForcedLiquidation(address vToken, bool enable) external;
 
     function _setPrimeToken(IPrime _prime) external returns (uint);
+
+    function _setForcedLiquidationForUser(address borrower, address vTokenBorrowed, bool enable) external;
 }


### PR DESCRIPTION
**Problem:** Sometimes it is useful to liquidate an individual borrower even if the account doesn't have a shortfall. One example may be the BNB exploiter position that, although is healthy, requires constant monitoring despite being disabled on the underlying blockchain level. Other examples may include positions of other individuals that the Governance deems unwanted to Venus, e.g. the accounts of those who have caused shortfalls in the past.

**Solution:** Implement a mechanism similar to forced liquidations that would allow Venus Governance to switch off liquidity checks for a certain account in a certain market.

**Note** that forced liquidations enabled for a user does not prohibit further borrows, i.e. the account being force-liquidated in a certain market can still borrow funds in this market.

Resolves VEN-2142

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
