### PR TITLE
feat: migrate to 0.8.20

### DIFF
--- a/contracts/Admin/VBNBAdmin.sol
+++ b/contracts/Admin/VBNBAdmin.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@venusprotocol/governance-contracts/contracts/Governance/AccessControlledV8.sol";

--- a/contracts/Admin/VBNBAdminStorage.sol
+++ b/contracts/Admin/VBNBAdminStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 

--- a/contracts/DelegateBorrowers/MoveDebtDelegate.sol
+++ b/contracts/DelegateBorrowers/MoveDebtDelegate.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";

--- a/contracts/DelegateBorrowers/SwapDebtDelegate.sol
+++ b/contracts/DelegateBorrowers/SwapDebtDelegate.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";

--- a/contracts/Governance/TokenRedeemer.sol
+++ b/contracts/Governance/TokenRedeemer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";

--- a/contracts/InterfacesV8.sol
+++ b/contracts/InterfacesV8.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { ResilientOracleInterface } from "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";

--- a/contracts/Liquidator/BUSDLiquidator.sol
+++ b/contracts/Liquidator/BUSDLiquidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/Liquidator/Liquidator.sol
+++ b/contracts/Liquidator/Liquidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/contracts/Liquidator/LiquidatorStorage.sol
+++ b/contracts/Liquidator/LiquidatorStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 contract LiquidatorStorage {
     /* State */

--- a/contracts/PegStability/IVAI.sol
+++ b/contracts/PegStability/IVAI.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IVAI {
     function balanceOf(address usr) external returns (uint256);

--- a/contracts/PegStability/PegStability.sol
+++ b/contracts/PegStability/PegStability.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/Swap/IRouterHelper.sol
+++ b/contracts/Swap/IRouterHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IRouterHelper {
     function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) external pure returns (uint256 amountB);

--- a/contracts/Swap/RouterHelper.sol
+++ b/contracts/Swap/RouterHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/Swap/SwapRouter.sol
+++ b/contracts/Swap/SwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/Swap/interfaces/CustomErrors.sol
+++ b/contracts/Swap/interfaces/CustomErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 // **************
 // *** ERRORS ***

--- a/contracts/Swap/interfaces/IPancakePair.sol
+++ b/contracts/Swap/interfaces/IPancakePair.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IPancakePair {
     event Approval(address indexed owner, address indexed spender, uint value);

--- a/contracts/Swap/interfaces/IPancakeSwapV2Factory.sol
+++ b/contracts/Swap/interfaces/IPancakeSwapV2Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IPancakeSwapV2Factory {
     event PairCreated(address indexed token0, address indexed token1, address pair, uint);

--- a/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
+++ b/contracts/Swap/interfaces/IPancakeSwapV2Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IPancakeSwapV2Router {
     function swapExactTokensForTokens(

--- a/contracts/Swap/interfaces/IVBNB.sol
+++ b/contracts/Swap/interfaces/IVBNB.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IVBNB {
     function repayBorrowBehalf(address borrower) external payable;

--- a/contracts/Swap/interfaces/IVtoken.sol
+++ b/contracts/Swap/interfaces/IVtoken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IVToken {
     function mintBehalf(address receiver, uint mintAmount) external returns (uint);

--- a/contracts/Swap/interfaces/IWBNB.sol
+++ b/contracts/Swap/interfaces/IWBNB.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IWBNB {
     function deposit() external payable;

--- a/contracts/Swap/interfaces/InterfaceComptroller.sol
+++ b/contracts/Swap/interfaces/InterfaceComptroller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface InterfaceComptroller {
     function markets(address) external view returns (bool);

--- a/contracts/Swap/lib/PancakeLibrary.sol
+++ b/contracts/Swap/lib/PancakeLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../interfaces/IPancakePair.sol";
 import "../interfaces/CustomErrors.sol";

--- a/contracts/Swap/lib/TransferHelper.sol
+++ b/contracts/Swap/lib/TransferHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../interfaces/CustomErrors.sol";
 

--- a/contracts/Tokens/Prime/Interfaces/IPoolRegistry.sol
+++ b/contracts/Tokens/Prime/Interfaces/IPoolRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 /**
  * @title PoolRegistryInterface

--- a/contracts/Tokens/Prime/Interfaces/IPrime.sol
+++ b/contracts/Tokens/Prime/Interfaces/IPrime.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 import { PrimeStorageV1 } from "../PrimeStorage.sol";
 

--- a/contracts/Tokens/Prime/Interfaces/IPrimeLiquidityProvider.sol
+++ b/contracts/Tokens/Prime/Interfaces/IPrimeLiquidityProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 

--- a/contracts/Tokens/Prime/Interfaces/IVToken.sol
+++ b/contracts/Tokens/Prime/Interfaces/IVToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IVToken {
     function borrowBalanceStored(address account) external view returns (uint256);

--- a/contracts/Tokens/Prime/Interfaces/IXVSVault.sol
+++ b/contracts/Tokens/Prime/Interfaces/IXVSVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface IXVSVault {
     function getUserInfo(

--- a/contracts/Tokens/Prime/Interfaces/InterfaceComptroller.sol
+++ b/contracts/Tokens/Prime/Interfaces/InterfaceComptroller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 interface InterfaceComptroller {
     function markets(address) external view returns (bool);

--- a/contracts/Tokens/Prime/Prime.sol
+++ b/contracts/Tokens/Prime/Prime.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeERC20Upgradeable, IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { AccessControlledV8 } from "@venusprotocol/governance-contracts/contracts/Governance/AccessControlledV8.sol";

--- a/contracts/Tokens/Prime/PrimeLiquidityProvider.sol
+++ b/contracts/Tokens/Prime/PrimeLiquidityProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { PrimeLiquidityProviderStorageV1 } from "./PrimeLiquidityProviderStorage.sol";
 import { SafeERC20Upgradeable, IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/Tokens/Prime/PrimeLiquidityProviderStorage.sol
+++ b/contracts/Tokens/Prime/PrimeLiquidityProviderStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /**
  * @title PrimeLiquidityProviderStorageV1

--- a/contracts/Tokens/Prime/PrimeStorage.sol
+++ b/contracts/Tokens/Prime/PrimeStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { ResilientOracleInterface } from "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";
 

--- a/contracts/Tokens/Prime/libs/FixedMath.sol
+++ b/contracts/Tokens/Prime/libs/FixedMath.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // solhint-disable var-name-mixedcase
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeCastUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 import { FixedMath0x } from "./FixedMath0x.sol";

--- a/contracts/Tokens/Prime/libs/FixedMath0x.sol
+++ b/contracts/Tokens/Prime/libs/FixedMath0x.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // solhint-disable max-line-length
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 // Below is code from 0x's LibFixedMath.sol. Changes:
 // - addition of 0.8-style errors

--- a/contracts/Tokens/Prime/libs/Scores.sol
+++ b/contracts/Tokens/Prime/libs/Scores.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeCastUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 import { FixedMath } from "./FixedMath.sol";

--- a/contracts/lib/approveOrRevert.sol
+++ b/contracts/lib/approveOrRevert.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 

--- a/contracts/test/AccessControlManagerMock.sol
+++ b/contracts/test/AccessControlManagerMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 contract AccessControlManagerMock {
     address public owner;

--- a/contracts/test/LiquidatorHarness.sol
+++ b/contracts/test/LiquidatorHarness.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../Liquidator/Liquidator.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";

--- a/contracts/test/MockProtocolShareReserve.sol
+++ b/contracts/test/MockProtocolShareReserve.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { SafeERC20Upgradeable, IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { AccessControlledV8 } from "@venusprotocol/governance-contracts/contracts/Governance/AccessControlledV8.sol";

--- a/contracts/test/PrimeScenario.sol
+++ b/contracts/test/PrimeScenario.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import "../Tokens/Prime/Prime.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -109,7 +109,7 @@ const config: HardhatUserConfig = {
         },
       },
       {
-        version: "0.8.13",
+        version: "0.8.20",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
This PR updates the 0.8 pragma to:

* `^0.8.20` for interfaces, constants, etc.
* `0.8.20` for anything that contains code

Before merging, the dependencies have to be updated after https://github.com/VenusProtocol/solidity-utilities/pull/17, https://github.com/VenusProtocol/governance-contracts/pull/61, and https://github.com/VenusProtocol/oracle/pull/173 are merged.