### PR TITLE
[VEN-3163]: Add CheckpointRateModel

### DIFF
--- a/contracts/InterestRateModels/CheckpointRateModel.sol
+++ b/contracts/InterestRateModels/CheckpointRateModel.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.25;
+
+import { ensureNonzeroAddress } from "@venusprotocol/solidity-utilities/contracts/validators.sol";
+import { InterestRateModelV8 } from "./InterestRateModelV8.sol";
+
+/**
+ * @title Venus CheckpointRateModel Contract
+ * @notice A contract that applies a rate model based on whether a certain checkpoint
+ *   in time has passed. Useful to adjust interest rates for block time changes in
+ *   the underlying networks, if the block time update is scheduled in advance.
+ * @author Venus
+ */
+contract CheckpointRateModel is InterestRateModelV8 {
+    InterestRateModelV8 public immutable OLD_RATE_MODEL;
+    InterestRateModelV8 public immutable NEW_RATE_MODEL;
+    uint256 public immutable CHECKPOINT_TIMESTAMP;
+
+    /**
+     * @notice Constructor
+     * @param oldRateModel Rate model to use before the checkpoint
+     * @param newRateModel Rate model to use after the checkpoint
+     * @param checkpointTimestamp Checkpoint timestamp
+     */
+    constructor(InterestRateModelV8 oldRateModel, InterestRateModelV8 newRateModel, uint256 checkpointTimestamp) {
+        ensureNonzeroAddress(address(oldRateModel));
+        ensureNonzeroAddress(address(newRateModel));
+        OLD_RATE_MODEL = oldRateModel;
+        NEW_RATE_MODEL = newRateModel;
+        CHECKPOINT_TIMESTAMP = checkpointTimestamp;
+    }
+
+    /**
+     * @notice Returns the current rate model contract (either the old one or the new one)
+     * @return Rate model in use
+     */
+    function currentRateModel() external view returns (InterestRateModelV8) {
+        return _getCurrentRateModel();
+    }
+
+    /**
+     * @inheritdoc InterestRateModelV8
+     */
+    function getBorrowRate(uint256 cash, uint256 borrows, uint256 reserves) external view override returns (uint256) {
+        return _getCurrentRateModel().getBorrowRate(cash, borrows, reserves);
+    }
+
+    /**
+     * @inheritdoc InterestRateModelV8
+     */
+    function getSupplyRate(
+        uint256 cash,
+        uint256 borrows,
+        uint256 reserves,
+        uint256 reserveFactorMantissa
+    ) external view override returns (uint256) {
+        return _getCurrentRateModel().getSupplyRate(cash, borrows, reserves, reserveFactorMantissa);
+    }
+
+    /**
+     * @dev Returns the current rate model contract (either the old one or the new one)
+     * @return Rate model in use
+     */
+    function _getCurrentRateModel() internal view returns (InterestRateModelV8) {
+        return (block.timestamp >= CHECKPOINT_TIMESTAMP) ? NEW_RATE_MODEL : OLD_RATE_MODEL;
+    }
+}

--- a/contracts/InterestRateModels/IRateModelWithUtilization.sol
+++ b/contracts/InterestRateModels/IRateModelWithUtilization.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.25;
+
+import { InterestRateModelV8 } from "./InterestRateModelV8.sol";
+
+/**
+ * @title Venus's IRateModelWithUtilization Interface
+ * @author Venus
+ */
+abstract contract IRateModelWithUtilization is InterestRateModelV8 {
+    /**
+     * @notice Calculates the utilization rate of the market: `borrows / (cash + borrows - reserves)`
+     * @param cash The amount of cash in the market
+     * @param borrows The amount of borrows in the market
+     * @param reserves The amount of reserves in the market
+     * @return The utilization rate as a mantissa between [0, EXP_SCALE]
+     */
+    function utilizationRate(uint256 cash, uint256 borrows, uint256 reserves) external view virtual returns (uint256);
+}

--- a/contracts/InterestRateModels/InterestRateModelV8.sol
+++ b/contracts/InterestRateModels/InterestRateModelV8.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.25;
 
 /**

--- a/contracts/InterestRateModels/TwoKinksInterestRateModel.sol
+++ b/contracts/InterestRateModels/TwoKinksInterestRateModel.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.25;
 
-import { InterestRateModelV8 } from "./InterestRateModelV8.sol";
+import { IRateModelWithUtilization } from "./IRateModelWithUtilization.sol";
 
 /**
  * @title TwoKinksInterestRateModel
  * @author Venus
  * @notice An interest rate model with two different slope increase or decrease each after a certain utilization threshold called **kink** is reached.
  */
-contract TwoKinksInterestRateModel is InterestRateModelV8 {
+contract TwoKinksInterestRateModel is IRateModelWithUtilization {
     int256 public constant BLOCKS_PER_YEAR = (60 * 60 * 24 * 365) / 3; // (assuming 3s blocks)
 
     ////////////////////// SLOPE 1 //////////////////////
@@ -152,13 +152,9 @@ contract TwoKinksInterestRateModel is InterestRateModelV8 {
     }
 
     /**
-     * @notice Calculates the utilization rate of the market: `borrows / (cash + borrows - reserves)`
-     * @param cash The amount of cash in the market
-     * @param borrows The amount of borrows in the market
-     * @param reserves The amount of reserves in the market
-     * @return The utilization rate as a mantissa between [0, EXP_SCALE]
+     * @inheritdoc IRateModelWithUtilization
      */
-    function utilizationRate(uint256 cash, uint256 borrows, uint256 reserves) public pure returns (uint256) {
+    function utilizationRate(uint256 cash, uint256 borrows, uint256 reserves) public pure override returns (uint256) {
         // Utilization rate is 0 when there are no borrows
         if (borrows == 0) {
             return 0;
@@ -174,7 +170,7 @@ contract TwoKinksInterestRateModel is InterestRateModelV8 {
     }
 
     /**
-     * @notice Calculates the current borrow rate per slot (block), with the error code expected by the market
+     * @dev Calculates the current borrow rate per slot (block), with the error code expected by the market
      * @param cash The amount of cash in the market
      * @param borrows The amount of borrows in the market
      * @param reserves The amount of reserves in the market
@@ -206,7 +202,7 @@ contract TwoKinksInterestRateModel is InterestRateModelV8 {
     }
 
     /**
-     * @notice Returns 0 if number is less than 0, otherwise returns the input
+     * @dev Returns 0 if number is less than 0, otherwise returns the input
      * @param number The first number
      * @return The maximum of 0 and input number
      */

--- a/tests/hardhat/InterestRateModels/CheckpointRateModel.ts
+++ b/tests/hardhat/InterestRateModels/CheckpointRateModel.ts
@@ -1,0 +1,82 @@
+import { FakeContract, smock } from "@defi-wonderland/smock";
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import chai from "chai";
+import { parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import { CheckpointRateModel, InterestRateModelV8 } from "../../../typechain";
+
+const { expect } = chai;
+chai.use(smock.matchers);
+
+describe("CheckpointRateModel tests", () => {
+  let checkpointRateModel: CheckpointRateModel;
+  let oldRateModel: FakeContract<InterestRateModelV8>;
+  let newRateModel: FakeContract<InterestRateModelV8>;
+  let checkpointTimestamp: number;
+  const cash = parseUnits("10", 18);
+  const borrows = parseUnits("4", 18);
+  const reserves = parseUnits("2", 18);
+  const reserveFactorMantissa = parseUnits("0.1", 18);
+
+  const fixture = async () => {
+    const interestRateModelFactory = await ethers.getContractFactory("WhitePaperInterestRateModel");
+    oldRateModel = await smock.fake<InterestRateModelV8>(interestRateModelFactory.interface);
+    newRateModel = await smock.fake<InterestRateModelV8>(interestRateModelFactory.interface);
+
+    const checkpointRateModelFactory = await ethers.getContractFactory("CheckpointRateModel");
+    checkpointTimestamp = (await time.latest()) + 100; // 100 seconds in the future
+    checkpointRateModel = await checkpointRateModelFactory.deploy(
+      oldRateModel.address,
+      newRateModel.address,
+      checkpointTimestamp,
+    );
+    await checkpointRateModel.deployed();
+  };
+
+  beforeEach(async () => {
+    await loadFixture(fixture);
+  });
+
+  it("should revert if oldRateModel address is zero", async () => {
+    const checkpointRateModelFactory = await ethers.getContractFactory("CheckpointRateModel");
+    await expect(
+      checkpointRateModelFactory.deploy(ethers.constants.AddressZero, newRateModel.address, checkpointTimestamp),
+    ).to.be.revertedWithCustomError(checkpointRateModelFactory, "ZeroAddressNotAllowed");
+  });
+
+  it("should revert if newRateModel address is zero", async () => {
+    const checkpointRateModelFactory = await ethers.getContractFactory("CheckpointRateModel");
+    await expect(
+      checkpointRateModelFactory.deploy(oldRateModel.address, ethers.constants.AddressZero, checkpointTimestamp),
+    ).to.be.revertedWithCustomError(checkpointRateModelFactory, "ZeroAddressNotAllowed");
+  });
+
+  it("should use old rate model before checkpoint", async () => {
+    await time.increaseTo(checkpointTimestamp - 1);
+
+    oldRateModel.getBorrowRate.returns(100);
+    oldRateModel.getSupplyRate.returns(50);
+
+    expect(await checkpointRateModel.getBorrowRate(cash, borrows, reserves)).to.equal(100);
+    expect(await checkpointRateModel.getSupplyRate(cash, borrows, reserves, reserveFactorMantissa)).to.equal(50);
+  });
+
+  it("should use new rate model after checkpoint", async () => {
+    await time.increaseTo(checkpointTimestamp);
+
+    newRateModel.getBorrowRate.returns(200);
+    newRateModel.getSupplyRate.returns(100);
+
+    expect(await checkpointRateModel.getBorrowRate(cash, borrows, reserves)).to.equal(200);
+    expect(await checkpointRateModel.getSupplyRate(cash, borrows, reserves, reserveFactorMantissa)).to.equal(100);
+  });
+
+  it("should return the correct current rate model", async () => {
+    expect(await checkpointRateModel.currentRateModel()).to.equal(oldRateModel.address);
+
+    await time.increaseTo(checkpointTimestamp);
+
+    expect(await checkpointRateModel.currentRateModel()).to.equal(newRateModel.address);
+  });
+});


### PR DESCRIPTION
This PR is an adaptation of https://github.com/VenusProtocol/isolated-pools/pull/501 for the BNB chain core pool. 

It introduces the CheckpointRateModel contract that dynamically switches between two interest rate models based on a predefined checkpoint timestamp.

It differs from the IL PR in `getSupplyRate` and `getBorrowRate` arguments (there's no concept of `badDebt` in the BNB chain core pool), and in the interfaces used. Apart from that, the code is identical.