### PR TITLE
[VEN-3343] : Whitelist Flash-loan Users

### DIFF
--- a/contracts/Comptroller/ComptrollerInterface.sol
+++ b/contracts/Comptroller/ComptrollerInterface.sol
@@ -30,6 +30,7 @@ contract ComptrollerInterface {
     function borrowVerify(address vToken, address borrower, uint borrowAmount) external;
 
     function executeFlashLoan(
+        address initiator,
         address payable receiver,
         VToken[] calldata assets,
         uint256[] calldata amounts,
@@ -146,6 +147,8 @@ contract ComptrollerInterface {
     function mintedVAIs(address user) external view returns (uint);
 
     function vaiMintRate() external view returns (uint);
+
+    function authorizedFlashLoan(address account) external view returns (bool);
 }
 
 interface IVAIVault {

--- a/contracts/Comptroller/ComptrollerStorage.sol
+++ b/contracts/Comptroller/ComptrollerStorage.sol
@@ -280,3 +280,7 @@ contract ComptrollerV16Storage is ComptrollerV15Storage {
     /// @notice The XVS vToken contract address
     address internal xvsVToken;
 }
+contract ComptrollerV17Storage is ComptrollerV16Storage {
+    /// @notice Mapping of accounts authorized to execute flash loans
+    mapping(address => bool) public authorizedFlashLoan;
+}

--- a/contracts/Comptroller/Diamond/Diamond.sol
+++ b/contracts/Comptroller/Diamond/Diamond.sol
@@ -4,14 +4,14 @@ pragma solidity 0.5.16;
 pragma experimental ABIEncoderV2;
 
 import { IDiamondCut } from "./interfaces/IDiamondCut.sol";
-import { Unitroller, ComptrollerV16Storage } from "../Unitroller.sol";
+import { Unitroller, ComptrollerV17Storage } from "../Unitroller.sol";
 
 /**
  * @title Diamond
  * @author Venus
  * @notice This contract contains functions related to facets
  */
-contract Diamond is IDiamondCut, ComptrollerV16Storage {
+contract Diamond is IDiamondCut, ComptrollerV17Storage {
     /// @notice Emitted when functions are added, replaced or removed to facets
     event DiamondCut(IDiamondCut.FacetCut[] _diamondCut);
 
@@ -72,7 +72,7 @@ contract Diamond is IDiamondCut, ComptrollerV16Storage {
      */
     function facetAddress(
         bytes4 functionSelector
-    ) external view returns (ComptrollerV16Storage.FacetAddressAndPosition memory) {
+    ) external view returns (ComptrollerV17Storage.FacetAddressAndPosition memory) {
         return _selectorToFacetAndPosition[functionSelector];
     }
 

--- a/contracts/Comptroller/Diamond/facets/FacetBase.sol
+++ b/contracts/Comptroller/Diamond/facets/FacetBase.sol
@@ -4,7 +4,7 @@ pragma solidity 0.5.16;
 
 import { VToken, ComptrollerErrorReporter, ExponentialNoError } from "../../../Tokens/VTokens/VToken.sol";
 import { IVAIVault } from "../../../Comptroller/ComptrollerInterface.sol";
-import { ComptrollerV16Storage } from "../../../Comptroller/ComptrollerStorage.sol";
+import { ComptrollerV17Storage } from "../../../Comptroller/ComptrollerStorage.sol";
 import { IAccessControlManagerV5 } from "@venusprotocol/governance-contracts/contracts/Governance/IAccessControlManagerV5.sol";
 
 import { SafeBEP20, IBEP20 } from "../../../Utils/SafeBEP20.sol";
@@ -14,7 +14,7 @@ import { SafeBEP20, IBEP20 } from "../../../Utils/SafeBEP20.sol";
  * @author Venus
  * @notice This facet contract contains functions related to access and checks
  */
-contract FacetBase is ComptrollerV16Storage, ExponentialNoError, ComptrollerErrorReporter {
+contract FacetBase is ComptrollerV17Storage, ExponentialNoError, ComptrollerErrorReporter {
     using SafeBEP20 for IBEP20;
 
     /// @notice The initial Venus index for a market

--- a/contracts/Comptroller/Diamond/facets/PolicyFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/PolicyFacet.sol
@@ -386,6 +386,7 @@ contract PolicyFacet is IPolicyFacet, XVSRewardsHelper {
      *      - Reverts with `Insufficient reypayment balance` if the repayment (amount + fee) is insufficient after the operation.
      */
     function executeFlashLoan(
+        address initiator,
         address payable receiver,
         VToken[] calldata vTokens,
         uint256[] calldata underlyingAmounts,
@@ -395,6 +396,10 @@ contract PolicyFacet is IPolicyFacet, XVSRewardsHelper {
         // Asset and amount length must be equals and not be zero
         if (vTokens.length != underlyingAmounts.length || vTokens.length == 0) {
             revert("Invalid flashLoan params");
+        }
+
+        if (!authorizedFlashLoan[initiator]) {
+            revert("Flash loan not authorized for this account");
         }
 
         uint256[] memory protocolFees = new uint256[](vTokens.length);

--- a/contracts/Comptroller/Diamond/facets/SetterFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/SetterFacet.sol
@@ -93,6 +93,9 @@ contract SetterFacet is ISetterFacet, FacetBase {
     /// @notice Emitted when XVS vToken address is changed
     event NewXVSVToken(address indexed oldXVSVToken, address indexed newXVSVToken);
 
+    /// @notice Event emitted when an account is added to flash loan whitelist
+    event IsAccountFlashLoanWhitlisted(address indexed account, bool indexed isWhitelisted);
+
     /**
      * @notice Compare two addresses to ensure they are different
      * @param oldAddress The original address to compare
@@ -602,5 +605,18 @@ contract SetterFacet is ISetterFacet, FacetBase {
 
         emit NewXVSVToken(xvsVToken, xvsVToken_);
         xvsVToken = xvsVToken_;
+    }
+
+    /**
+     * @notice Adds/Removes an account to the flash loan whitelist
+     * @param account The account to authorize for flash loans
+     * @param _isWhiteListed True to whitelist the account for flash loans, false to remove from whitelist
+     */
+    function _setWhiteListFlashLoanAccount(address account, bool _isWhiteListed) external {
+        ensureAllowed("_setWhiteListFlashLoanAccount(address)");
+        ensureNonzeroAddress(account);
+
+        authorizedFlashLoan[account] = _isWhiteListed;
+        emit IsAccountFlashLoanWhitlisted(account, _isWhiteListed);
     }
 }

--- a/contracts/Comptroller/Diamond/interfaces/ISetterFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/ISetterFacet.sol
@@ -63,4 +63,6 @@ interface ISetterFacet {
     function _setXVSToken(address xvs_) external;
 
     function _setXVSVToken(address xvsVToken_) external;
+
+    function _setWhiteListFlashLoanAccount(address account, bool _isWhiteListed) external;
 }

--- a/contracts/Tokens/VTokens/VToken.sol
+++ b/contracts/Tokens/VTokens/VToken.sol
@@ -420,11 +420,17 @@ contract VToken is VTokenInterface, Exponential, TokenErrorReporter {
      * custom:event Emits FlashLoanExecuted event on success
      */
     function executeFlashLoan(
+        address initiator,
         address payable receiver,
         uint256 amount,
         bytes calldata param
     ) external nonReentrant returns (uint256) {
         ensureNonZeroAddress(receiver);
+
+        // Check if the caller is authorized to execute flash loans
+        if (!comptroller.authorizedFlashLoan(initiator)) {
+            revert("Flash loan not authorized for this account");
+        }
 
         IFlashLoanSimpleReceiver receiverContract = IFlashLoanSimpleReceiver(receiver);
 

--- a/contracts/test/MockFlashLoanReceiver.sol
+++ b/contracts/test/MockFlashLoanReceiver.sol
@@ -31,7 +31,7 @@ contract MockFlashLoanReceiver is FlashLoanReceiverBase {
         bytes calldata param
     ) external {
         // Request the flashLoan from the Comptroller contract
-        COMPTROLLER.executeFlashLoan(receiver, assets, amount, param);
+        COMPTROLLER.executeFlashLoan(msg.sender, receiver, assets, amount, param);
     }
 
     /**

--- a/contracts/test/MockFlashLoanSimpleReceiver.sol
+++ b/contracts/test/MockFlashLoanSimpleReceiver.sol
@@ -25,7 +25,7 @@ contract MockFlashLoanSimpleReceiver is FlashLoanSimpleReceiverBase {
      */
     function requestFlashLoan(uint256 amount, address payable receiver, bytes calldata param) external {
         // Request the flashLoan from the VToken contract
-        VTOKEN.executeFlashLoan(receiver, amount, param);
+        VTOKEN.executeFlashLoan(msg.sender, receiver, amount, param);
     }
 
     /**


### PR DESCRIPTION


## Description

Add a new check on the Flash loan feature, to authorize the execution of the flash loans only to some whitelisted accounts. We should:
- add a new storage variable with the authorized accounts
- setter function, controlled by the ACM, to add and remove accounts from the whitelist
- add new check in the flashLoan functions

