### PR TITLE
Update facet-cut-params-generator to handle add and replace selectors dynamically

### DIFF
--- a/contracts/Comptroller/Diamond/interfaces/IRewardFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/IRewardFacet.sol
@@ -3,10 +3,8 @@
 pragma solidity 0.8.25;
 
 import { VToken } from "../../../Tokens/VTokens/VToken.sol";
-import { Action } from "../../ComptrollerInterface.sol";
-import { IFacetBase } from "./IFacetBase.sol";
 
-interface IRewardFacet is IFacetBase {
+interface IRewardFacet {
     function claimVenus(address holder) external;
 
     function claimVenus(address holder, VToken[] calldata vTokens) external;

--- a/script/deploy/comptroller/facet-cut-params-generator.ts
+++ b/script/deploy/comptroller/facet-cut-params-generator.ts
@@ -8,29 +8,48 @@ import { FacetCutAction, getSelectors } from "./diamond";
  * to add diamond facets
  */
 
-// Insert the addresses of the deployed facets to generate the cut params, do not change the order.
-const newFacetAddresses = {
-  MarketFacet: "",
-  PolicyFacet: "",
-  RewardFacet: "",
-  SetterFacet: "",
-  FacetBase: "*FacetBase",
-};
+type FacetName = "MarketFacet" | "PolicyFacet" | "RewardFacet" | "SetterFacet" | "FlashLoanFacet" | "FacetBase";
+type CutEntry = [string, number, string[]];
 
-// Set interfaces for the setters to generate function selectors from
-const FacetsInterfaces = {
+// FacetBase is a base contract whose selectors are inlined into the other facets. We surface
+// any IFacetBase selectors not already claimed under this placeholder so the operator can
+// reassign them manually to the appropriate setter facet before submitting the cut.
+const FACETBASE_PLACEHOLDER = "*FacetBase";
+
+// Interfaces used to derive function selectors for each facet.
+const FacetsInterfaces: Record<FacetName, string> = {
   MarketFacet: "IMarketFacet",
   PolicyFacet: "IPolicyFacet",
   RewardFacet: "IRewardFacet",
   SetterFacet: "ISetterFacet",
+  FlashLoanFacet: "IFlashLoanFacet",
   FacetBase: "IFacetBase",
 };
 
-// Facets for which cut params need to generate
-const FacetNames = ["MarketFacet", "PolicyFacet", "RewardFacet", "SetterFacet", "FacetBase"];
+// Order matters: earlier facets claim shared selectors (inlined FacetBase methods) first.
+const FacetNames = Object.keys(FacetsInterfaces) as FacetName[];
 
-// Name of the file to write the cut-params
 const jsonFileName = `cut-params-${network.name}`;
+
+async function fetchContractName(address: string, chainId: number, apiKey: string): Promise<string> {
+  const url = `https://api.etherscan.io/v2/api?chainid=${chainId}&module=contract&action=getsourcecode&address=${address}&apikey=${apiKey}`;
+  const delays = [500, 1500, 4500];
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const json = (await res.json()) as { result?: Array<{ ContractName?: string }> };
+      const name = json.result?.[0]?.ContractName;
+      if (!name) throw new Error("no contract name in response");
+      return name;
+    } catch (e) {
+      lastError = e as Error;
+      if (attempt < delays.length) await new Promise(r => setTimeout(r, delays[attempt]));
+    }
+  }
+  throw new Error(`failed to get contract name for ${address}: ${lastError?.message}`);
+}
 
 async function generateCutParams() {
   const comptrollerDeployment = await deployments.get("Unitroller");
@@ -38,56 +57,152 @@ async function generateCutParams() {
   const diamond = await ethers.getContractAt("Diamond", diamondAddress);
   const currentFacets = await diamond.facets();
 
-  // Build a global set of all selectors currently in the diamond to filter out redundent selectors
-  const globalReplaced = new Set<string>();
+  // Resolve new facet addresses from hardhat-deploy artifacts (just-deployed). FacetBase
+  // has no on-chain instance, so it stays as the manual-reassignment placeholder.
+  const newFacetAddresses = new Map<FacetName, string>();
+  for (const facetName of FacetNames) {
+    if (facetName === "FacetBase") {
+      newFacetAddresses.set(facetName, FACETBASE_PLACEHOLDER);
+      continue;
+    }
+    const dep = await deployments.get(facetName);
+    newFacetAddresses.set(facetName, dep.address);
+  }
+
+  // Map every currently-deployed selector to the facet address that owns it.
+  const selectorToCurrentFacet = new Map<string, string>();
   for (const f of currentFacets) {
     for (const sel of f.functionSelectors) {
-      globalReplaced.add(sel.toLowerCase());
+      selectorToCurrentFacet.set(sel.toLowerCase(), f.facetAddress);
     }
   }
 
-  const cut: any[] = [];
+  // Resolve the new selectors for each facet from its interface, and build a
+  // selector → "fnName(types)" map so the diff file can show what each selector is.
+  const newSelectorsByFacet = new Map<FacetName, string[]>();
+  const signatureBySelector = new Map<string, string>();
+  for (const facetName of FacetNames) {
+    const addr = newFacetAddresses.get(facetName)!;
+    const ifaceAddress = addr === FACETBASE_PLACEHOLDER ? ethers.constants.AddressZero : addr;
+    const iface = await ethers.getContractAt(FacetsInterfaces[facetName], ifaceAddress);
+    const selectors = (getSelectors(iface) as string[]).map(s => s.toLowerCase());
+    newSelectorsByFacet.set(facetName, selectors);
+    for (const sig of Object.keys(iface.interface.functions)) {
+      if (sig === "init(bytes)") continue;
+      const sel = iface.interface.getSighash(sig).toLowerCase();
+      if (!signatureBySelector.has(sel)) signatureBySelector.set(sel, sig);
+    }
+  }
 
-  for (let i = 0; i < FacetNames.length; i++) {
-    const facetName = FacetNames[i];
-    const newFacetAddress = newFacetAddresses[facetName];
+  // Identify which currently-deployed facet backs each new facet by querying Etherscan v2
+  // for the verified ContractName at each on-chain address.
+  const apiKey = process.env.ETHERSCAN_API_KEY;
+  if (!apiKey) throw new Error("ETHERSCAN_API_KEY env var is required");
+  const chainId = network.config.chainId;
+  if (!chainId) throw new Error(`network.config.chainId is not set for network "${network.name}"`);
 
-    // Current facet selectors (from diamond, assuming the facet addresses in the same order as newFacetAddresses)
-    const currentSelectors: string[] = facetName === "FacetBase" ? [] : currentFacets[i].functionSelectors;
+  const knownFacetNames = new Set<string>(FacetNames);
+  const oldFacetAddressByName = new Map<FacetName, string>();
+  const oldFacetNameByAddress = new Map<string, FacetName>();
+  for (const f of currentFacets) {
+    const name = await fetchContractName(f.facetAddress, chainId, apiKey);
+    if (knownFacetNames.has(name)) {
+      const fname = name as FacetName;
+      oldFacetAddressByName.set(fname, f.facetAddress);
+      oldFacetNameByAddress.set(f.facetAddress, fname);
+    }
+  }
 
-    // New facet selectors (from interface)
-    const newFacetInterface = await ethers.getContractAt(FacetsInterfaces[facetName], newFacetAddress);
-    const newSelectors: string[] = getSelectors(newFacetInterface);
+  const cut: CutEntry[] = [];
+  // Each selector may appear in at most one cut entry; later facets defer to earlier ones.
+  const claimedInCut = new Set<string>();
 
-    const currentSet = new Set(currentSelectors.map(s => s.toLowerCase()));
+  type DiffChange = {
+    selector: string;
+    signature: string;
+    facet: FacetName;
+    oldAddress?: string;
+    newAddress: string;
+  };
+  type DiffRemoved = {
+    selector: string;
+    signature: string;
+    oldAddress: string;
+    oldFacet?: FacetName;
+  };
+  const added: DiffChange[] = [];
+  const replaced: DiffChange[] = [];
 
-    // Replace = already in this facet
-    const replaceSelectors = [...currentSet];
+  for (const facetName of FacetNames) {
+    const newFacetAddress = newFacetAddresses.get(facetName)!;
+    const newSelectors = newSelectorsByFacet.get(facetName)!;
 
-    // Add = not in current facet AND not globally occupied already
-    const addSelectors = newSelectors.filter(
-      s => !currentSet.has(s.toLowerCase()) && !globalReplaced.has(s.toLowerCase()),
-    );
-
-    // Update global registry only for selectors that are being added
-    for (const s of addSelectors) {
-      globalReplaced.add(s.toLowerCase());
+    const replaceSelectors: string[] = [];
+    const addSelectors: string[] = [];
+    for (const sel of newSelectors) {
+      if (claimedInCut.has(sel)) continue;
+      claimedInCut.add(sel);
+      const signature = signatureBySelector.get(sel) ?? "unknown";
+      const oldAddress = selectorToCurrentFacet.get(sel);
+      if (oldAddress) {
+        replaceSelectors.push(sel);
+        replaced.push({ selector: sel, signature, facet: facetName, oldAddress, newAddress: newFacetAddress });
+      } else {
+        addSelectors.push(sel);
+        added.push({ selector: sel, signature, facet: facetName, newAddress: newFacetAddress });
+      }
     }
 
     if (replaceSelectors.length > 0) {
       cut.push([newFacetAddress, FacetCutAction.Replace, replaceSelectors]);
     }
-
     if (addSelectors.length > 0) {
       cut.push([newFacetAddress, FacetCutAction.Add, addSelectors]);
     }
   }
 
-  // Write to file
+  // Selectors that live on an old version of an upgraded facet but are absent from the
+  // new layout must be Removed, otherwise diamondCut would leave them dangling.
+  const oldUpgradedAddresses = new Set(oldFacetAddressByName.values());
+  const removeSelectors: string[] = [];
+  const removed: DiffRemoved[] = [];
+  for (const f of currentFacets) {
+    if (!oldUpgradedAddresses.has(f.facetAddress)) continue;
+    for (const sel of f.functionSelectors) {
+      const s = sel.toLowerCase();
+      if (claimedInCut.has(s)) continue;
+      removeSelectors.push(s);
+      removed.push({
+        selector: s,
+        signature: signatureBySelector.get(s) ?? "unknown",
+        oldAddress: f.facetAddress,
+        oldFacet: oldFacetNameByAddress.get(f.facetAddress),
+      });
+    }
+  }
+  if (removeSelectors.length > 0) {
+    cut.push([ethers.constants.AddressZero, FacetCutAction.Remove, removeSelectors]);
+  }
+
   const cutParams = { cutParams: cut };
   fs.writeFileSync(`./${jsonFileName}.json`, JSON.stringify(cutParams, null, 4));
 
+  const diff = {
+    summary: {
+      added: added.length,
+      replaced: replaced.length,
+      removed: removed.length,
+    },
+    added,
+    replaced,
+    removed,
+  };
+  const diffFileName = `cut-diff-${network.name}`;
+  fs.writeFileSync(`./${diffFileName}.json`, JSON.stringify(diff, null, 4));
+
   console.log("Cut params generated:");
+  console.log(`  - ${jsonFileName}.json`);
+  console.log(`  - ${diffFileName}.json (added=${added.length} replaced=${replaced.length} removed=${removed.length})`);
   console.log("Note: New FacetBase selectors should be manually assigned to their respective setter facets.");
   return cutParams;
 }


### PR DESCRIPTION
## Description
This PR updates the `facet-cut-params-generator` script to improve how diamond cut parameters are generated:

* The script now **fetches the current function selectors** from the deployed diamond contract.
* It generates the **final cut-params array**, considering both **Add** and **Replace** operations dynamically.
* For `IFacetBase` selectors:

  * If there are **no new selectors**, the resulting cut-params JSON can be **used directly**.
  * If there **are new selectors**, they need to be **manually assigned** to the appropriate facet addresses before using the cut-params.
  
  **Note**: Now onwards when running the script, please use the` --network` flag to specify the target network.