### PR TITLE
ci: pin slim-publish npm to v11 to fix EBADENGINE

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,8 +52,10 @@ jobs:
 
       - name: Publish slim package
         run: |
-          # Ensure npm 11.5.1 or later is installed
-          npm install -g npm@latest
+          # Ensure npm 11.5.1 or later is installed. Pin to the v11 line: npm@latest
+          # now resolves to npm@12, which requires a newer Node than CI provides
+          # (node ^22.22.2 || ^24.15.0 || >=26.0.0) and fails with EBADENGINE.
+          npm install -g npm@^11.5.1
 
           cd slim
 


### PR DESCRIPTION
## Problem

The `release` job's **Publish slim package** step fails with:

\`\`\`
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.14.0"}
\`\`\`

Failing run: https://github.com/VenusProtocol/venus-protocol/actions/runs/29325391520/job/87060361905

The main package publishes fine (`10.3.0-dev.2` to `develop`); only the slim step fails. It runs `npm install -g npm@latest`, which now resolves to **npm@12.0.1**. npm 12 requires node `^22.22.2 || ^24.15.0 || >=26.0.0`, but CI provides node `v22.14.0`, so the global install aborts with `EBADENGINE` and the step exits 1.

## Fix

Pin the global npm install to the v11 line (`npm@^11.5.1`), matching the step's own stated intent ("Ensure npm 11.5.1 or later"). This keeps it compatible with the CI node version and avoids being dragged onto npm 12 by `@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)