### PR TITLE
refactor: make imports explicit and direct

### DIFF
--- a/contracts/Admin/VBNBAdmin.sol
+++ b/contracts/Admin/VBNBAdmin.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.13;
 
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@venusprotocol/governance-contracts/contracts/Governance/AccessControlledV8.sol";
-import "./VBNBAdminStorage.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { IProtocolShareReserve, IWBNB, VBNBAdminStorage, VTokenInterface } from "./VBNBAdminStorage.sol";
 
 /**
  * @title VBNBAdmin

--- a/contracts/Comptroller/Diamond/facets/MarketFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/MarketFacet.sol
@@ -3,7 +3,8 @@
 pragma solidity 0.5.16;
 
 import { IMarketFacet } from "../interfaces/IMarketFacet.sol";
-import { FacetBase, VToken } from "./FacetBase.sol";
+import { FacetBase } from "./FacetBase.sol";
+import { VToken } from "../../../Tokens/VTokens/VToken.sol";
 
 /**
  * @title MarketFacet

--- a/contracts/Comptroller/Diamond/facets/PolicyFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/PolicyFacet.sol
@@ -2,9 +2,10 @@
 
 pragma solidity 0.5.16;
 
+import { VToken } from "../../../Tokens/VTokens/VToken.sol";
 import { IPolicyFacet } from "../interfaces/IPolicyFacet.sol";
 
-import { XVSRewardsHelper, VToken } from "./XVSRewardsHelper.sol";
+import { XVSRewardsHelper } from "./XVSRewardsHelper.sol";
 
 /**
  * @title PolicyFacet

--- a/contracts/Comptroller/Diamond/facets/RewardFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/RewardFacet.sol
@@ -2,8 +2,9 @@
 
 pragma solidity 0.5.16;
 
+import { VToken } from "../../../Tokens/VTokens/VToken.sol";
 import { IRewardFacet } from "../interfaces/IRewardFacet.sol";
-import { XVSRewardsHelper, VToken } from "./XVSRewardsHelper.sol";
+import { XVSRewardsHelper } from "./XVSRewardsHelper.sol";
 import { SafeBEP20, IBEP20 } from "../../../Utils/SafeBEP20.sol";
 import { VBep20Interface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 

--- a/contracts/Comptroller/Diamond/facets/SetterFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/SetterFacet.sol
@@ -2,11 +2,12 @@
 
 pragma solidity 0.5.16;
 
+import { VToken } from "../../../Tokens/VTokens/VToken.sol";
 import { ISetterFacet } from "../interfaces/ISetterFacet.sol";
 import { PriceOracle } from "../../../Oracle/PriceOracle.sol";
 import { ComptrollerLensInterface } from "../../ComptrollerLensInterface.sol";
 import { VAIControllerInterface } from "../../../Tokens/VAI/VAIControllerInterface.sol";
-import { FacetBase, VToken } from "./FacetBase.sol";
+import { FacetBase } from "./FacetBase.sol";
 import { IPrime } from "../../../Tokens/Prime/IPrime.sol";
 
 /**

--- a/contracts/Comptroller/Diamond/facets/XVSRewardsHelper.sol
+++ b/contracts/Comptroller/Diamond/facets/XVSRewardsHelper.sol
@@ -2,7 +2,8 @@
 
 pragma solidity 0.5.16;
 
-import { FacetBase, VToken } from "./FacetBase.sol";
+import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { FacetBase } from "./FacetBase.sol";
 
 /**
  * @title XVSRewardsHelper

--- a/contracts/Lens/ComptrollerLens.sol
+++ b/contracts/Lens/ComptrollerLens.sol
@@ -2,7 +2,8 @@ pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
 import "../Tokens/VTokens/VBep20.sol";
-import "../Tokens/VTokens/VToken.sol";
+import { VToken } from "../Tokens/VTokens/VToken.sol";
+import { ExponentialNoError } from "../Utils/ExponentialNoError.sol";
 import "../Tokens/EIP20Interface.sol";
 import "../Oracle/PriceOracle.sol";
 import "../Utils/ErrorReporter.sol";

--- a/contracts/Lens/SnapshotLens.sol
+++ b/contracts/Lens/SnapshotLens.sol
@@ -1,7 +1,8 @@
 pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
-import "../Tokens/VTokens/VToken.sol";
+import { VToken } from   "../Tokens/VTokens/VToken.sol";
+import { ExponentialNoError } from "../Utils/ExponentialNoError.sol";
 import "../Utils/SafeMath.sol";
 import "../Comptroller/ComptrollerInterface.sol";
 import "../Tokens/EIP20Interface.sol";

--- a/contracts/Lens/SnapshotLens.sol
+++ b/contracts/Lens/SnapshotLens.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
-import { VToken } from   "../Tokens/VTokens/VToken.sol";
+import { VToken } from "../Tokens/VTokens/VToken.sol";
 import { ExponentialNoError } from "../Utils/ExponentialNoError.sol";
 import "../Utils/SafeMath.sol";
 import "../Comptroller/ComptrollerInterface.sol";

--- a/contracts/Tokens/VAI/VAIController.sol
+++ b/contracts/Tokens/VAI/VAIController.sol
@@ -5,7 +5,7 @@ import "../../Utils/ErrorReporter.sol";
 import "../../Utils/Exponential.sol";
 import "../../Comptroller/ComptrollerInterface.sol";
 import "@venusprotocol/governance-contracts/contracts/Governance/IAccessControlManagerV5.sol";
-import "../VTokens/VToken.sol";
+import { VToken, EIP20Interface } from "../VTokens/VToken.sol";
 import "./VAIUnitroller.sol";
 import "./VAI.sol";
 

--- a/contracts/Tokens/VTokens/VBep20.sol
+++ b/contracts/Tokens/VTokens/VBep20.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.5.16;
 
-import "./VToken.sol";
+import { VToken, VBep20Interface, ComptrollerInterface, InterestRateModel, VTokenInterface } from "./VToken.sol";
+import { EIP20Interface } from "../EIP20Interface.sol";
+import { EIP20NonStandardInterface } from "../EIP20NonStandardInterface.sol";
 
 /**
  * @title Venus's VBep20 Contract

--- a/contracts/Tokens/VTokens/VBep20Delegate.sol
+++ b/contracts/Tokens/VTokens/VBep20Delegate.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.16;
 
-import "./VBep20.sol";
+import { VBep20 } from "./VBep20.sol";
+import { VDelegateInterface } from "./VTokenInterfaces.sol";
 
 /**
  * @title Venus's VBep20Delegate Contract


### PR DESCRIPTION
## Description

To make the contracts compile for the subgraph tests we have to patch some clashing contract names which requires named imports. When preparing that patch, errors started to appear that lead me to discover that variables are being imported through files where they are not defined.

I was able to resolve those errors by making the imports from the files where the variables were defined.

This PR updates VToken and related imports to be named and direct from the files where they are defined