### PR TITLE
[VEN-2239]: add a utility contract to redeem VBep20 tokens

### DIFF
--- a/contracts/Governance/TokenRedeemer.sol
+++ b/contracts/Governance/TokenRedeemer.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+
+import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ensureNonzeroAddress } from "@venusprotocol/solidity-utilities/contracts/validators.sol";
+
+import { IVBep20 } from "../InterfacesV8.sol";
+
+contract TokenRedeemer is ReentrancyGuard, Ownable2Step {
+    using SafeERC20 for IERC20;
+
+    error RedeemFailed(uint256 errCode);
+
+    constructor(address owner_) {
+        ensureNonzeroAddress(owner_);
+        _transferOwnership(owner_);
+    }
+
+    function redeemAndTransfer(IVBep20 vToken, address destination) external nonReentrant onlyOwner {
+        IERC20 underlying = IERC20(vToken.underlying());
+        uint256 err = vToken.redeem(vToken.balanceOf(address(this)));
+        if (err != 0) {
+            revert RedeemFailed(err);
+        }
+        _transferAll(underlying, destination);
+    }
+
+    function sweepTokens(IERC20 token, address destination) external onlyOwner {
+        _transferAll(token, destination);
+    }
+
+    function _transferAll(IERC20 token, address destination) internal {
+        token.safeTransfer(destination, token.balanceOf(address(this)));
+    }
+}

--- a/contracts/InterfacesV8.sol
+++ b/contracts/InterfacesV8.sol
@@ -5,6 +5,8 @@ import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC
 import { ResilientOracleInterface } from "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";
 
 interface IVToken is IERC20Upgradeable {
+    function redeem(uint256 redeemTokens) external returns (uint256);
+
     function borrowBalanceCurrent(address borrower) external returns (uint256);
 
     function comptroller() external view returns (IComptroller);

--- a/tests/hardhat/Fork/TokenRedeemer.ts
+++ b/tests/hardhat/Fork/TokenRedeemer.ts
@@ -1,0 +1,146 @@
+import { smock } from "@defi-wonderland/smock";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import chai from "chai";
+import { parseEther, parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import { FaucetToken, TokenRedeemer, TokenRedeemer__factory, VBep20 } from "../../../typechain";
+import { deployComptrollerWithMarkets } from "../fixtures/ComptrollerWithMarkets";
+import { FORK_MAINNET, around, forking, initMainnetUser } from "./utils";
+
+const { expect } = chai;
+chai.use(smock.matchers);
+
+const SUPPLIED_AMOUNT = parseUnits("5000", 18);
+
+const addresses = {
+  bscmainnet: {
+    COMPTROLLER: "0xfD36E2c2a6789Db23113685031d7F16329158384",
+    VBUSD: "0x95c78222B3D6e262426483D42CfA53685A67Ab9D",
+    BUSD_HOLDER: "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56",
+    TIMELOCK: "0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396",
+    ACCESS_CONTROL_MANAGER: "0x4788629ABc6cFCA10F9f969efdEAa1cF70c23555",
+  },
+};
+
+const deployTokenRedeemer = async (owner: { address: string }): Promise<TokenRedeemer> => {
+  const redeemerFactory: TokenRedeemer__factory = await ethers.getContractFactory("TokenRedeemer");
+  const redeemer = await redeemerFactory.deploy(owner.address);
+  await redeemer.deployed();
+  return redeemer;
+};
+
+interface TokenRedeemerFixture {
+  redeemer: TokenRedeemer;
+  vToken: VBep20;
+  underlying: FaucetToken;
+  owner: SignerWithAddress;
+  supplier: SignerWithAddress;
+  treasuryAddress: string;
+}
+
+const setupLocal = async (): Promise<TokenRedeemerFixture> => {
+  const [, owner, supplier, treasury] = await ethers.getSigners();
+  const { comptroller, vTokens } = await deployComptrollerWithMarkets({ numBep20Tokens: 1 });
+  const [vToken] = vTokens;
+
+  const redeemer = await deployTokenRedeemer(owner);
+  await comptroller._setMarketSupplyCaps([vToken.address], [ethers.constants.MaxUint256]);
+  const underlying = await ethers.getContractAt("FaucetToken", await vToken.underlying());
+
+  await underlying.allocateTo(supplier.address, SUPPLIED_AMOUNT);
+  await underlying.connect(supplier).approve(vToken.address, SUPPLIED_AMOUNT);
+  await vToken.connect(supplier).mint(SUPPLIED_AMOUNT);
+
+  return { redeemer, supplier, vToken, underlying, owner, treasuryAddress: treasury.address };
+};
+
+const setupFork = async (): Promise<TokenRedeemerFixture> => {
+  const comptroller = await ethers.getContractAt("ComptrollerMock", addresses.bscmainnet.COMPTROLLER);
+  const vToken = await ethers.getContractAt("VBep20", addresses.bscmainnet.VBUSD);
+  const underlying = await ethers.getContractAt("contracts/Utils/IBEP20.sol:IBEP20", await vToken.underlying());
+  const treasuryAddress = await comptroller.treasuryAddress();
+
+  const timelock = await initMainnetUser(addresses.bscmainnet.TIMELOCK, parseEther("1"));
+  const redeemer = await deployTokenRedeemer(timelock);
+  await comptroller.connect(timelock)._setMarketSupplyCaps([vToken.address], [ethers.constants.MaxUint256]);
+  const actions = { MINT: 0 };
+  await comptroller.connect(timelock)._setActionsPaused([vToken.address], [actions.MINT], false);
+
+  const supplier = await initMainnetUser(addresses.bscmainnet.BUSD_HOLDER, parseEther("1"));
+  await underlying.connect(supplier).approve(vToken.address, SUPPLIED_AMOUNT);
+  await vToken.connect(supplier).mint(SUPPLIED_AMOUNT); // inject liquidity
+  return { redeemer, supplier, vToken, underlying, owner: timelock, treasuryAddress };
+};
+
+const test = (setup: () => Promise<TokenRedeemerFixture>) => () => {
+  describe("TokenRedeemer", () => {
+    let redeemer: TokenRedeemer;
+    let vToken: VBep20;
+    let underlying: FaucetToken;
+    let owner: SignerWithAddress;
+    let supplier: SignerWithAddress;
+    let someone: SignerWithAddress;
+    let treasuryAddress: string;
+
+    beforeEach(async () => {
+      ({ redeemer, vToken, underlying, owner, supplier, treasuryAddress } = await loadFixture(setup));
+      [someone] = await ethers.getSigners();
+    });
+
+    describe("redeemAndTransfer", () => {
+      it("should fail if called by a non-owner", async () => {
+        await expect(redeemer.connect(someone).redeemAndTransfer(vToken.address, treasuryAddress)).to.be.revertedWith(
+          "Ownable: caller is not the owner",
+        );
+      });
+
+      it("should fail if redeem fails", async () => {
+        const failingVToken = await smock.fake<VBep20>("VBep20");
+        failingVToken.redeem.returns(42);
+        await expect(redeemer.connect(owner).redeemAndTransfer(failingVToken.address, treasuryAddress))
+          .to.be.revertedWithCustomError(redeemer, "RedeemFailed")
+          .withArgs(42);
+      });
+
+      it("should succeed with zero amount", async () => {
+        const tx = await redeemer.connect(owner).redeemAndTransfer(vToken.address, treasuryAddress);
+        await expect(tx).to.emit(vToken, "Transfer").withArgs(redeemer.address, vToken.address, "0");
+        await expect(tx).to.emit(underlying, "Transfer").withArgs(redeemer.address, treasuryAddress, "0");
+      });
+
+      it("should redeem all vTokens", async () => {
+        const vTokenAmount = await vToken.balanceOf(supplier.address);
+        const closeToSuppliedAmount = around(SUPPLIED_AMOUNT, parseUnits("0.1", 18));
+        await vToken.connect(supplier).transfer(redeemer.address, vTokenAmount);
+        const tx = await redeemer.connect(owner).redeemAndTransfer(vToken.address, treasuryAddress);
+        await expect(tx).to.emit(vToken, "Redeem").withArgs(redeemer.address, closeToSuppliedAmount, vTokenAmount, "0");
+        await expect(tx).to.emit(vToken, "Transfer").withArgs(redeemer.address, vToken.address, vTokenAmount);
+        await expect(tx)
+          .to.emit(underlying, "Transfer")
+          .withArgs(vToken.address, redeemer.address, closeToSuppliedAmount);
+        expect(await vToken.balanceOf(redeemer.address)).to.equal(0);
+      });
+
+      it("should transfer all underlying to the receiver", async () => {
+        const vTokenAmount = await vToken.balanceOf(supplier.address);
+        const closeToSuppliedAmount = around(SUPPLIED_AMOUNT, parseUnits("0.1", 18));
+        await vToken.connect(supplier).transfer(redeemer.address, vTokenAmount);
+        const tx = await redeemer.connect(owner).redeemAndTransfer(vToken.address, treasuryAddress);
+        await expect(tx)
+          .to.emit(underlying, "Transfer")
+          .withArgs(redeemer.address, treasuryAddress, closeToSuppliedAmount);
+        expect(await underlying.balanceOf(redeemer.address)).to.equal(0);
+        expect(await underlying.balanceOf(treasuryAddress)).to.satisfy(closeToSuppliedAmount);
+      });
+    });
+  });
+};
+
+if (FORK_MAINNET) {
+  const blockNumber = 34699200;
+  forking(blockNumber, test(setupFork));
+} else {
+  test(setupLocal)();
+}

--- a/tests/hardhat/Fork/utils.ts
+++ b/tests/hardhat/Fork/utils.ts
@@ -1,5 +1,6 @@
 import { impersonateAccount, setBalance } from "@nomicfoundation/hardhat-network-helpers";
 import { NumberLike } from "@nomicfoundation/hardhat-network-helpers/dist/src/types";
+import { BigNumber, BigNumberish } from "ethers";
 import { ethers } from "hardhat";
 import { network } from "hardhat";
 
@@ -35,3 +36,10 @@ export const initMainnetUser = async (user: string, balance?: NumberLike) => {
 };
 
 export const FORK_MAINNET = process.env.FORK === "true" && process.env.FORKED_NETWORK === "bscmainnet";
+
+export const around = (expected: BigNumberish, tolerance: BigNumberish) => {
+  return (actual: BigNumberish) => {
+    const diff = BigNumber.from(expected).sub(actual).abs();
+    return diff.lte(tolerance);
+  };
+};


### PR DESCRIPTION
It's sometimes useful to redeem vTokens and transfer the received amount to some third party. However, it can't be done in one transaction because, in general, it's impossible to know exactly how much underlying the caller would get for one redeemed vToken.

This contract redeems all vTokens it has and transfers these vTokens to the specified receiver.

The contract is ownable to limit the potential attack surface and minimize audit requirements, but I see no risk in making it permissionless in future.