### PR TITLE
refactor: reference interface in contracts to remove possible circular dependencies

### DIFF
--- a/contracts/Comptroller/ComptrollerInterface.sol
+++ b/contracts/Comptroller/ComptrollerInterface.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.16;
 
-import "../Tokens/VTokens/VToken.sol";
-import "../Oracle/PriceOracle.sol";
-import "../Tokens/VAI/VAIControllerInterface.sol";
+import { VTokenInterface } from "../Tokens/VTokens/VTokenInterfaces.sol";
+import { PriceOracle } from "../Oracle/PriceOracle.sol";
+import { VAIControllerInterface } from "../Tokens/VAI/VAIControllerInterface.sol";
 import { ComptrollerTypes } from "./ComptrollerStorage.sol";
 
 contract ComptrollerInterface {
@@ -104,7 +104,7 @@ contract ComptrollerInterface {
 
     function getAccountLiquidity(address) external view returns (uint, uint, uint);
 
-    function getAssetsIn(address) external view returns (VToken[] memory);
+    function getAssetsIn(address) external view returns (VTokenInterface[] memory);
 
     function claimVenus(address) external;
 
@@ -114,7 +114,7 @@ contract ComptrollerInterface {
 
     function venusBorrowSpeeds(address) external view returns (uint);
 
-    function getAllMarkets() external view returns (VToken[] memory);
+    function getAllMarkets() external view returns (VTokenInterface[] memory);
 
     function venusSupplierIndex(address, address) external view returns (uint);
 

--- a/contracts/Comptroller/ComptrollerLensInterface.sol
+++ b/contracts/Comptroller/ComptrollerLensInterface.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
-import "../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../Tokens/VTokens/VTokenInterfaces.sol";
 
 interface ComptrollerLensInterface {
     function liquidateCalculateSeizeTokens(
@@ -20,7 +20,7 @@ interface ComptrollerLensInterface {
     function getHypotheticalAccountLiquidity(
         address comptroller,
         address account,
-        VToken vTokenModify,
+        VTokenInterface vTokenModify,
         uint redeemTokens,
         uint borrowAmount
     ) external view returns (uint, uint, uint);

--- a/contracts/Comptroller/ComptrollerStorage.sol
+++ b/contracts/Comptroller/ComptrollerStorage.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.5.16;
 
-import { VToken } from "../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../Tokens/VTokens/VTokenInterfaces.sol";
 import { PriceOracle } from "../Oracle/PriceOracle.sol";
 import { VAIControllerInterface } from "../Tokens/VAI/VAIControllerInterface.sol";
 import { ComptrollerLensInterface } from "./ComptrollerLensInterface.sol";
@@ -68,7 +68,7 @@ contract ComptrollerV1Storage is ComptrollerTypes, UnitrollerAdminStorage {
     /**
      * @notice Per-account mapping of "assets you are in", capped by maxAssets
      */
-    mapping(address => VToken[]) public accountAssets;
+    mapping(address => VTokenInterface[]) public accountAssets;
 
     struct Market {
         /// @notice Whether or not this market is listed
@@ -117,7 +117,7 @@ contract ComptrollerV1Storage is ComptrollerTypes, UnitrollerAdminStorage {
     }
 
     /// @notice A list of all markets
-    VToken[] public allMarkets;
+    VTokenInterface[] public allMarkets;
 
     /// @notice The rate at which the flywheel distributes XVS, per block
     uint256 internal venusRate;

--- a/contracts/Comptroller/Diamond/facets/FacetBase.sol
+++ b/contracts/Comptroller/Diamond/facets/FacetBase.sol
@@ -2,7 +2,8 @@
 
 pragma solidity 0.5.16;
 
-import { VToken, ComptrollerErrorReporter, ExponentialNoError } from "../../../Tokens/VTokens/VToken.sol";
+import { ComptrollerErrorReporter, ExponentialNoError } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 import { IVAIVault } from "../../../Comptroller/ComptrollerInterface.sol";
 import { ComptrollerV16Storage } from "../../../Comptroller/ComptrollerStorage.sol";
 import { IAccessControlManagerV5 } from "@venusprotocol/governance-contracts/contracts/Governance/IAccessControlManagerV5.sol";
@@ -27,7 +28,7 @@ contract FacetBase is ComptrollerV16Storage, ExponentialNoError, ComptrollerErro
     uint256 internal constant collateralFactorMaxMantissa = 0.9e18; // 0.9
 
     /// @notice Emitted when an account enters a market
-    event MarketEntered(VToken indexed vToken, address indexed account);
+    event MarketEntered(VTokenInterface indexed vToken, address indexed account);
 
     /// @notice Emitted when XVS is distributed to VAI Vault
     event DistributedVAIVaultVenus(uint256 amount);
@@ -142,7 +143,7 @@ contract FacetBase is ComptrollerV16Storage, ExponentialNoError, ComptrollerErro
      */
     function getHypotheticalAccountLiquidityInternal(
         address account,
-        VToken vTokenModify,
+        VTokenInterface vTokenModify,
         uint256 redeemTokens,
         uint256 borrowAmount
     ) internal view returns (Error, uint256, uint256) {
@@ -162,7 +163,7 @@ contract FacetBase is ComptrollerV16Storage, ExponentialNoError, ComptrollerErro
      * @param borrower The address of the account to modify
      * @return Success indicator for whether the market was entered
      */
-    function addToMarketInternal(VToken vToken, address borrower) internal returns (Error) {
+    function addToMarketInternal(VTokenInterface vToken, address borrower) internal returns (Error) {
         checkActionPauseState(address(vToken), Action.ENTER_MARKET);
         Market storage marketToJoin = markets[address(vToken)];
         ensureListed(marketToJoin);
@@ -203,7 +204,7 @@ contract FacetBase is ComptrollerV16Storage, ExponentialNoError, ComptrollerErro
         /* Otherwise, perform a hypothetical liquidity check to guard against shortfall */
         (Error err, , uint256 shortfall) = getHypotheticalAccountLiquidityInternal(
             redeemer,
-            VToken(vToken),
+            VTokenInterface(vToken),
             redeemTokens,
             0
         );

--- a/contracts/Comptroller/Diamond/facets/MarketFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/MarketFacet.sol
@@ -4,7 +4,7 @@ pragma solidity 0.5.16;
 
 import { IMarketFacet } from "../interfaces/IMarketFacet.sol";
 import { FacetBase } from "./FacetBase.sol";
-import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 
 /**
  * @title MarketFacet
@@ -14,10 +14,10 @@ import { VToken } from "../../../Tokens/VTokens/VToken.sol";
  */
 contract MarketFacet is IMarketFacet, FacetBase {
     /// @notice Emitted when an admin supports a market
-    event MarketListed(VToken indexed vToken);
+    event MarketListed(VTokenInterface indexed vToken);
 
     /// @notice Emitted when an account exits a market
-    event MarketExited(VToken indexed vToken, address indexed account);
+    event MarketExited(VTokenInterface indexed vToken, address indexed account);
 
     /// @notice Emitted when the borrowing or redeeming delegate rights are updated for an account
     event DelegateUpdated(address indexed approver, address indexed delegate, bool approved);
@@ -35,12 +35,12 @@ contract MarketFacet is IMarketFacet, FacetBase {
      * @param account The address of the account to pull assets for
      * @return A dynamic list with the assets the account has entered
      */
-    function getAssetsIn(address account) external view returns (VToken[] memory) {
+    function getAssetsIn(address account) external view returns (VTokenInterface[] memory) {
         uint256 len;
-        VToken[] memory _accountAssets = accountAssets[account];
+        VTokenInterface[] memory _accountAssets = accountAssets[account];
         uint256 _accountAssetsLength = _accountAssets.length;
 
-        VToken[] memory assetsIn = new VToken[](_accountAssetsLength);
+        VTokenInterface[] memory assetsIn = new VTokenInterface[](_accountAssetsLength);
 
         for (uint256 i; i < _accountAssetsLength; ++i) {
             Market memory market = markets[address(_accountAssets[i])];
@@ -62,7 +62,7 @@ contract MarketFacet is IMarketFacet, FacetBase {
      * @dev The automatic getter may be used to access an individual market
      * @return The list of market addresses
      */
-    function getAllMarkets() external view returns (VToken[] memory) {
+    function getAllMarkets() external view returns (VTokenInterface[] memory) {
         return allMarkets;
     }
 
@@ -113,7 +113,7 @@ contract MarketFacet is IMarketFacet, FacetBase {
      * @param vToken The vToken to check
      * @return True if the account is in the asset, otherwise false
      */
-    function checkMembership(address account, VToken vToken) external view returns (bool) {
+    function checkMembership(address account, VTokenInterface vToken) external view returns (bool) {
         return markets[address(vToken)].accountMembership[account];
     }
 
@@ -127,7 +127,7 @@ contract MarketFacet is IMarketFacet, FacetBase {
 
         uint256[] memory results = new uint256[](len);
         for (uint256 i; i < len; ++i) {
-            results[i] = uint256(addToMarketInternal(VToken(vTokens[i]), msg.sender));
+            results[i] = uint256(addToMarketInternal(VTokenInterface(vTokens[i]), msg.sender));
         }
 
         return results;
@@ -179,7 +179,7 @@ contract MarketFacet is IMarketFacet, FacetBase {
     function exitMarket(address vTokenAddress) external returns (uint256) {
         checkActionPauseState(vTokenAddress, Action.EXIT_MARKET);
 
-        VToken vToken = VToken(vTokenAddress);
+        VTokenInterface vToken = VTokenInterface(vTokenAddress);
         /* Get sender tokensHeld and amountOwed underlying from the vToken */
         (uint256 oErr, uint256 tokensHeld, uint256 amountOwed, ) = vToken.getAccountSnapshot(msg.sender);
         require(oErr == 0, "getAccountSnapshot failed"); // semi-opaque error code
@@ -207,7 +207,7 @@ contract MarketFacet is IMarketFacet, FacetBase {
 
         /* Delete vToken from the account’s list of assets */
         // In order to delete vToken, copy last item in list to location of item to be removed, reduce length by 1
-        VToken[] storage userAssetList = accountAssets[msg.sender];
+        VTokenInterface[] storage userAssetList = accountAssets[msg.sender];
         uint256 len = userAssetList.length;
         uint256 i;
         for (; i < len; ++i) {
@@ -232,7 +232,7 @@ contract MarketFacet is IMarketFacet, FacetBase {
      * @param vToken The address of the market (token) to list
      * @return uint256 0=success, otherwise a failure. (See enum Error for details)
      */
-    function _supportMarket(VToken vToken) external returns (uint256) {
+    function _supportMarket(VTokenInterface vToken) external returns (uint256) {
         ensureAllowed("_supportMarket(address)");
 
         if (markets[address(vToken)].isListed) {
@@ -277,7 +277,7 @@ contract MarketFacet is IMarketFacet, FacetBase {
         emit DelegateUpdated(approver, delegate, approved);
     }
 
-    function _addMarketInternal(VToken vToken) internal {
+    function _addMarketInternal(VTokenInterface vToken) internal {
         uint256 allMarketsLength = allMarkets.length;
         for (uint256 i; i < allMarketsLength; ++i) {
             require(allMarkets[i] != vToken, "already added");

--- a/contracts/Comptroller/Diamond/facets/RewardFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/RewardFacet.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.5.16;
 
-import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 import { IRewardFacet } from "../interfaces/IRewardFacet.sol";
 import { XVSRewardsHelper } from "./XVSRewardsHelper.sol";
 import { SafeBEP20, IBEP20 } from "../../../Utils/SafeBEP20.sol";
@@ -36,7 +36,7 @@ contract RewardFacet is IRewardFacet, XVSRewardsHelper {
      * @param holder The address to claim XVS for
      * @param vTokens The list of markets to claim XVS in
      */
-    function claimVenus(address holder, VToken[] memory vTokens) public {
+    function claimVenus(address holder, VTokenInterface[] memory vTokens) public {
         address[] memory holders = new address[](1);
         holders[0] = holder;
         claimVenus(holders, vTokens, true, true);
@@ -49,7 +49,12 @@ contract RewardFacet is IRewardFacet, XVSRewardsHelper {
      * @param borrowers Whether or not to claim XVS earned by borrowing
      * @param suppliers Whether or not to claim XVS earned by supplying
      */
-    function claimVenus(address[] memory holders, VToken[] memory vTokens, bool borrowers, bool suppliers) public {
+    function claimVenus(
+        address[] memory holders,
+        VTokenInterface[] memory vTokens,
+        bool borrowers,
+        bool suppliers
+    ) public {
         claimVenus(holders, vTokens, borrowers, suppliers, false);
     }
 
@@ -174,7 +179,7 @@ contract RewardFacet is IRewardFacet, XVSRewardsHelper {
      */
     function claimVenus(
         address[] memory holders,
-        VToken[] memory vTokens,
+        VTokenInterface[] memory vTokens,
         bool borrowers,
         bool suppliers,
         bool collateral
@@ -187,7 +192,12 @@ contract RewardFacet is IRewardFacet, XVSRewardsHelper {
 
             // If there is a positive shortfall, the XVS reward is accrued,
             // but won't be granted to this holder
-            (, , uint256 shortfall) = getHypotheticalAccountLiquidityInternal(holder, VToken(address(0)), 0, 0);
+            (, , uint256 shortfall) = getHypotheticalAccountLiquidityInternal(
+                holder,
+                VTokenInterface(address(0)),
+                0,
+                0
+            );
 
             uint256 value = venusAccrued[holder];
             delete venusAccrued[holder];
@@ -210,7 +220,7 @@ contract RewardFacet is IRewardFacet, XVSRewardsHelper {
      */
     function updateAndDistributeRewardsInternal(
         address[] memory holders,
-        VToken[] memory vTokens,
+        VTokenInterface[] memory vTokens,
         bool borrowers,
         bool suppliers
     ) internal {
@@ -219,7 +229,7 @@ contract RewardFacet is IRewardFacet, XVSRewardsHelper {
         uint256 vTokensLength = vTokens.length;
 
         for (uint256 i; i < vTokensLength; ++i) {
-            VToken vToken = vTokens[i];
+            VTokenInterface vToken = vTokens[i];
             ensureListed(markets[address(vToken)]);
             if (borrowers) {
                 Exp memory borrowIndex = Exp({ mantissa: vToken.borrowIndex() });

--- a/contracts/Comptroller/Diamond/facets/SetterFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/SetterFacet.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.5.16;
 
-import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 import { ISetterFacet } from "../interfaces/ISetterFacet.sol";
 import { PriceOracle } from "../../../Oracle/PriceOracle.sol";
 import { ComptrollerLensInterface } from "../../ComptrollerLensInterface.sol";
@@ -22,7 +22,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
 
     /// @notice Emitted when a collateral factor is changed by admin
     event NewCollateralFactor(
-        VToken indexed vToken,
+        VTokenInterface indexed vToken,
         uint256 oldCollateralFactorMantissa,
         uint256 newCollateralFactorMantissa
     );
@@ -34,7 +34,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
     event NewPriceOracle(PriceOracle oldPriceOracle, PriceOracle newPriceOracle);
 
     /// @notice Emitted when borrow cap for a vToken is changed
-    event NewBorrowCap(VToken indexed vToken, uint256 newBorrowCap);
+    event NewBorrowCap(VTokenInterface indexed vToken, uint256 newBorrowCap);
 
     /// @notice Emitted when VAIController is changed
     event NewVAIController(VAIControllerInterface oldVAIController, VAIControllerInterface newVAIController);
@@ -61,7 +61,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
     event NewComptrollerLens(address oldComptrollerLens, address newComptrollerLens);
 
     /// @notice Emitted when supply cap for a vToken is changed
-    event NewSupplyCap(VToken indexed vToken, uint256 newSupplyCap);
+    event NewSupplyCap(VTokenInterface indexed vToken, uint256 newSupplyCap);
 
     /// @notice Emitted when access control address is changed by admin
     event NewAccessControl(address oldAccessControlAddress, address newAccessControlAddress);
@@ -70,7 +70,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
     event NewPauseGuardian(address oldPauseGuardian, address newPauseGuardian);
 
     /// @notice Emitted when an action is paused on a market
-    event ActionPausedMarket(VToken indexed vToken, Action indexed action, bool pauseState);
+    event ActionPausedMarket(VTokenInterface indexed vToken, Action indexed action, bool pauseState);
 
     /// @notice Emitted when VAI Vault info is changed
     event NewVAIVaultInfo(address indexed vault_, uint256 releaseStartBlock_, uint256 releaseInterval_);
@@ -196,7 +196,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
      * @return uint256 0=success, otherwise a failure. (See ErrorReporter for details)
      */
     function _setCollateralFactor(
-        VToken vToken,
+        VTokenInterface vToken,
         uint256 newCollateralFactorMantissa
     )
         external
@@ -303,7 +303,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
      * @param vTokens The addresses of the markets (tokens) to change the borrow caps for
      * @param newBorrowCaps The new borrow cap values in underlying to be set. A value of 0 corresponds to Borrow not allowed
      */
-    function _setMarketBorrowCaps(VToken[] calldata vTokens, uint256[] calldata newBorrowCaps) external {
+    function _setMarketBorrowCaps(VTokenInterface[] calldata vTokens, uint256[] calldata newBorrowCaps) external {
         ensureAllowed("_setMarketBorrowCaps(address[],uint256[])");
 
         uint256 numMarkets = vTokens.length;
@@ -323,7 +323,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
      * @param vTokens The addresses of the markets (tokens) to change the supply caps for
      * @param newSupplyCaps The new supply cap values in underlying to be set. A value of 0 corresponds to Minting NotAllowed
      */
-    function _setMarketSupplyCaps(VToken[] calldata vTokens, uint256[] calldata newSupplyCaps) external {
+    function _setMarketSupplyCaps(VTokenInterface[] calldata vTokens, uint256[] calldata newSupplyCaps) external {
         ensureAllowed("_setMarketSupplyCaps(address[],uint256[])");
 
         uint256 numMarkets = vTokens.length;
@@ -379,7 +379,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
     function setActionPausedInternal(address market, Action action, bool paused) internal {
         ensureListed(markets[market]);
         _actionPaused[market][uint256(action)] = paused;
-        emit ActionPausedMarket(VToken(market), action, paused);
+        emit ActionPausedMarket(VTokenInterface(market), action, paused);
     }
 
     /**
@@ -597,7 +597,7 @@ contract SetterFacet is ISetterFacet, FacetBase {
         ensureAdmin();
         ensureNonzeroAddress(xvsVToken_);
 
-        address underlying = VToken(xvsVToken_).underlying();
+        address underlying = VTokenInterface(xvsVToken_).underlying();
         require(underlying == xvs, "invalid xvs vtoken address");
 
         emit NewXVSVToken(xvsVToken, xvsVToken_);

--- a/contracts/Comptroller/Diamond/facets/XVSRewardsHelper.sol
+++ b/contracts/Comptroller/Diamond/facets/XVSRewardsHelper.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.5.16;
 
-import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 import { FacetBase } from "./FacetBase.sol";
 
 /**
@@ -14,7 +14,7 @@ import { FacetBase } from "./FacetBase.sol";
 contract XVSRewardsHelper is FacetBase {
     /// @notice Emitted when XVS is distributed to a borrower
     event DistributedBorrowerVenus(
-        VToken indexed vToken,
+        VTokenInterface indexed vToken,
         address indexed borrower,
         uint256 venusDelta,
         uint256 venusBorrowIndex
@@ -22,7 +22,7 @@ contract XVSRewardsHelper is FacetBase {
 
     /// @notice Emitted when XVS is distributed to a supplier
     event DistributedSupplierVenus(
-        VToken indexed vToken,
+        VTokenInterface indexed vToken,
         address indexed supplier,
         uint256 venusDelta,
         uint256 venusSupplyIndex
@@ -38,7 +38,7 @@ contract XVSRewardsHelper is FacetBase {
         uint32 blockNumber = getBlockNumberAsUint32();
         uint256 deltaBlocks = sub_(blockNumber, borrowState.block);
         if (deltaBlocks != 0 && borrowSpeed != 0) {
-            uint256 borrowAmount = div_(VToken(vToken).totalBorrows(), marketBorrowIndex);
+            uint256 borrowAmount = div_(VTokenInterface(vToken).totalBorrows(), marketBorrowIndex);
             uint256 accruedVenus = mul_(deltaBlocks, borrowSpeed);
             Double memory ratio = borrowAmount != 0 ? fraction(accruedVenus, borrowAmount) : Double({ mantissa: 0 });
             borrowState.index = safe224(add_(Double({ mantissa: borrowState.index }), ratio).mantissa, "224");
@@ -59,7 +59,7 @@ contract XVSRewardsHelper is FacetBase {
 
         uint256 deltaBlocks = sub_(blockNumber, supplyState.block);
         if (deltaBlocks != 0 && supplySpeed != 0) {
-            uint256 supplyTokens = VToken(vToken).totalSupply();
+            uint256 supplyTokens = VTokenInterface(vToken).totalSupply();
             uint256 accruedVenus = mul_(deltaBlocks, supplySpeed);
             Double memory ratio = supplyTokens != 0 ? fraction(accruedVenus, supplyTokens) : Double({ mantissa: 0 });
             supplyState.index = safe224(add_(Double({ mantissa: supplyState.index }), ratio).mantissa, "224");
@@ -91,10 +91,10 @@ contract XVSRewardsHelper is FacetBase {
         // Calculate change in the cumulative sum of the XVS per vToken accrued
         Double memory deltaIndex = Double({ mantissa: sub_(supplyIndex, supplierIndex) });
         // Multiply of supplierTokens and supplierDelta
-        uint256 supplierDelta = mul_(VToken(vToken).balanceOf(supplier), deltaIndex);
+        uint256 supplierDelta = mul_(VTokenInterface(vToken).balanceOf(supplier), deltaIndex);
         // Addition of supplierAccrued and supplierDelta
         venusAccrued[supplier] = add_(venusAccrued[supplier], supplierDelta);
-        emit DistributedSupplierVenus(VToken(vToken), supplier, supplierDelta, supplyIndex);
+        emit DistributedSupplierVenus(VTokenInterface(vToken), supplier, supplierDelta, supplyIndex);
     }
 
     /**
@@ -119,8 +119,11 @@ contract XVSRewardsHelper is FacetBase {
         }
         // Calculate change in the cumulative sum of the XVS per borrowed unit accrued
         Double memory deltaIndex = Double({ mantissa: sub_(borrowIndex, borrowerIndex) });
-        uint256 borrowerDelta = mul_(div_(VToken(vToken).borrowBalanceStored(borrower), marketBorrowIndex), deltaIndex);
+        uint256 borrowerDelta = mul_(
+            div_(VTokenInterface(vToken).borrowBalanceStored(borrower), marketBorrowIndex),
+            deltaIndex
+        );
         venusAccrued[borrower] = add_(venusAccrued[borrower], borrowerDelta);
-        emit DistributedBorrowerVenus(VToken(vToken), borrower, borrowerDelta, borrowIndex);
+        emit DistributedBorrowerVenus(VTokenInterface(vToken), borrower, borrowerDelta, borrowIndex);
     }
 }

--- a/contracts/Comptroller/Diamond/interfaces/IMarketFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/IMarketFacet.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.5.16;
 
-import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 
 interface IMarketFacet {
     function isComptroller() external pure returns (bool);
@@ -18,17 +18,17 @@ interface IMarketFacet {
         uint256 actualRepayAmount
     ) external view returns (uint256, uint256);
 
-    function checkMembership(address account, VToken vToken) external view returns (bool);
+    function checkMembership(address account, VTokenInterface vToken) external view returns (bool);
 
     function enterMarkets(address[] calldata vTokens) external returns (uint256[] memory);
 
     function exitMarket(address vToken) external returns (uint256);
 
-    function _supportMarket(VToken vToken) external returns (uint256);
+    function _supportMarket(VTokenInterface vToken) external returns (uint256);
 
-    function getAssetsIn(address account) external view returns (VToken[] memory);
+    function getAssetsIn(address account) external view returns (VTokenInterface[] memory);
 
-    function getAllMarkets() external view returns (VToken[] memory);
+    function getAllMarkets() external view returns (VTokenInterface[] memory);
 
     function updateDelegate(address delegate, bool allowBorrows) external;
 

--- a/contracts/Comptroller/Diamond/interfaces/IPolicyFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/IPolicyFacet.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.5.16;
 
-import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 
 interface IPolicyFacet {
     function mintAllowed(address vToken, address minter, uint256 mintAmount) external returns (uint256);
@@ -84,7 +84,7 @@ interface IPolicyFacet {
     ) external view returns (uint256, uint256, uint256);
 
     function _setVenusSpeeds(
-        VToken[] calldata vTokens,
+        VTokenInterface[] calldata vTokens,
         uint256[] calldata supplySpeeds,
         uint256[] calldata borrowSpeeds
     ) external;

--- a/contracts/Comptroller/Diamond/interfaces/IRewardFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/IRewardFacet.sol
@@ -2,15 +2,20 @@
 
 pragma solidity 0.5.16;
 
-import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 import { ComptrollerTypes } from "../../ComptrollerStorage.sol";
 
 interface IRewardFacet {
     function claimVenus(address holder) external;
 
-    function claimVenus(address holder, VToken[] calldata vTokens) external;
+    function claimVenus(address holder, VTokenInterface[] calldata vTokens) external;
 
-    function claimVenus(address[] calldata holders, VToken[] calldata vTokens, bool borrowers, bool suppliers) external;
+    function claimVenus(
+        address[] calldata holders,
+        VTokenInterface[] calldata vTokens,
+        bool borrowers,
+        bool suppliers
+    ) external;
 
     function claimVenusAsCollateral(address holder) external;
 
@@ -24,7 +29,7 @@ interface IRewardFacet {
 
     function claimVenus(
         address[] calldata holders,
-        VToken[] calldata vTokens,
+        VTokenInterface[] calldata vTokens,
         bool borrowers,
         bool suppliers,
         bool collateral

--- a/contracts/Comptroller/Diamond/interfaces/ISetterFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/ISetterFacet.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.5.16;
 
 import { PriceOracle } from "../../../Oracle/PriceOracle.sol";
-import { VToken } from "../../../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../../../Tokens/VTokens/VTokenInterfaces.sol";
 import { ComptrollerTypes } from "../../ComptrollerStorage.sol";
 import { VAIControllerInterface } from "../../../Tokens/VAI/VAIControllerInterface.sol";
 import { ComptrollerLensInterface } from "../../../Comptroller/ComptrollerLensInterface.sol";
@@ -16,7 +16,10 @@ interface ISetterFacet {
 
     function _setAccessControl(address newAccessControlAddress) external returns (uint256);
 
-    function _setCollateralFactor(VToken vToken, uint256 newCollateralFactorMantissa) external returns (uint256);
+    function _setCollateralFactor(
+        VTokenInterface vToken,
+        uint256 newCollateralFactorMantissa
+    ) external returns (uint256);
 
     function _setLiquidationIncentive(uint256 newLiquidationIncentiveMantissa) external returns (uint256);
 
@@ -24,9 +27,9 @@ interface ISetterFacet {
 
     function _setPauseGuardian(address newPauseGuardian) external returns (uint256);
 
-    function _setMarketBorrowCaps(VToken[] calldata vTokens, uint256[] calldata newBorrowCaps) external;
+    function _setMarketBorrowCaps(VTokenInterface[] calldata vTokens, uint256[] calldata newBorrowCaps) external;
 
-    function _setMarketSupplyCaps(VToken[] calldata vTokens, uint256[] calldata newSupplyCaps) external;
+    function _setMarketSupplyCaps(VTokenInterface[] calldata vTokens, uint256[] calldata newSupplyCaps) external;
 
     function _setProtocolPaused(bool state) external returns (bool);
 

--- a/contracts/Lens/ComptrollerLens.sol
+++ b/contracts/Lens/ComptrollerLens.sol
@@ -2,10 +2,10 @@ pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
 import "../Tokens/VTokens/VBep20.sol";
-import { VToken } from "../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../Tokens/VTokens/VTokenInterfaces.sol";
 import { ExponentialNoError } from "../Utils/ExponentialNoError.sol";
 import "../Tokens/EIP20Interface.sol";
-import "../Oracle/PriceOracle.sol";
+import { PriceOracle } from "../Oracle/PriceOracle.sol";
 import "../Utils/ErrorReporter.sol";
 import "../Comptroller/ComptrollerInterface.sol";
 import "../Comptroller/ComptrollerLensInterface.sol";
@@ -52,10 +52,10 @@ contract ComptrollerLens is ComptrollerLensInterface, ComptrollerErrorReporter, 
     ) external view returns (uint, uint) {
         /* Read oracle prices for borrowed and collateral markets */
         uint priceBorrowedMantissa = ComptrollerInterface(comptroller).oracle().getUnderlyingPrice(
-            VToken(vTokenBorrowed)
+            VTokenInterface(vTokenBorrowed)
         );
         uint priceCollateralMantissa = ComptrollerInterface(comptroller).oracle().getUnderlyingPrice(
-            VToken(vTokenCollateral)
+            VTokenInterface(vTokenCollateral)
         );
         if (priceBorrowedMantissa == 0 || priceCollateralMantissa == 0) {
             return (uint(Error.PRICE_ERROR), 0);
@@ -100,7 +100,7 @@ contract ComptrollerLens is ComptrollerLensInterface, ComptrollerErrorReporter, 
         /* Read oracle prices for borrowed and collateral markets */
         uint priceBorrowedMantissa = 1e18; // Note: this is VAI
         uint priceCollateralMantissa = ComptrollerInterface(comptroller).oracle().getUnderlyingPrice(
-            VToken(vTokenCollateral)
+            VTokenInterface(vTokenCollateral)
         );
         if (priceCollateralMantissa == 0) {
             return (uint(Error.PRICE_ERROR), 0);
@@ -143,7 +143,7 @@ contract ComptrollerLens is ComptrollerLensInterface, ComptrollerErrorReporter, 
     function getHypotheticalAccountLiquidity(
         address comptroller,
         address account,
-        VToken vTokenModify,
+        VTokenInterface vTokenModify,
         uint redeemTokens,
         uint borrowAmount
     ) external view returns (uint, uint, uint) {
@@ -151,10 +151,10 @@ contract ComptrollerLens is ComptrollerLensInterface, ComptrollerErrorReporter, 
         uint oErr;
 
         // For each asset the account is in
-        VToken[] memory assets = ComptrollerInterface(comptroller).getAssetsIn(account);
+        VTokenInterface[] memory assets = ComptrollerInterface(comptroller).getAssetsIn(account);
         uint assetsCount = assets.length;
         for (uint i = 0; i < assetsCount; ++i) {
-            VToken asset = assets[i];
+            VTokenInterface asset = assets[i];
 
             // Read the balances and exchange rate from the vToken
             (oErr, vars.vTokenBalance, vars.borrowBalance, vars.exchangeRateMantissa) = asset.getAccountSnapshot(

--- a/contracts/Lens/SnapshotLens.sol
+++ b/contracts/Lens/SnapshotLens.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
-import { VToken } from "../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../Tokens/VTokens/VTokenInterfaces.sol";
 import { ExponentialNoError } from "../Utils/ExponentialNoError.sol";
 import "../Utils/SafeMath.sol";
 import "../Comptroller/ComptrollerInterface.sol";
@@ -56,7 +56,7 @@ contract SnapshotLens is ExponentialNoError {
         address comptrollerAddress
     ) public returns (AccountSnapshot[] memory) {
         // For each asset the account is in
-        VToken[] memory assets = ComptrollerInterface(comptrollerAddress).getAllMarkets();
+        VTokenInterface[] memory assets = ComptrollerInterface(comptrollerAddress).getAllMarkets();
         AccountSnapshot[] memory accountSnapshots = new AccountSnapshot[](assets.length);
         for (uint256 i = 0; i < assets.length; ++i) {
             accountSnapshots[i] = getAccountSnapshot(account, comptrollerAddress, assets[i]);
@@ -65,7 +65,7 @@ contract SnapshotLens is ExponentialNoError {
     }
 
     function isACollateral(address account, address asset, address comptrollerAddress) public view returns (bool) {
-        VToken[] memory assetsAsCollateral = ComptrollerInterface(comptrollerAddress).getAssetsIn(account);
+        VTokenInterface[] memory assetsAsCollateral = ComptrollerInterface(comptrollerAddress).getAssetsIn(account);
         for (uint256 j = 0; j < assetsAsCollateral.length; ++j) {
             if (address(assetsAsCollateral[j]) == asset) {
                 return true;
@@ -78,7 +78,7 @@ contract SnapshotLens is ExponentialNoError {
     function getAccountSnapshot(
         address payable account,
         address comptrollerAddress,
-        VToken vToken
+        VTokenInterface vToken
     ) public returns (AccountSnapshot memory) {
         AccountSnapshotLocalVars memory vars; // Holds all our calculation results
         uint oErr;

--- a/contracts/Oracle/PriceOracle.sol
+++ b/contracts/Oracle/PriceOracle.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.16;
 
-import "../Tokens/VTokens/VToken.sol";
+import { VTokenInterface } from "../Tokens/VTokens/VTokenInterfaces.sol";
 
 contract PriceOracle {
     /// @notice Indicator that this is a PriceOracle contract (for inspection)
@@ -12,5 +12,5 @@ contract PriceOracle {
      * @return The underlying asset price mantissa (scaled by 1e18).
      *  Zero means the price is unavailable.
      */
-    function getUnderlyingPrice(VToken vToken) external view returns (uint);
+    function getUnderlyingPrice(VTokenInterface vToken) external view returns (uint);
 }

--- a/contracts/Tokens/VAI/VAIController.sol
+++ b/contracts/Tokens/VAI/VAIController.sol
@@ -6,7 +6,7 @@ import { VAIControllerErrorReporter } from "../../Utils/ErrorReporter.sol";
 import { Exponential } from "../../Utils/Exponential.sol";
 import { ComptrollerInterface } from "../../Comptroller/ComptrollerInterface.sol";
 import { IAccessControlManagerV5 } from "@venusprotocol/governance-contracts/contracts/Governance/IAccessControlManagerV5.sol";
-import { VToken, EIP20Interface } from "../VTokens/VToken.sol";
+import { VTokenInterface, EIP20Interface } from "../VTokens/VToken.sol";
 import { VAIUnitroller, VAIControllerStorageG4 } from "./VAIUnitroller.sol";
 import { VAIControllerInterface } from "./VAIControllerInterface.sol";
 import { VAI } from "./VAI.sol";
@@ -452,7 +452,7 @@ contract VAIController is VAIControllerInterface, VAIControllerStorageG4, VAICon
         }
 
         PriceOracle oracle = comptroller.oracle();
-        VToken[] memory enteredMarkets = comptroller.getAssetsIn(minter);
+        VTokenInterface[] memory enteredMarkets = comptroller.getAssetsIn(minter);
 
         AccountAmountLocalVars memory vars; // Holds all our calculation results
 
@@ -587,7 +587,7 @@ contract VAIController is VAIControllerInterface, VAIControllerStorageG4, VAICon
 
         if (baseRateMantissa > 0) {
             if (floatRateMantissa > 0) {
-                uint256 oraclePrice = oracle.getUnderlyingPrice(VToken(getVAIAddress()));
+                uint256 oraclePrice = oracle.getUnderlyingPrice(VTokenInterface(getVAIAddress()));
                 if (1e18 > oraclePrice) {
                     uint256 delta;
                     uint256 rate;

--- a/contracts/Tokens/VTokens/VTokenInterfaces.sol
+++ b/contracts/Tokens/VTokens/VTokenInterfaces.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.16;
 
-import "../../Comptroller/ComptrollerInterface.sol";
-import "../../InterestRateModels/InterestRateModel.sol";
+import { ComptrollerInterface } from "../../Comptroller/ComptrollerInterface.sol";
+import { InterestRateModel } from "../../InterestRateModels/InterestRateModel.sol";
 
 interface IProtocolShareReserveV5 {
     enum IncomeType {

--- a/contracts/test/ComptrollerHarness.sol
+++ b/contracts/test/ComptrollerHarness.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.16;
 
 import "./ComptrollerMock.sol";
-import "../Oracle/PriceOracle.sol";
 import "../Comptroller/Unitroller.sol";
 
 contract ComptrollerHarness is ComptrollerMock {
@@ -45,10 +44,10 @@ contract ComptrollerHarness is ComptrollerMock {
      * @notice Recalculate and update XVS speeds for all XVS markets
      */
     function harnessRefreshVenusSpeeds() public {
-        VToken[] memory allMarkets_ = allMarkets;
+        VTokenInterface[] memory allMarkets_ = allMarkets;
 
         for (uint i = 0; i < allMarkets_.length; i++) {
-            VToken vToken = allMarkets_[i];
+            VTokenInterface vToken = allMarkets_[i];
             Exp memory borrowIndex = Exp({ mantissa: vToken.borrowIndex() });
             updateVenusSupplyIndex(address(vToken));
             updateVenusBorrowIndex(address(vToken), borrowIndex);
@@ -57,7 +56,7 @@ contract ComptrollerHarness is ComptrollerMock {
         Exp memory totalUtility = Exp({ mantissa: 0 });
         Exp[] memory utilities = new Exp[](allMarkets_.length);
         for (uint i = 0; i < allMarkets_.length; i++) {
-            VToken vToken = allMarkets_[i];
+            VTokenInterface vToken = allMarkets_[i];
             if (venusSpeeds[address(vToken)] > 0) {
                 Exp memory assetPrice = Exp({ mantissa: oracle.getUnderlyingPrice(vToken) });
                 Exp memory utility = mul_(assetPrice, vToken.totalBorrows());
@@ -67,7 +66,7 @@ contract ComptrollerHarness is ComptrollerMock {
         }
 
         for (uint i = 0; i < allMarkets_.length; i++) {
-            VToken vToken = allMarkets[i];
+            VTokenInterface vToken = allMarkets[i];
             uint newSpeed = totalUtility.mantissa > 0 ? mul_(venusRate, div_(utilities[i], totalUtility)) : 0;
             setVenusSpeedInternal(vToken, newSpeed, newSpeed);
         }
@@ -121,7 +120,7 @@ contract ComptrollerHarness is ComptrollerMock {
     function harnessAddVenusMarkets(address[] memory vTokens) public {
         for (uint i = 0; i < vTokens.length; i++) {
             // temporarily set venusSpeed to 1 (will be fixed by `harnessRefreshVenusSpeeds`)
-            setVenusSpeedInternal(VToken(vTokens[i]), 1, 1);
+            setVenusSpeedInternal(VTokenInterface(vTokens[i]), 1, 1);
         }
     }
 

--- a/contracts/test/ComptrollerScenario.sol
+++ b/contracts/test/ComptrollerScenario.sol
@@ -25,7 +25,7 @@ contract ComptrollerScenario is ComptrollerMock {
         return vaiAddress;
     }
 
-    function membershipLength(VToken vToken) public view returns (uint) {
+    function membershipLength(VTokenInterface vToken) public view returns (uint) {
         return accountAssets[address(vToken)].length;
     }
 
@@ -62,7 +62,7 @@ contract ComptrollerScenario is ComptrollerMock {
         return venusMarkets;
     }
 
-    function unlist(VToken vToken) public {
+    function unlist(VTokenInterface vToken) public {
         markets[address(vToken)].isListed = false;
     }
 
@@ -70,10 +70,10 @@ contract ComptrollerScenario is ComptrollerMock {
      * @notice Recalculate and update XVS speeds for all XVS markets
      */
     function refreshVenusSpeeds() public {
-        VToken[] memory allMarkets_ = allMarkets;
+        VTokenInterface[] memory allMarkets_ = allMarkets;
 
         for (uint i = 0; i < allMarkets_.length; i++) {
-            VToken vToken = allMarkets_[i];
+            VTokenInterface vToken = allMarkets_[i];
             Exp memory borrowIndex = Exp({ mantissa: vToken.borrowIndex() });
             updateVenusSupplyIndex(address(vToken));
             updateVenusBorrowIndex(address(vToken), borrowIndex);
@@ -82,7 +82,7 @@ contract ComptrollerScenario is ComptrollerMock {
         Exp memory totalUtility = Exp({ mantissa: 0 });
         Exp[] memory utilities = new Exp[](allMarkets_.length);
         for (uint i = 0; i < allMarkets_.length; i++) {
-            VToken vToken = allMarkets_[i];
+            VTokenInterface vToken = allMarkets_[i];
             if (venusSpeeds[address(vToken)] > 0) {
                 Exp memory assetPrice = Exp({ mantissa: oracle.getUnderlyingPrice(vToken) });
                 Exp memory utility = mul_(assetPrice, vToken.totalBorrows());
@@ -92,7 +92,7 @@ contract ComptrollerScenario is ComptrollerMock {
         }
 
         for (uint i = 0; i < allMarkets_.length; i++) {
-            VToken vToken = allMarkets[i];
+            VTokenInterface vToken = allMarkets[i];
             uint newSpeed = totalUtility.mantissa > 0 ? mul_(venusRate, div_(utilities[i], totalUtility)) : 0;
             setVenusSpeedInternal(vToken, newSpeed, newSpeed);
         }

--- a/contracts/test/FixedPriceOracle.sol
+++ b/contracts/test/FixedPriceOracle.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.16;
 
-import "../Oracle/PriceOracle.sol";
+import { PriceOracle } from "../Oracle/PriceOracle.sol";
+import { VTokenInterface } from "../Tokens/VTokens/VTokenInterfaces.sol";
 
 contract FixedPriceOracle is PriceOracle {
     uint public price;
@@ -9,7 +10,7 @@ contract FixedPriceOracle is PriceOracle {
         price = _price;
     }
 
-    function getUnderlyingPrice(VToken vToken) public view returns (uint) {
+    function getUnderlyingPrice(VTokenInterface vToken) public view returns (uint) {
         vToken;
         return price;
     }

--- a/contracts/test/SimplePriceOracle.sol
+++ b/contracts/test/SimplePriceOracle.sol
@@ -1,13 +1,13 @@
 pragma solidity ^0.5.16;
 
-import "../Oracle/PriceOracle.sol";
+import { PriceOracle } from "../Oracle/PriceOracle.sol";
 import "../Tokens/VTokens/VBep20.sol";
 
 contract SimplePriceOracle is PriceOracle {
     mapping(address => uint) internal prices;
     event PricePosted(address asset, uint previousPriceMantissa, uint requestedPriceMantissa, uint newPriceMantissa);
 
-    function getUnderlyingPrice(VToken vToken) public view returns (uint) {
+    function getUnderlyingPrice(VTokenInterface vToken) public view returns (uint) {
         if (compareStrings(vToken.symbol(), "vBNB")) {
             return 1e18;
         } else if (compareStrings(vToken.symbol(), "VAI")) {
@@ -17,7 +17,7 @@ contract SimplePriceOracle is PriceOracle {
         }
     }
 
-    function setUnderlyingPrice(VToken vToken, uint underlyingPriceMantissa) public {
+    function setUnderlyingPrice(VTokenInterface vToken, uint underlyingPriceMantissa) public {
         address asset = address(VBep20(address(vToken)).underlying());
         emit PricePosted(asset, prices[asset], underlyingPriceMantissa, underlyingPriceMantissa);
         prices[asset] = underlyingPriceMantissa;

--- a/contracts/test/VAIControllerHarness.sol
+++ b/contracts/test/VAIControllerHarness.sol
@@ -32,7 +32,7 @@ contract VAIControllerHarness is VAIController {
         address liquidator,
         address borrower,
         uint repayAmount,
-        VToken vTokenCollateral
+        VTokenInterface vTokenCollateral
     ) public returns (uint) {
         (uint err, ) = liquidateVAIFresh(liquidator, borrower, repayAmount, vTokenCollateral);
         return err;


### PR DESCRIPTION
## Description

When working on the RiskSteward I hit an issue with circular dependencies because `IAccessControlManagerV5.sol` uses the `VToken` to declare the contract interface which imports from `@venusprotocol/governance-contracts`.

This PR refactors to use the VTokenInterface to declare instances VToken contract in other contracts avoiding this issue when the governance repo needs to use the VTokenInterface