### PR TITLE
[VEN-3163]: Add CheckpointView contract

### DIFF
--- a/contracts/Utils/CheckpointView.sol
+++ b/contracts/Utils/CheckpointView.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.25;
+
+import { ensureNonzeroAddress } from "@venusprotocol/solidity-utilities/contracts/validators.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @title Venus CheckpointView Contract
+ * @notice A contract that calls a view function from two different contracts
+ *   based on whether a checkpoint in time has passed. Using this contract, we
+ *   can change dependencies at a certain timestamp, which is useful for
+ *   scheduled changes in, e.g., interest rate models.
+ * @author Venus
+ */
+contract CheckpointView {
+    using Address for address;
+
+    address public immutable DATA_SOURCE_1;
+    address public immutable DATA_SOURCE_2;
+    uint256 public immutable CHECKPOINT_TIMESTAMP;
+
+    /**
+     * @notice Constructor
+     * @param dataSource1 Data source to use before the checkpoint
+     * @param dataSource2 Data source to use after the checkpoint
+     * @param checkpointTimestamp Checkpoint timestamp
+     */
+    constructor(address dataSource1, address dataSource2, uint256 checkpointTimestamp) {
+        ensureNonzeroAddress(address(dataSource1));
+        ensureNonzeroAddress(address(dataSource2));
+        DATA_SOURCE_1 = dataSource1;
+        DATA_SOURCE_2 = dataSource2;
+        CHECKPOINT_TIMESTAMP = checkpointTimestamp;
+    }
+
+    /**
+     * @notice Fallback function that proxies the view calls to the current data source
+     * @param input Input data (with a function selector) for the call
+     */
+    fallback(bytes calldata input) external returns (bytes memory) {
+        return _getCurrentDataSource().functionStaticCall(input);
+    }
+
+    /**
+     * @notice Returns the current data source contract (either the old one or the new one)
+     * @return Data source contract in use
+     */
+    function currentDataSource() external view returns (address) {
+        return _getCurrentDataSource();
+    }
+
+    /**
+     * @dev Returns the current data source contract (either the old one or the new one)
+     * @return Data source contract in use
+     */
+    function _getCurrentDataSource() internal view returns (address) {
+        return (block.timestamp < CHECKPOINT_TIMESTAMP) ? DATA_SOURCE_1 : DATA_SOURCE_2;
+    }
+}

--- a/tests/hardhat/Utils/CheckpointView.ts
+++ b/tests/hardhat/Utils/CheckpointView.ts
@@ -1,0 +1,86 @@
+import { FakeContract, smock } from "@defi-wonderland/smock";
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import chai from "chai";
+import { parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import { CheckpointView, WhitePaperInterestRateModel } from "../../../typechain";
+
+const { expect } = chai;
+chai.use(smock.matchers);
+
+describe("CheckpointView tests (using interest rate models as data sources)", () => {
+  let checkpointView: CheckpointView;
+  let checkpointRateModel: WhitePaperInterestRateModel;
+  let oldRateModel: FakeContract<WhitePaperInterestRateModel>;
+  let newRateModel: FakeContract<WhitePaperInterestRateModel>;
+  let checkpointTimestamp: number;
+  const cash = parseUnits("10", 18);
+  const borrows = parseUnits("4", 18);
+  const reserves = parseUnits("2", 18);
+  const reserveFactorMantissa = parseUnits("0.1", 18);
+
+  const fixture = async () => {
+    const interestRateModelFactory = await ethers.getContractFactory("WhitePaperInterestRateModel");
+    oldRateModel = await smock.fake<WhitePaperInterestRateModel>(interestRateModelFactory.interface);
+    newRateModel = await smock.fake<WhitePaperInterestRateModel>(interestRateModelFactory.interface);
+
+    const checkpointViewFactory = await ethers.getContractFactory("CheckpointView");
+    checkpointTimestamp = (await time.latest()) + 100; // 100 seconds in the future
+    checkpointView = await checkpointViewFactory.deploy(
+      oldRateModel.address,
+      newRateModel.address,
+      checkpointTimestamp,
+    );
+    await checkpointView.deployed();
+    checkpointRateModel = await ethers.getContractAt("WhitePaperInterestRateModel", checkpointView.address);
+  };
+
+  beforeEach(async () => {
+    await loadFixture(fixture);
+  });
+
+  it("should revert if dataSource1 address is zero", async () => {
+    const checkpointViewFactory = await ethers.getContractFactory("CheckpointView");
+    await expect(
+      checkpointViewFactory.deploy(ethers.constants.AddressZero, newRateModel.address, checkpointTimestamp),
+    ).to.be.revertedWithCustomError(checkpointViewFactory, "ZeroAddressNotAllowed");
+  });
+
+  it("should revert if dataSource2 address is zero", async () => {
+    const checkpointViewFactory = await ethers.getContractFactory("CheckpointView");
+    await expect(
+      checkpointViewFactory.deploy(oldRateModel.address, ethers.constants.AddressZero, checkpointTimestamp),
+    ).to.be.revertedWithCustomError(checkpointViewFactory, "ZeroAddressNotAllowed");
+  });
+
+  it("should use old rate model before checkpoint", async () => {
+    await time.increaseTo(checkpointTimestamp - 1);
+
+    oldRateModel.getBorrowRate.returns(100);
+    oldRateModel.getSupplyRate.returns(50);
+    oldRateModel.utilizationRate.returns(1234);
+
+    expect(await checkpointRateModel.getBorrowRate(cash, borrows, reserves)).to.equal(100);
+    expect(await checkpointRateModel.getSupplyRate(cash, borrows, reserves, reserveFactorMantissa)).to.equal(50);
+    expect(await checkpointRateModel.utilizationRate(cash, borrows, reserves)).to.equal(1234);
+  });
+
+  it("should use new rate model after checkpoint", async () => {
+    await time.increaseTo(checkpointTimestamp);
+
+    newRateModel.getBorrowRate.returns(200);
+    newRateModel.getSupplyRate.returns(100);
+    newRateModel.utilizationRate.returns(4321);
+
+    expect(await checkpointRateModel.getBorrowRate(cash, borrows, reserves)).to.equal(200);
+    expect(await checkpointRateModel.getSupplyRate(cash, borrows, reserves, reserveFactorMantissa)).to.equal(100);
+    expect(await checkpointRateModel.utilizationRate(cash, borrows, reserves)).to.equal(4321);
+  });
+
+  it("should return the correct current data source", async () => {
+    expect(await checkpointView.currentDataSource()).to.equal(oldRateModel.address);
+    await time.increaseTo(checkpointTimestamp);
+    expect(await checkpointView.currentDataSource()).to.equal(newRateModel.address);
+  });
+});


### PR DESCRIPTION
This PR is an alternative implementation for https://github.com/VenusProtocol/isolated-pools/pull/501 and https://github.com/VenusProtocol/venus-protocol/pull/575. Instead of introducing a new kind of rate model, it adds a generic contract with a fallback function that dispatches the calls between two data sources.

Using a generic approach, we can reduce the potential consumer impact stemming from incompatibilities between rate model interfaces – the contract will behave identically to the current data source, so the consumers won't need to adjust their code to interact with the `CheckpointView` contract.