### PR TITLE
fix: allow exiting a zero-balance market when its price feed is unavailable

### DIFF
--- a/contracts/Comptroller/Diamond/facets/MarketFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/MarketFacet.sol
@@ -258,9 +258,17 @@ contract MarketFacet is IMarketFacet, FacetBase {
         }
 
         /* Fail if the sender is not permitted to redeem all of their tokens */
-        uint256 allowed = redeemAllowedInternal(vTokenAddress, msg.sender, tokensHeld);
-        if (allowed != 0) {
-            return failOpaque(Error.REJECTION, FailureInfo.EXIT_MARKET_REJECTION, allowed);
+        // When the sender holds no balance in this market there is nothing to redeem, and a market
+        // with a zero balance contributes no collateral to the account. Removing it from the account's
+        // asset list therefore cannot reduce the account's liquidity, so the hypothetical liquidity
+        // check is unnecessary here. Skipping it also lets users exit a delisted market whose oracle
+        // feed has been retired: that check fetches a fresh price for every entered market and would
+        // otherwise revert, leaving the account unable to operate on its other markets.
+        if (tokensHeld != 0) {
+            uint256 allowed = redeemAllowedInternal(vTokenAddress, msg.sender, tokensHeld);
+            if (allowed != 0) {
+                return failOpaque(Error.REJECTION, FailureInfo.EXIT_MARKET_REJECTION, allowed);
+            }
         }
 
         Market storage marketToExit = getCorePoolMarket(address(vToken));

--- a/tests/hardhat/Comptroller/Diamond/assetListTest.ts
+++ b/tests/hardhat/Comptroller/Diamond/assetListTest.ts
@@ -45,6 +45,8 @@ describe("Comptroller: assetListTest", () => {
   let BAT: FakeContract<VBep20Immutable>;
   let SKT: FakeContract<VBep20Immutable>;
   let allTokens: FakeContract<VBep20Immutable>[];
+  let oracle: FakeContract<PriceOracle>;
+  let dbo: FakeContract<IDeviationBoundedOracle>;
 
   type AssetListFixture = {
     unitroller: MockContract<ComptrollerMock>;
@@ -71,7 +73,7 @@ describe("Comptroller: assetListTest", () => {
     await comptroller._setAccessControl(accessControl.address);
     await comptroller._setComptrollerLens(comptrollerLens.address);
     await comptroller._setPriceOracle(oracle.address);
-    const dbo = await smock.fake<IDeviationBoundedOracle>("IDeviationBoundedOracle");
+    dbo = await smock.fake<IDeviationBoundedOracle>("IDeviationBoundedOracle");
     dbo.getBoundedPricesView.returns([convertToUnit("1", 18), convertToUnit("1", 18)]);
     await comptroller.setDeviationBoundedOracle(dbo.address);
     const names = ["OMG", "ZRX", "BAT", "sketch"];
@@ -92,6 +94,7 @@ describe("Comptroller: assetListTest", () => {
 
   function configure({ oracle, allTokens, names }: AssetListFixture) {
     oracle.getUnderlyingPrice.returns(convertToUnit("0.5", 18));
+    dbo.getBoundedPricesView.returns([convertToUnit("1", 18), convertToUnit("1", 18)]);
     allTokens.map((vToken, i) => {
       vToken.isVToken.returns(true);
       vToken.symbol.returns(names[i]);
@@ -104,7 +107,7 @@ describe("Comptroller: assetListTest", () => {
     [root, customer] = await ethers.getSigners();
     const contracts = await loadFixture(assetListFixture);
     configure(contracts);
-    ({ unitroller, OMG, ZRX, BAT, SKT, allTokens } = contracts);
+    ({ unitroller, oracle, OMG, ZRX, BAT, SKT, allTokens } = contracts);
   });
 
   async function checkMarkets(expectedTokens: FakeContract<VBep20Immutable>[]) {
@@ -221,12 +224,35 @@ describe("Comptroller: assetListTest", () => {
 
     it("rejects unless redeem allowed", async () => {
       await enterAndCheckMarkets([OMG, BAT], [OMG, BAT]);
+      // Hold a non-zero OMG balance so the hypothetical liquidity check runs on exit.
+      OMG.getAccountSnapshot.returns([0, 1, 0, 1]);
       // We need to borrow at least 2, otherwise our borrow balance in USD gets truncated
       // when multiplied by price=0.5
       BAT.getAccountSnapshot.returns([0, 0, 2, 1]);
 
       // BAT has a negative balance and there's no supply, thus account should be underwater
       await exitAndCheckMarkets(OMG, [OMG, BAT], Error.REJECTION);
+    });
+
+    it("allows exiting a zero-balance market even when the account is underwater", async () => {
+      await enterAndCheckMarkets([OMG, BAT], [OMG, BAT]);
+      // OMG balance is zero (default snapshot); BAT is an unbacked borrow, so the account is underwater.
+      BAT.getAccountSnapshot.returns([0, 0, 2, 1]);
+
+      // A zero-balance market contributes no collateral, so dropping it cannot change the
+      // account's liquidity. The liquidity check is skipped and the exit is allowed.
+      await exitAndCheckMarkets(OMG, [BAT], Error.NO_ERROR);
+    });
+
+    it("allows exiting a zero-balance market when its price feed reverts", async () => {
+      await enterAndCheckMarkets([OMG], [OMG]);
+      // Simulate a delisted market whose oracle feed has been retired and now reverts.
+      oracle.getUnderlyingPrice.reverts("oracle feed retired");
+      dbo.getBoundedPricesView.reverts("oracle feed retired");
+
+      // OMG balance is zero, so the liquidity check that would query the reverting feed is
+      // skipped and the user can still remove the dead market from their asset list.
+      await exitAndCheckMarkets(OMG, [], Error.NO_ERROR);
     });
 
     it("accepts when you're not in the market already", async () => {


### PR DESCRIPTION
## Context

We periodically *partially delist* an asset (pause supply + borrow, set CF to 0) so no new exposure can accrue. This is a "half-dead" state: existing holders can still repay/withdraw/exit, but the protocol still treats the market as live.

The problem surfaces when the asset's **oracle feed is later retired** (e.g. SXP — all providers stopped feeding price). Any account that ever entered that market still has it in its asset list, and `exitMarket` runs a hypothetical liquidity check (`redeemAllowedInternal`) that fetches a fresh price for **every** entered market. The retired feed reverts → the account can no longer exit the dead market, and that same revert blocks the account's actions on its *other* markets too.

## Change

`MarketFacet.exitMarket`: when the sender holds a **zero balance** in the market being exited, skip the hypothetical liquidity check.

A zero-balance market contributes no collateral, so removing it from the asset list cannot change the account's liquidity — the check is unnecessary, and skipping it avoids the dead-feed dependency. `amountOwed == 0` is already required earlier in the function, so a borrower of the asset still cannot exit (they must repay first).

### Behavior change (intentional)
Previously, an underwater account was rejected from exiting *any* market, including a zero-balance one. It is now allowed to drop a zero-balance market regardless of overall liquidity. This is safe — dropping a weightless market cannot worsen solvency — and is the whole point of the fix. The existing `assetListTest` "rejects unless redeem allowed" case was updated to hold a non-zero balance so it still exercises the rejection path.

### Repay — no change needed
`repayBorrowAllowed` only checks pause/listed state and moves the XVS flywheel; it does **not** read the oracle or run a liquidity check, so repaying a dead-oracle asset already works.

### Out of scope
An account holding a **non-zero** balance in a dead-oracle market still cannot withdraw/exit it (that genuinely needs a price). Those residual positions are covered operationally by pinning a fixed oracle price for the delisted market.

## Tests
`tests/hardhat/Comptroller/Diamond/assetListTest.ts`:
- updated "rejects unless redeem allowed" to use a non-zero balance
- added: exit a zero-balance market while the account is underwater → succeeds
- added: exit a zero-balance market whose price feed reverts → succeeds

All 20 cases in the suite pass. `deviationBoundedOracleTest` + `oraclePumpCrashTest` show no regression vs. baseline (non-zero-balance CF-path exits unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)