### PR TITLE
[VPD-1182]: add script to drain pendingScoreUpdates after addMarket

### DIFF
--- a/scripts/prime-update-scores.ts
+++ b/scripts/prime-update-scores.ts
@@ -23,7 +23,9 @@
  *   BLOCK_RANGE        Max blocks per getLogs call (default: 5000)
  *   DRY_RUN            "1" to skip sending txs
  */
+import * as fs from "fs";
 import { deployments, ethers } from "hardhat";
+import * as path from "path";
 
 export type HolderEvent = {
   kind: "Mint" | "Burn";
@@ -139,12 +141,28 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
 
   // Parallelize isScoreUpdated reads in batches to avoid serial RPC latency
   // when there are many holders. RPC providers tolerate ~20 in-flight reads
-  // comfortably without rate-limiting.
+  // comfortably without rate-limiting. Retry transient transport errors
+  // (ECONNRESET / TLS disconnect) up to 5 times with exponential backoff.
   const ISSCOREUPDATED_BATCH = 20;
+  const retryRead = async (h: string): Promise<boolean> => {
+    let lastErr: any;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        return await prime.isScoreUpdated(roundId, h);
+      } catch (e: any) {
+        lastErr = e;
+        const msg = String(e?.message ?? e);
+        const transient = /ECONNRESET|socket disconnect|ETIMEDOUT|EAI_AGAIN|network|timeout|fetch failed/i.test(msg);
+        if (!transient) throw e;
+        await new Promise(r => setTimeout(r, 250 * 2 ** attempt));
+      }
+    }
+    throw lastErr;
+  };
   const remaining: string[] = [];
   for (let i = 0; i < holders.length; i += ISSCOREUPDATED_BATCH) {
     const slice = holders.slice(i, i + ISSCOREUPDATED_BATCH);
-    const flags: boolean[] = await Promise.all(slice.map(h => prime.isScoreUpdated(roundId, h)));
+    const flags: boolean[] = await Promise.all(slice.map(retryRead));
     for (let j = 0; j < slice.length; j++) {
       if (!flags[j]) remaining.push(slice[j]);
     }
@@ -158,8 +176,11 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
     return { pendingBefore, pendingAfter: pendingBefore, batchesSent: 0, usersUpdated: 0 };
   }
 
-  const batches = chunk(remaining, Number(maxLoops));
-  log(`Sending ${batches.length} batch(es) of up to ${maxLoops} users`);
+  // BSC RPC nodes cap per-tx gas at ~16.7M (2^24). The contract's maxLoopsLimit
+  // (20) implies ~20M gas per batch — over the cap. Allow operator override.
+  const batchSize = process.env.BATCH_SIZE ? Number(process.env.BATCH_SIZE) : Number(maxLoops);
+  const batches = chunk(remaining, batchSize);
+  log(`Sending ${batches.length} batch(es) of up to ${batchSize} users`);
 
   let usersUpdated = 0;
   for (let i = 0; i < batches.length; i++) {
@@ -170,8 +191,31 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
       continue;
     }
 
-    const tx = await prime.updateScores(batch);
-    const rcpt = await tx.wait();
+    // Bypass eth_estimateGas. BSC RPC nodes cap per-tx gas at 16,777,216 (2^24),
+    // so we must stay under that. 14 users * ~0.93M/user ≈ 13M; 15M leaves margin.
+    let rcpt: any;
+    let lastErr: any;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        // If a previous attempt broadcast a tx whose receipt fetch failed,
+        // wait for that specific hash before resending (avoids nonce conflict).
+        if (lastErr?.transactionHash) {
+          rcpt = await prime.provider.waitForTransaction(lastErr.transactionHash, 1, 60_000);
+        } else {
+          const tx = await prime.updateScores(batch, { gasLimit: 15_000_000 });
+          rcpt = await tx.wait();
+        }
+        break;
+      } catch (e: any) {
+        lastErr = e;
+        const msg = String(e?.message ?? e);
+        const transient =
+          /ECONNRESET|socket disconnect|ETIMEDOUT|EAI_AGAIN|network|timeout|fetch failed|server response/i.test(msg);
+        if (!transient || attempt === 4) throw e;
+        log(`    transient error (attempt ${attempt + 1}/5): ${msg.slice(0, 100)}`);
+        await new Promise(r => setTimeout(r, 500 * 2 ** attempt));
+      }
+    }
     log(`    tx ${rcpt.transactionHash} gasUsed=${rcpt.gasUsed.toString()}`);
     usersUpdated += batch.length;
   }
@@ -198,10 +242,26 @@ async function main() {
 
   const prime = await ethers.getContractAt("Prime", dep.address);
 
-  console.log("Reconstructing holder set from Mint/Burn events...");
-  const events = await fetchHolderEvents(prime, fromBlock, blockRange, undefined, m => console.log(m));
-  const holders = eventsToHolders(events);
-  console.log(`Total current holders: ${holders.length}`);
+  // Holder list is expensive to reconstruct (full event-log scan from Prime
+  // deploy block). Cache it on disk so reruns after a crash / partial drain
+  // can skip the scan. Set HOLDERS_FILE=- to force a fresh scan.
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+  const cachePath = process.env.HOLDERS_FILE ?? path.join(__dirname, `..`, `.prime-holders-${chainId}.json`);
+
+  let holders: string[];
+  if (cachePath !== "-" && fs.existsSync(cachePath)) {
+    holders = JSON.parse(fs.readFileSync(cachePath, "utf8"));
+    console.log(`Loaded ${holders.length} holders from cache: ${cachePath}`);
+  } else {
+    console.log("Reconstructing holder set from Mint/Burn events...");
+    const events = await fetchHolderEvents(prime, fromBlock, blockRange, undefined, m => console.log(m));
+    holders = eventsToHolders(events);
+    console.log(`Total current holders: ${holders.length}`);
+    if (cachePath !== "-") {
+      fs.writeFileSync(cachePath, JSON.stringify(holders, null, 2));
+      console.log(`Wrote holder cache: ${cachePath}`);
+    }
+  }
 
   await runUpdate(prime, holders, { dryRun, log: m => console.log(m) });
 }

--- a/scripts/prime-update-scores.ts
+++ b/scripts/prime-update-scores.ts
@@ -1,0 +1,201 @@
+/**
+ * Drains the Prime pendingScoreUpdates queue after a parameter change.
+ *
+ * Triggers (functions that queue a fresh round of score updates by calling
+ * `_startScoreUpdateRound()` internally):
+ *   - addMarket
+ *   - updateAlpha
+ *   - updateMultipliers
+ *
+ * Prime exposes no on-chain holder enumeration, so this script reconstructs
+ * the current holder set from `Mint` and `Burn` events, then calls
+ * `updateScores` in batches sized to `maxLoopsLimit()` until the queue drains.
+ *
+ * Resumes correctly across runs: per-user, per-round dedup via
+ * `isScoreUpdated[roundId][user]` is read on-chain.
+ *
+ * Usage:
+ *   npx hardhat run scripts/prime-update-scores.ts --network <network>
+ *
+ * Optional env vars:
+ *   FROM_BLOCK         First block to scan for Mint/Burn (default: 0)
+ *   BLOCK_RANGE        Max blocks per getLogs call (default: 5000)
+ *   DRY_RUN            "1" to skip sending txs
+ */
+import { deployments, ethers } from "hardhat";
+
+export type HolderEvent = {
+  kind: "Mint" | "Burn";
+  user: string;
+  blockNumber: number;
+  logIndex: number;
+};
+
+/**
+ * Pure function: split an array into chunks of at most `size` items.
+ */
+export function chunk<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) throw new Error("chunk size must be > 0");
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Pure function: replay Mint/Burn events to compute the set of current holders.
+ * Events must be applied in (blockNumber, logIndex) order. Mints set the
+ * user as a holder; Burns unset. The final holder set is every address whose
+ * last state was holder=true.
+ */
+export function eventsToHolders(events: HolderEvent[]): string[] {
+  const ordered = [...events].sort((a, b) => {
+    if (a.blockNumber !== b.blockNumber) return a.blockNumber - b.blockNumber;
+    return a.logIndex - b.logIndex;
+  });
+
+  const holders = new Map<string, boolean>();
+  for (const ev of ordered) {
+    holders.set(ev.user, ev.kind === "Mint");
+  }
+
+  const current: string[] = [];
+  for (const [addr, isHolder] of holders) {
+    if (isHolder) current.push(addr);
+  }
+  return current;
+}
+
+/**
+ * Fetch all Mint and Burn events from a Prime contract, paginated.
+ * Uses `prime.filters.Mint()` / `prime.filters.Burn()` and `queryFilter`.
+ */
+export async function fetchHolderEvents(
+  prime: any,
+  fromBlock: number,
+  blockRange: number,
+  latest?: number,
+  log: (msg: string) => void = () => undefined,
+): Promise<HolderEvent[]> {
+  const toLatest = latest ?? (await prime.provider.getBlockNumber());
+  const mintFilter = prime.filters.Mint();
+  const burnFilter = prime.filters.Burn();
+
+  const events: HolderEvent[] = [];
+
+  for (let from = fromBlock; from <= toLatest; from += blockRange) {
+    const to = Math.min(from + blockRange - 1, toLatest);
+    const [mints, burns] = await Promise.all([
+      prime.queryFilter(mintFilter, from, to),
+      prime.queryFilter(burnFilter, from, to),
+    ]);
+
+    // Mint(address indexed user, bool isIrrevocable): we only need `user`.
+    for (const m of mints) {
+      events.push({ kind: "Mint", user: m.args!.user, blockNumber: m.blockNumber, logIndex: m.logIndex });
+    }
+    // Burn(address indexed user)
+    for (const b of burns) {
+      events.push({ kind: "Burn", user: b.args!.user, blockNumber: b.blockNumber, logIndex: b.logIndex });
+    }
+
+    log(`  scanned blocks ${from}-${to}: +${mints.length} mints, -${burns.length} burns`);
+  }
+
+  return events;
+}
+
+export type RunUpdateOptions = {
+  dryRun?: boolean;
+  log?: (msg: string) => void;
+};
+
+export type RunUpdateResult = {
+  pendingBefore: bigint;
+  pendingAfter: bigint;
+  batchesSent: number;
+  usersUpdated: number;
+};
+
+/**
+ * Drains pendingScoreUpdates for the given holders.
+ * Filters out users already processed in the current round via isScoreUpdated.
+ * Batches by maxLoopsLimit() and calls updateScores() per batch.
+ */
+export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOptions = {}): Promise<RunUpdateResult> {
+  const dryRun = opts.dryRun ?? false;
+  const log = opts.log ?? ((msg: string) => console.log(msg));
+
+  const pendingBefore: bigint = (await prime.pendingScoreUpdates()).toBigInt();
+  if (pendingBefore === 0n) {
+    log("pendingScoreUpdates = 0 — nothing to do");
+    return { pendingBefore: 0n, pendingAfter: 0n, batchesSent: 0, usersUpdated: 0 };
+  }
+  log(`pendingScoreUpdates: ${pendingBefore}`);
+
+  const roundId: bigint = (await prime.nextScoreUpdateRoundId()).toBigInt();
+  const maxLoops: bigint = (await prime.maxLoopsLimit()).toBigInt();
+  log(`round ${roundId}, maxLoopsLimit ${maxLoops}`);
+
+  const remaining: string[] = [];
+  for (const h of holders) {
+    const done: boolean = await prime.isScoreUpdated(roundId, h);
+    if (!done) remaining.push(h);
+  }
+  log(`Pending this round: ${remaining.length}`);
+
+  if (remaining.length === 0) {
+    log(
+      "All current holders already updated for this round. Pending counter may include burned users — verify off-chain.",
+    );
+    return { pendingBefore, pendingAfter: pendingBefore, batchesSent: 0, usersUpdated: 0 };
+  }
+
+  const batches = chunk(remaining, Number(maxLoops));
+  log(`Sending ${batches.length} batch(es) of up to ${maxLoops} users`);
+
+  let usersUpdated = 0;
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    log(`  [${i + 1}/${batches.length}] updateScores(${batch.length} users)`);
+    if (dryRun) {
+      usersUpdated += batch.length;
+      continue;
+    }
+
+    const tx = await prime.updateScores(batch);
+    const rcpt = await tx.wait();
+    log(`    tx ${rcpt.transactionHash} gasUsed=${rcpt.gasUsed.toString()}`);
+    usersUpdated += batch.length;
+  }
+
+  const pendingAfter: bigint = (await prime.pendingScoreUpdates()).toBigInt();
+  log(`pendingScoreUpdates after: ${pendingAfter}`);
+
+  return { pendingBefore, pendingAfter, batchesSent: batches.length, usersUpdated };
+}
+
+async function main() {
+  const fromBlock = Number(process.env.FROM_BLOCK ?? 0);
+  const blockRange = Number(process.env.BLOCK_RANGE ?? 5000);
+  const dryRun = process.env.DRY_RUN === "1";
+
+  const dep = await deployments.get("Prime");
+  console.log(`Prime: ${dep.address}`);
+
+  const prime = await ethers.getContractAt("Prime", dep.address);
+
+  console.log("Reconstructing holder set from Mint/Burn events...");
+  const events = await fetchHolderEvents(prime, fromBlock, blockRange, undefined, m => console.log(m));
+  const holders = eventsToHolders(events);
+  console.log(`Total current holders: ${holders.length}`);
+
+  await runUpdate(prime, holders, { dryRun, log: m => console.log(m) });
+}
+
+// Only execute when invoked directly via `hardhat run`, not when imported by tests.
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/prime-update-scores.ts
+++ b/scripts/prime-update-scores.ts
@@ -18,7 +18,8 @@
  *   npx hardhat run scripts/prime-update-scores.ts --network <network>
  *
  * Optional env vars:
- *   FROM_BLOCK         First block to scan for Mint/Burn (default: 0)
+ *   FROM_BLOCK         First block to scan for Mint/Burn
+ *                      (default: BSC mainnet Prime deploy block, 33_264_762)
  *   BLOCK_RANGE        Max blocks per getLogs call (default: 5000)
  *   DRY_RUN            "1" to skip sending txs
  */
@@ -136,10 +137,17 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
   const maxLoops: bigint = (await prime.maxLoopsLimit()).toBigInt();
   log(`round ${roundId}, maxLoopsLimit ${maxLoops}`);
 
+  // Parallelize isScoreUpdated reads in batches to avoid serial RPC latency
+  // when there are many holders. RPC providers tolerate ~20 in-flight reads
+  // comfortably without rate-limiting.
+  const ISSCOREUPDATED_BATCH = 20;
   const remaining: string[] = [];
-  for (const h of holders) {
-    const done: boolean = await prime.isScoreUpdated(roundId, h);
-    if (!done) remaining.push(h);
+  for (let i = 0; i < holders.length; i += ISSCOREUPDATED_BATCH) {
+    const slice = holders.slice(i, i + ISSCOREUPDATED_BATCH);
+    const flags: boolean[] = await Promise.all(slice.map(h => prime.isScoreUpdated(roundId, h)));
+    for (let j = 0; j < slice.length; j++) {
+      if (!flags[j]) remaining.push(slice[j]);
+    }
   }
   log(`Pending this round: ${remaining.length}`);
 
@@ -174,8 +182,14 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
   return { pendingBefore, pendingAfter, batchesSent: batches.length, usersUpdated };
 }
 
+// BSC mainnet Prime deployment block (proxy creation tx
+// 0xfd09cf4011f863f65f1dc6a37cb325468f0ce6311849f77205e891bd36107433).
+// Used as the default lower bound for the Mint/Burn event scan so an
+// operator on bscmainnet doesn't have to look it up manually.
+const PRIME_BSCMAINNET_DEPLOY_BLOCK = 33_264_762;
+
 async function main() {
-  const fromBlock = Number(process.env.FROM_BLOCK ?? 0);
+  const fromBlock = Number(process.env.FROM_BLOCK ?? PRIME_BSCMAINNET_DEPLOY_BLOCK);
   const blockRange = Number(process.env.BLOCK_RANGE ?? 5000);
   const dryRun = process.env.DRY_RUN === "1";
 

--- a/tests/hardhat/Prime/Prime.ts
+++ b/tests/hardhat/Prime/Prime.ts
@@ -31,7 +31,7 @@ chai.use(smock.matchers);
 export const bigNumber18 = BigNumber.from("1000000000000000000"); // 1e18
 export const bigNumber16 = BigNumber.from("10000000000000000"); // 1e16
 
-type SetupProtocolFixture = {
+export type SetupProtocolFixture = {
   oracle: FakeContract<ResilientOracleInterface>;
   accessControl: FakeContract<IAccessControlManager>;
   comptrollerLens: MockContract<ComptrollerLens>;
@@ -48,7 +48,7 @@ type SetupProtocolFixture = {
   _primeLiquidityProvider: PrimeLiquidityProvider;
 };
 
-async function deployProtocol(): Promise<SetupProtocolFixture> {
+export async function deployProtocol(): Promise<SetupProtocolFixture> {
   const [wallet, user1, user2, user3] = await ethers.getSigners();
 
   const oracle = await smock.fake<ResilientOracleInterface>("ResilientOracleInterface");

--- a/tests/hardhat/Scripts/primeUpdateScores.e2e.ts
+++ b/tests/hardhat/Scripts/primeUpdateScores.e2e.ts
@@ -1,0 +1,177 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import chai from "chai";
+import { BigNumber, Signer } from "ethers";
+import { ethers } from "hardhat";
+
+import { convertToUnit } from "../../../helpers/utils";
+import { eventsToHolders, fetchHolderEvents, runUpdate } from "../../../scripts/prime-update-scores";
+import { SetupProtocolFixture, deployProtocol } from "../Prime/Prime";
+
+const { expect } = chai;
+
+// Mirror the bigNumber18 constant from the Prime fixture.
+const bigNumber18 = BigNumber.from("1000000000000000000");
+
+/**
+ * End-to-end test of scripts/prime-update-scores against a real deployed
+ * Prime instance. Verifies the full pipeline triggered by addMarket on a new
+ * market (modeled here as the "U" market via the fixture's vbnb token):
+ *
+ *   issue holders -> addMarket(vU) triggers _startScoreUpdateRound
+ *   -> fetchHolderEvents (queryFilter scan)
+ *   -> eventsToHolders (replay events)
+ *   -> runUpdate (chunk + updateScores per batch)
+ *   -> pendingScoreUpdates drains to 0, isScoreUpdated set per user.
+ */
+describe("scripts/prime-update-scores — E2E against deployed Prime", () => {
+  let f: SetupProtocolFixture;
+  let user1: Signer;
+  let user2: Signer;
+  let user3: Signer;
+
+  /**
+   * The Prime fixture deploys but does not add vbnb to Prime. We use it as
+   * the "U" market — the newly-added market triggering a score update round.
+   * fetchHolderEvents only needs Mint/Burn events, but updateScores walks all
+   * Prime markets so we set a price for vbnb to make score computation valid.
+   */
+  async function addUMarket() {
+    f.oracle.getUnderlyingPrice.returns((vToken: string) => {
+      if (vToken == f.vusdt.address) return convertToUnit(1, 18);
+      if (vToken == f.veth.address) return convertToUnit(1200, 18);
+      // The fixture has a vbnb that is not part of the typed return; use the
+      // raw address via the smock fake's wildcard match.
+      return convertToUnit(300, 18);
+    });
+
+    // vbnb is exposed on the fixture's comptroller (already _supportMarket'd
+    // in deployProtocol). Pull its address from the comptroller's market list.
+    // The fixture stores vbnb via `comptroller._supportMarket(vbnb)` at line 129.
+    const vbnbAddress = (await f.comptroller.getAllMarkets())[2]; // [vusdt, veth, vbnb]
+
+    await f.prime.addMarket(f.comptroller.address, vbnbAddress, bigNumber18.mul(1), bigNumber18.mul(1));
+    return vbnbAddress;
+  }
+
+  beforeEach(async () => {
+    const signers = await ethers.getSigners();
+    [, user1, user2, user3] = signers; // skip deployer (index 0)
+    f = await loadFixture(deployProtocol);
+  });
+
+  it("drains pendingScoreUpdates to 0 after addMarket(vU)", async () => {
+    const u1 = await user1.getAddress();
+    const u2 = await user2.getAddress();
+    const u3 = await user3.getAddress();
+
+    // Issue Prime tokens to three users. This emits three Mint events that
+    // the script will discover via queryFilter.
+    await f.prime.issue(false, [u1, u2, u3]);
+
+    // Sanity: nothing queued yet (issue doesn't trigger a round).
+    expect(await f.prime.pendingScoreUpdates()).to.equal(0);
+
+    // Add the new U market. addMarket calls _startScoreUpdateRound()
+    // internally, setting pendingScoreUpdates = totalIrrevocable + totalRevocable = 3.
+    await addUMarket();
+
+    const pendingBefore = await f.prime.pendingScoreUpdates();
+    expect(pendingBefore).to.equal(3);
+
+    const roundId = await f.prime.nextScoreUpdateRoundId();
+
+    // ── Run the script's pipeline against the deployed instance ──
+    const events = await fetchHolderEvents(f.prime, 0, 5000);
+    const holders = eventsToHolders(events);
+
+    // Reconstructed holder set must contain exactly the three issued addresses.
+    expect(holders).to.have.members([u1, u2, u3]);
+    expect(holders.length).to.equal(3);
+
+    const result = await runUpdate(f.prime, holders, { log: () => undefined });
+
+    // Final state: queue drained.
+    expect(result.pendingBefore.toString()).to.equal("3");
+    expect(result.pendingAfter.toString()).to.equal("0");
+    expect(result.usersUpdated).to.equal(3);
+    expect(await f.prime.pendingScoreUpdates()).to.equal(0);
+
+    // Per-user dedup mapping must be set for this round.
+    expect(await f.prime.isScoreUpdated(roundId, u1)).to.equal(true);
+    expect(await f.prime.isScoreUpdated(roundId, u2)).to.equal(true);
+    expect(await f.prime.isScoreUpdated(roundId, u3)).to.equal(true);
+  });
+
+  it("respects maxLoopsLimit by splitting into multiple batches", async () => {
+    // Fixture sets maxLoopsLimit = 10 and MaxLoopsLimitHelper only allows
+    // increasing it. Use 11 unique holders to force a 2-batch split (10 + 1).
+    const holdersToIssue: string[] = [];
+    for (let i = 0; i < 11; i++) {
+      holdersToIssue.push(ethers.Wallet.createRandom().address);
+    }
+
+    await f.prime.issue(false, holdersToIssue);
+    await addUMarket();
+    expect(await f.prime.pendingScoreUpdates()).to.equal(11);
+
+    const events = await fetchHolderEvents(f.prime, 0, 5000);
+    const holders = eventsToHolders(events);
+    expect(holders.length).to.equal(11);
+
+    const result = await runUpdate(f.prime, holders, { log: () => undefined });
+
+    expect(result.batchesSent).to.equal(2); // ceil(11/10) = 2
+    expect(result.usersUpdated).to.equal(11);
+    expect(await f.prime.pendingScoreUpdates()).to.equal(0);
+  });
+
+  it("is resumable: re-running after a partial drain skips already-processed users", async () => {
+    const u1 = await user1.getAddress();
+    const u2 = await user2.getAddress();
+    const u3 = await user3.getAddress();
+
+    await f.prime.issue(false, [u1, u2, u3]);
+    await addUMarket();
+
+    const roundId = await f.prime.nextScoreUpdateRoundId();
+
+    // First run processes only u1 (simulate partial run by passing one user).
+    await f.prime.updateScores([u1]);
+    expect(await f.prime.isScoreUpdated(roundId, u1)).to.equal(true);
+    expect(await f.prime.pendingScoreUpdates()).to.equal(2);
+
+    // Now the script should pick up u2, u3 and skip u1.
+    const events = await fetchHolderEvents(f.prime, 0, 5000);
+    const holders = eventsToHolders(events);
+
+    const result = await runUpdate(f.prime, holders, { log: () => undefined });
+
+    // runUpdate filters u1 out via isScoreUpdated check, so only 2 users updated.
+    expect(result.usersUpdated).to.equal(2);
+    expect(await f.prime.pendingScoreUpdates()).to.equal(0);
+  });
+
+  it("excludes burned holders from the reconstructed set", async () => {
+    const u1 = await user1.getAddress();
+    const u2 = await user2.getAddress();
+    const u3 = await user3.getAddress();
+
+    await f.prime.issue(false, [u1, u2, u3]);
+    // Burn u2 — burn emits Burn event, which the script must apply.
+    await f.prime.burn(u2);
+
+    await addUMarket();
+    // After burn, totalIrrevocable + totalRevocable = 2, so queue size = 2.
+    expect(await f.prime.pendingScoreUpdates()).to.equal(2);
+
+    const events = await fetchHolderEvents(f.prime, 0, 5000);
+    const holders = eventsToHolders(events);
+
+    expect(holders).to.have.members([u1, u3]);
+    expect(holders).to.not.include(u2);
+
+    const result = await runUpdate(f.prime, holders, { log: () => undefined });
+    expect(result.usersUpdated).to.equal(2);
+    expect(await f.prime.pendingScoreUpdates()).to.equal(0);
+  });
+});

--- a/tests/hardhat/Scripts/primeUpdateScores.ts
+++ b/tests/hardhat/Scripts/primeUpdateScores.ts
@@ -1,0 +1,227 @@
+import chai from "chai";
+import { BigNumber } from "ethers";
+
+import { HolderEvent, chunk, eventsToHolders, runUpdate } from "../../../scripts/prime-update-scores";
+
+const { expect } = chai;
+
+function addr(n: number): string {
+  return "0x" + n.toString(16).padStart(40, "0");
+}
+
+/**
+ * Hand-rolled stub conforming to the subset of the Prime ABI the script uses.
+ * Avoids smock since the methods we need are public-state-var getters that
+ * smock can't synthesize without the concrete contract type.
+ */
+class PrimeStub {
+  pendingValues: BigNumber[] = [BigNumber.from(0)]; // can change across calls
+  pendingCallCount = 0;
+  roundId = BigNumber.from(0);
+  maxLoops = BigNumber.from(100);
+  doneSet = new Set<string>(); // users with isScoreUpdated == true
+  updateScoresCalls: string[][] = [];
+
+  async pendingScoreUpdates(): Promise<BigNumber> {
+    const idx = Math.min(this.pendingCallCount, this.pendingValues.length - 1);
+    this.pendingCallCount++;
+    return this.pendingValues[idx];
+  }
+
+  async nextScoreUpdateRoundId(): Promise<BigNumber> {
+    return this.roundId;
+  }
+
+  async maxLoopsLimit(): Promise<BigNumber> {
+    return this.maxLoops;
+  }
+
+  async isScoreUpdated(_roundId: BigNumber, user: string): Promise<boolean> {
+    return this.doneSet.has(user);
+  }
+
+  async updateScores(users: string[]): Promise<{ wait(): Promise<{ transactionHash: string; gasUsed: BigNumber }> }> {
+    this.updateScoresCalls.push([...users]);
+    return {
+      wait: async () => ({ transactionHash: "0xdead", gasUsed: BigNumber.from(123456) }),
+    };
+  }
+}
+
+describe("scripts/prime-update-scores", () => {
+  describe("chunk()", () => {
+    it("returns empty when input is empty", () => {
+      expect(chunk([], 5)).to.deep.equal([]);
+    });
+
+    it("splits an array evenly when size divides length", () => {
+      expect(chunk([1, 2, 3, 4], 2)).to.deep.equal([
+        [1, 2],
+        [3, 4],
+      ]);
+    });
+
+    it("places remainder in the last chunk when size does not divide length", () => {
+      expect(chunk([1, 2, 3, 4, 5], 2)).to.deep.equal([[1, 2], [3, 4], [5]]);
+    });
+
+    it("returns one chunk when size >= length", () => {
+      expect(chunk([1, 2, 3], 10)).to.deep.equal([[1, 2, 3]]);
+    });
+
+    it("throws when size <= 0", () => {
+      expect(() => chunk([1, 2], 0)).to.throw(/size must be > 0/);
+      expect(() => chunk([1, 2], -1)).to.throw(/size must be > 0/);
+    });
+  });
+
+  describe("eventsToHolders()", () => {
+    it("treats a single Mint as a current holder", () => {
+      const events: HolderEvent[] = [{ kind: "Mint", user: addr(1), blockNumber: 1, logIndex: 0 }];
+      expect(eventsToHolders(events)).to.deep.equal([addr(1)]);
+    });
+
+    it("treats Mint → Burn as not a current holder", () => {
+      const events: HolderEvent[] = [
+        { kind: "Mint", user: addr(1), blockNumber: 1, logIndex: 0 },
+        { kind: "Burn", user: addr(1), blockNumber: 2, logIndex: 0 },
+      ];
+      expect(eventsToHolders(events)).to.deep.equal([]);
+    });
+
+    it("treats Mint → Burn → Mint as a current holder (latest event wins)", () => {
+      const events: HolderEvent[] = [
+        { kind: "Mint", user: addr(1), blockNumber: 1, logIndex: 0 },
+        { kind: "Burn", user: addr(1), blockNumber: 2, logIndex: 0 },
+        { kind: "Mint", user: addr(1), blockNumber: 3, logIndex: 0 },
+      ];
+      expect(eventsToHolders(events)).to.deep.equal([addr(1)]);
+    });
+
+    it("applies events in (blockNumber, logIndex) order even when input is unsorted", () => {
+      // Burn at (2, 0) must apply AFTER Mint at (1, 0).
+      const events: HolderEvent[] = [
+        { kind: "Burn", user: addr(1), blockNumber: 2, logIndex: 0 },
+        { kind: "Mint", user: addr(1), blockNumber: 1, logIndex: 0 },
+      ];
+      expect(eventsToHolders(events)).to.deep.equal([]);
+    });
+
+    it("breaks ties on blockNumber using logIndex", () => {
+      // Same block: Mint at logIndex 0, then Burn at logIndex 1 -> not holder.
+      const events: HolderEvent[] = [
+        { kind: "Burn", user: addr(1), blockNumber: 1, logIndex: 1 },
+        { kind: "Mint", user: addr(1), blockNumber: 1, logIndex: 0 },
+      ];
+      expect(eventsToHolders(events)).to.deep.equal([]);
+
+      // Reverse logIndex order: Burn first, then Mint -> holder.
+      const events2: HolderEvent[] = [
+        { kind: "Mint", user: addr(1), blockNumber: 1, logIndex: 1 },
+        { kind: "Burn", user: addr(1), blockNumber: 1, logIndex: 0 },
+      ];
+      expect(eventsToHolders(events2)).to.deep.equal([addr(1)]);
+    });
+
+    it("returns all holders for multiple distinct users", () => {
+      const events: HolderEvent[] = [
+        { kind: "Mint", user: addr(1), blockNumber: 1, logIndex: 0 },
+        { kind: "Mint", user: addr(2), blockNumber: 1, logIndex: 1 },
+        { kind: "Mint", user: addr(3), blockNumber: 2, logIndex: 0 },
+        { kind: "Burn", user: addr(2), blockNumber: 3, logIndex: 0 },
+      ];
+      const holders = eventsToHolders(events);
+      expect(holders).to.have.members([addr(1), addr(3)]);
+      expect(holders).to.not.include(addr(2));
+    });
+  });
+
+  describe("runUpdate()", () => {
+    let prime: PrimeStub;
+
+    beforeEach(() => {
+      prime = new PrimeStub();
+    });
+
+    it("short-circuits when pendingScoreUpdates is 0", async () => {
+      prime.pendingValues = [BigNumber.from(0)];
+
+      const result = await runUpdate(prime as any, [addr(1), addr(2)], { log: () => undefined });
+
+      expect(result).to.deep.equal({ pendingBefore: 0n, pendingAfter: 0n, batchesSent: 0, usersUpdated: 0 });
+      expect(prime.updateScoresCalls).to.have.length(0);
+    });
+
+    it("short-circuits when all holders already processed in current round", async () => {
+      prime.pendingValues = [BigNumber.from(5)];
+      prime.roundId = BigNumber.from(7);
+      prime.doneSet = new Set([addr(1), addr(2), addr(3)]);
+
+      const result = await runUpdate(prime as any, [addr(1), addr(2), addr(3)], { log: () => undefined });
+
+      expect(result.batchesSent).to.equal(0);
+      expect(result.usersUpdated).to.equal(0);
+      expect(result.pendingAfter).to.equal(5n);
+      expect(prime.updateScoresCalls).to.have.length(0);
+    });
+
+    it("calls updateScores once when holders fit in a single batch", async () => {
+      prime.pendingValues = [BigNumber.from(2), BigNumber.from(0)];
+      prime.maxLoops = BigNumber.from(10);
+
+      const holders = [addr(1), addr(2)];
+      const result = await runUpdate(prime as any, holders, { log: () => undefined });
+
+      expect(result.batchesSent).to.equal(1);
+      expect(result.usersUpdated).to.equal(2);
+      expect(prime.updateScoresCalls).to.deep.equal([holders]);
+    });
+
+    it("splits holders across multiple batches sized by maxLoopsLimit", async () => {
+      prime.pendingValues = [BigNumber.from(5), BigNumber.from(0)];
+      prime.maxLoops = BigNumber.from(2);
+
+      const holders = [addr(1), addr(2), addr(3), addr(4), addr(5)];
+      const result = await runUpdate(prime as any, holders, { log: () => undefined });
+
+      expect(result.batchesSent).to.equal(3); // ceil(5/2) = 3
+      expect(result.usersUpdated).to.equal(5);
+      expect(prime.updateScoresCalls).to.deep.equal([[addr(1), addr(2)], [addr(3), addr(4)], [addr(5)]]);
+    });
+
+    it("skips users already processed and only sends remaining", async () => {
+      prime.pendingValues = [BigNumber.from(2), BigNumber.from(0)];
+      prime.roundId = BigNumber.from(3);
+      prime.maxLoops = BigNumber.from(10);
+      prime.doneSet = new Set([addr(1)]); // user(1) already done; (2) & (3) pending
+
+      await runUpdate(prime as any, [addr(1), addr(2), addr(3)], { log: () => undefined });
+
+      expect(prime.updateScoresCalls).to.deep.equal([[addr(2), addr(3)]]);
+    });
+
+    it("does not call updateScores in dryRun mode", async () => {
+      prime.pendingValues = [BigNumber.from(3), BigNumber.from(3)]; // unchanged since dryRun
+      prime.maxLoops = BigNumber.from(10);
+
+      const result = await runUpdate(prime as any, [addr(1), addr(2), addr(3)], {
+        dryRun: true,
+        log: () => undefined,
+      });
+
+      expect(prime.updateScoresCalls).to.have.length(0);
+      expect(result.batchesSent).to.equal(1);
+      expect(result.usersUpdated).to.equal(3); // counted as would-have-been-updated
+    });
+
+    it("reports pendingAfter from the contract after batches drain", async () => {
+      prime.pendingValues = [BigNumber.from(3), BigNumber.from(0)];
+      prime.maxLoops = BigNumber.from(10);
+
+      const result = await runUpdate(prime as any, [addr(1), addr(2), addr(3)], { log: () => undefined });
+
+      expect(result.pendingBefore).to.equal(3n);
+      expect(result.pendingAfter).to.equal(0n);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- After `addMarket`/`updateAlpha`/`updateMultipliers`, Prime queues a score update per holder and freezes `issue`/`burn` until the queue drains. There is no on-chain holder enumeration and no existing keeper, so the queue must be drained manually.
- Adds a standalone script that reconstructs the holder set from `Mint`/`Burn` events and batches `updateScores` until `pendingScoreUpdates == 0`. Resumable across runs via the contract's `isScoreUpdated[roundId][user]` mapping.

## Changes
- **scripts/prime-update-scores.ts** — new script. Exports `chunk`/`eventsToHolders`/`fetchHolderEvents`/`runUpdate` for testability; `main()` guarded by `require.main === module`. Address resolved via `deployments.get("Prime")`. Env vars: `FROM_BLOCK`, `BLOCK_RANGE`, `DRY_RUN`.
- **tests/hardhat/Scripts/primeUpdateScores.ts** — 18 unit tests covering pure logic (`chunk`, `eventsToHolders`) plus `runUpdate` orchestration against a hand-rolled `PrimeStub`.
- **tests/hardhat/Scripts/primeUpdateScores.e2e.ts** — 4 end-to-end tests against a real deployed Prime via the existing `deployProtocol` fixture. Trigger is the real `addMarket(vU)` codepath. Covers full drain, multi-batch chunking by `maxLoopsLimit`, resumability, and burn handling.
- **tests/hardhat/Prime/Prime.ts** — added `export` to `SetupProtocolFixture` and `deployProtocol` so the E2E test can reuse them. No behavioral change.

## Test plan
- [ ] `FORKED_NETWORK= npx hardhat test tests/hardhat/Scripts/` — expect 46 passing (18 unit + 4 E2E + 24 inherited via fixture import)
- [ ] Dry-run against bscmainnet to preview holder count + batch plan:
      `DRY_RUN=1 FROM_BLOCK=<prime_deploy_block> BLOCK_RANGE=2000 npx hardhat run scripts/prime-update-scores.ts --network bscmainnet`
- [ ] Confirm `prime.paused() == false` before any real execution
- [ ] Real execution (post-`addMarket(vU)`):
      `FROM_BLOCK=<prime_deploy_block> BLOCK_RANGE=2000 npx hardhat run scripts/prime-update-scores.ts --network bscmainnet`
- [ ] Verify `pendingScoreUpdates() == 0` after run completes