### PR TITLE
fix: restore localhost deployment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ npx hardhat deploy
 - This command will execute all the deployment scripts in `./deploy` directory - It will skip only deployment scripts which implement a `skip` condition - Here is example of a skip condition: - Skipping deployment script on `bsctestnet` network `func.skip = async (hre: HardhatRuntimeEnvironment) => hre.network.name !== "bsctestnet";`
 - The default network will be `hardhat`
 - Deployment to another network: - Make sure the desired network is configured in `hardhat.config.ts` - Add `MNEMONIC` variable in `.env` file - Execute deploy command by adding `--network <network_name>` in the deploy command above - E.g. `npx hardhat deploy --network bsctestnet`
+- Local Hardhat node: start `npx hardhat node` in one terminal, then run `npx hardhat deploy --network localhost` in another
 - Execution of single or custom set of scripts is possible, if:
   - In the deployment scripts you have added `tags` for example: - `func.tags = ["MockTokens"];`
   - Once this is done, adding `--tags "<tag_name>,<tag_name>..."` to the deployment command will execute only the scripts containing the tags.

--- a/deploy/005-deploy-VTreasuryV8.ts
+++ b/deploy/005-deploy-VTreasuryV8.ts
@@ -56,6 +56,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     bscmainnet: await getTimelock(),
     bsctestnet: await getTimelock(),
     hardhat: deployer,
+    localhost: deployer,,
   };
 
   const deployerSigner = await hre.ethers.getSigner(deployer);

--- a/deploy/006-deploy-psm.ts
+++ b/deploy/006-deploy-psm.ts
@@ -4,7 +4,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { skipRemoteNetworks } from "../helpers/deploymentConfig";
+import { isLocalNetwork, skipRemoteNetworks } from "../helpers/deploymentConfig";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, network, getNamedAccounts, getChainId } = hre;
@@ -16,11 +16,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const usdtAddress = (await deployments.get("USDT")).address;
   const acmAddress = (await deployments.get("AccessControlManager")).address;
-  const treasuryAddress = (await deployments.get(hre.network.name == "hardhat" ? "VTreasuryV8" : "VTreasury")).address;
+  const treasuryAddress = (await deployments.get(isLocalNetwork(network.name) ? "VTreasuryV8" : "VTreasury")).address;
   const oracleAddress = (await deployments.get("ResilientOracle")).address;
 
   let normalVipTimelockAddress;
-  if (hre.network.name === "hardhat") {
+  if (isLocalNetwork(network.name)) {
     normalVipTimelockAddress = (
       await deploy("NormalTimelock", {
         contract: "TestTimelockV8",
@@ -55,7 +55,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
     autoMine: true,
     proxy: {
-      owner: network.name === "hardhat" ? deployer : normalVipTimelockAddress,
+      owner: isLocalNetwork(network.name) ? deployer : normalVipTimelockAddress,
       proxyContract: "OpenZeppelinTransparentProxy",
       execute: {
         methodName: "initialize",
@@ -66,7 +66,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const psm = await ethers.getContract("PegStability_USDT");
 
-  if (network.name !== "hardhat") {
+  if (!isLocalNetwork(network.name)) {
     const timelockAddress = normalVipTimelockAddress;
     await psm.transferOwnership(timelockAddress);
     console.log(`PSM Contract (${psm.address}) owner changed from ${deployer} to ${timelockAddress}`);

--- a/deploy/006-update-liquidator.ts
+++ b/deploy/006-update-liquidator.ts
@@ -2,7 +2,7 @@ import { parseUnits } from "ethers/lib/utils";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { skipRemoteNetworks } from "../helpers/deploymentConfig";
+import { isLocalNetwork, skipRemoteNetworks } from "../helpers/deploymentConfig";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, network, getNamedAccounts } = hre;
@@ -27,7 +27,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       log: true,
       autoMine: true,
       proxy: {
-        owner: network.name === "hardhat" ? deployer : timelockAddress,
+        owner: isLocalNetwork(network.name) ? deployer : timelockAddress,
         proxyContract: "OpenZeppelinTransparentProxy",
         execute: {
           methodName: "initialize",

--- a/deploy/007-deploy-VBNBAdmin.ts
+++ b/deploy/007-deploy-VBNBAdmin.ts
@@ -3,7 +3,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { skipRemoteNetworks } from "../helpers/deploymentConfig";
+import { isLocalNetwork, skipRemoteNetworks } from "../helpers/deploymentConfig";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, network, getNamedAccounts } = hre;
@@ -26,7 +26,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
     autoMine: true,
     proxy: {
-      owner: network.name === "hardhat" ? deployer : normalVipTimelockAddress,
+      owner: isLocalNetwork(network.name) ? deployer : normalVipTimelockAddress,
       proxyContract: "OpenZeppelinTransparentProxy",
       execute: {
         methodName: "initialize",
@@ -37,7 +37,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const vBNBAdmin = await ethers.getContract("VBNBAdmin");
 
-  if (network.name !== "hardhat") {
+  if (!isLocalNetwork(network.name)) {
     await vBNBAdmin.transferOwnership(normalVipTimelockAddress);
     console.log(
       `VBNBAdmin Contract (${vBNBAdmin.address}) owner changed from ${deployer} to ${normalVipTimelockAddress}`,

--- a/deploy/009-configure-vaults.ts
+++ b/deploy/009-configure-vaults.ts
@@ -47,6 +47,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     unichainsepolia: unichainsepoliaGovernanceDeployments.contracts.NormalTimelock.address,
     unichainmainnet: unichainmainnetGovernanceDeployments.contracts.NormalTimelock.address,
     hardhat: deployer,
+    localhost: deployer,,
   };
 
   const accessControlManager = await ethers.getContract("AccessControlManager");

--- a/deploy/012-deploy-prime.ts
+++ b/deploy/012-deploy-prime.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
+import { isLocalNetwork, getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
 
 interface AdminAccounts {
   [key: string]: string;
@@ -25,6 +25,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
   const stakingPeriod: Config = {
     hardhat: TEN_MINUTES,
+    localhost: TEN_MINUTES,,
     bsctestnet: TEN_MINUTES,
     sepolia: TEN_MINUTES,
     arbitrumsepolia: TEN_MINUTES,
@@ -54,6 +55,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     opmainnet: 0,
     unichainsepolia: 0,
     hardhat: 0,
+    localhost: 0,,
     basesepolia: 0,
     basemainnet: 0,
     unichainmainnet: 0,
@@ -75,6 +77,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     bscmainnet: 70_080_000,
     ethereum: 2_628_000,
     hardhat: 100,
+    localhost: 100,,
   };
 
   const networkName: string = network.name;
@@ -125,7 +128,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       deterministicDeployment: false,
       args: [isTimeBased, blocksPerYear[networkName]],
       proxy: {
-        owner: network.name === "hardhat" ? deployer : adminAccount[networkName],
+        owner: isLocalNetwork(network.name) ? deployer : adminAccount[networkName],
         proxyContract: "OptimizedTransparentUpgradeableProxy",
         execute: {
           methodName: "initialize",
@@ -154,7 +157,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         isTimeBased,
       ],
       proxy: {
-        owner: network.name === "hardhat" ? deployer : adminAccount[networkName],
+        owner: isLocalNetwork(network.name) ? deployer : adminAccount[networkName],
         proxyContract: "OptimizedTransparentUpgradeableProxy",
         execute: {
           methodName: "initialize",

--- a/deploy/013-configure-prime.ts
+++ b/deploy/013-configure-prime.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
+import { isLocalNetwork, getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
 
 interface AdminAccounts {
   [key: string]: string;
@@ -33,7 +33,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const prime = await ethers.getContract("Prime");
   const plp = await ethers.getContract("PrimeLiquidityProvider");
 
-  if (network.name !== "hardhat") {
+  if (!isLocalNetwork(network.name)) {
     console.log("Transferring Prime ownership to Timelock");
     await prime.transferOwnership(adminAccount[network.name]);
 

--- a/deploy/014-deploy-prime-leaderboard.ts
+++ b/deploy/014-deploy-prime-leaderboard.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
+import { isLocalNetwork, getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
 
 interface AdminAccounts {
   [key: string]: string;
@@ -30,6 +30,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     opmainnet: 0,
     unichainsepolia: 0,
     hardhat: 0,
+    localhost: 0,,
     basesepolia: 0,
     basemainnet: 0,
     unichainmainnet: 0,
@@ -72,7 +73,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     deterministicDeployment: false,
     args: constructorArgs,
     proxy: {
-      owner: network.name === "hardhat" ? deployer : adminAccount[networkName],
+      owner: isLocalNetwork(network.name) ? deployer : adminAccount[networkName],
       proxyContract: "OptimizedTransparentUpgradeableProxy",
       execute: {
         methodName: "initialize",
@@ -89,7 +90,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`PrimeLeaderboard deployed: ${primeLeaderboard.address}`);
 
   // ============ Verify implementation ============
-  if (network.name !== "hardhat" && primeLeaderboardDeployment.implementation) {
+  if (!isLocalNetwork(network.name) && primeLeaderboardDeployment.implementation) {
     try {
       await hre.run("verify:verify", {
         address: primeLeaderboardDeployment.implementation,
@@ -101,7 +102,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   // ============ Transfer ownership to Timelock ============
-  if (network.name !== "hardhat") {
+  if (!isLocalNetwork(network.name)) {
     console.log("Transferring PrimeLeaderboard ownership to Timelock...");
     await primeLeaderboard.transferOwnership(adminAccount[networkName]);
     console.log(`PrimeLeaderboard ownership transfer initiated to ${adminAccount[networkName]} (pending acceptance)`);

--- a/deploy/014-deploy-prime-v2.ts
+++ b/deploy/014-deploy-prime-v2.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
+import { isLocalNetwork, getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
 
 interface AdminAccounts {
   [key: string]: string;
@@ -35,6 +35,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     bscmainnet: 70_080_000,
     ethereum: 2_628_000,
     hardhat: 100,
+    localhost: 100,,
   };
 
   const xVSVaultPoolId: Config = {
@@ -50,6 +51,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     opmainnet: 0,
     unichainsepolia: 0,
     hardhat: 0,
+    localhost: 0,,
     basesepolia: 0,
     basemainnet: 0,
     unichainmainnet: 0,
@@ -112,7 +114,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     deterministicDeployment: false,
     args: constructorArgs,
     proxy: {
-      owner: network.name === "hardhat" ? deployer : adminAccount[networkName],
+      owner: isLocalNetwork(network.name) ? deployer : adminAccount[networkName],
       proxyContract: "OptimizedTransparentUpgradeableProxy",
       execute: {
         methodName: "initialize",
@@ -136,7 +138,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const primeV2 = await ethers.getContract("PrimeV2");
 
   // ============ Verify implementation ============
-  if (network.name !== "hardhat" && primeV2Deployment.implementation) {
+  if (!isLocalNetwork(network.name) && primeV2Deployment.implementation) {
     try {
       await hre.run("verify:verify", {
         address: primeV2Deployment.implementation,
@@ -151,7 +153,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // On live networks the setPrimeV2 / setPrimeLeaderboard wiring is performed via a VIP
   // (both setters are ACM-gated and called by governance). On hardhat we grant the deployer
   // permission and wire inline so local/integration runs have a usable, fully-wired pair.
-  if (network.name === "hardhat") {
+  if (isLocalNetwork(network.name)) {
     const accessControlManager = await ethers.getContract("AccessControlManager");
     await accessControlManager.giveCallPermission(primeLeaderboard.address, "setPrimeV2(address)", deployer);
     await accessControlManager.giveCallPermission(primeV2.address, "setPrimeLeaderboard(address)", deployer);
@@ -165,7 +167,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   // ============ Transfer ownership to Timelock ============
-  if (network.name !== "hardhat") {
+  if (!isLocalNetwork(network.name)) {
     console.log("Transferring PrimeV2 ownership to Timelock...");
     await primeV2.transferOwnership(adminAccount[networkName]);
     console.log(`PrimeV2 ownership transfer initiated to ${adminAccount[networkName]} (pending acceptance)`);

--- a/deploy/015-deploy-prime-v2-impl.ts
+++ b/deploy/015-deploy-prime-v2-impl.ts
@@ -2,7 +2,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
+import { isLocalNetwork, getContractAddressOrNullAddress } from "../helpers/deploymentConfig";
 
 /**
  * Deploys ONLY a new PrimeV2 implementation contract — no proxy, no wiring.
@@ -37,6 +37,7 @@ const blocksPerYear: Config = {
   bscmainnet: 70_080_000,
   ethereum: 2_628_000,
   hardhat: 100,
+  localhost: 100,,
 };
 
 const xVSVaultPoolId: Config = {
@@ -52,6 +53,7 @@ const xVSVaultPoolId: Config = {
   opmainnet: 0,
   unichainsepolia: 0,
   hardhat: 0,
+  localhost: 0,,
   basesepolia: 0,
   basemainnet: 0,
   unichainmainnet: 0,
@@ -95,7 +97,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`PrimeV2 implementation: ${implDeployment.address}`);
 
   // ============ Verify implementation ============
-  if (network.name !== "hardhat") {
+  if (!isLocalNetwork(network.name)) {
     try {
       await hre.run("verify:verify", {
         address: implDeployment.address,

--- a/deploy/015-deploy-token-redeemer.ts
+++ b/deploy/015-deploy-token-redeemer.ts
@@ -1,3 +1,4 @@
+import { isLocalNetwork } from "../helpers/deploymentConfig";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -19,6 +20,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 };
 
 func.tags = ["TokenRedeemer"];
-func.skip = async hre => hre.network.name !== "hardhat" && hre.network.name !== "bscmainnet";
+func.skip = async hre => !isLocalNetwork(hre.network.name) && hre.network.name !== "bscmainnet";
 
 export default func;

--- a/deploy/016-deploy-prime-lens.ts
+++ b/deploy/016-deploy-prime-lens.ts
@@ -1,3 +1,4 @@
+import { isLocalNetwork } from "../helpers/deploymentConfig";
 import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
@@ -32,7 +33,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`PrimeLens: ${lensDeployment.address}`);
   console.log(`  reads from PrimeV2: ${primeV2.address}`);
 
-  if (network.name !== "hardhat") {
+  if (!isLocalNetwork(network.name)) {
     try {
       await hre.run("verify:verify", {
         address: lensDeployment.address,

--- a/deploy/019-deploy-bstock-liquidator.ts
+++ b/deploy/019-deploy-bstock-liquidator.ts
@@ -1,3 +1,4 @@
+import { isLocalNetwork } from "../helpers/deploymentConfig";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -24,8 +25,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   //   - Ownable owner (OPERATIONAL admin) -> the bStock owner Safe, set directly in `initialize`.
   // On hardhat both collapse to the deployer so tests can drive them.
   const timelockAddress = (await deployments.get("NormalTimelock")).address;
-  const proxyAdmin = network.name === "hardhat" ? deployer : timelockAddress;
-  const contractOwner = network.name === "hardhat" ? deployer : BSTOCK_LIQUIDATOR_OWNER;
+  const proxyAdmin = isLocalNetwork(network.name) ? deployer : timelockAddress;
+  const contractOwner = isLocalNetwork(network.name) ? deployer : BSTOCK_LIQUIDATOR_OWNER;
 
   await catchUnknownSigner(
     deploy("BStockLiquidator", {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -257,6 +257,10 @@ const config: HardhatUserConfig = {
       live: true,
       accounts: DEPLOYER_PRIVATE_KEY ? [`0x${DEPLOYER_PRIVATE_KEY}`] : [],
     },
+    localhost: {
+      url: process.env.ARCHIVE_NODE_localhost || "http://127.0.0.1:8545",
+      chainId: 31337,
+    },
   },
   sourcify: {
     enabled: false,
@@ -348,6 +352,7 @@ const config: HardhatUserConfig = {
     paths: [
       "hardhat-deploy/solc_0.8/proxy/OptimizedTransparentUpgradeableProxy.sol",
       "hardhat-deploy/solc_0.8/openzeppelin/proxy/transparent/ProxyAdmin.sol",
+      "contracts/test/MockToken.sol",
     ],
   },
 };

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -1,5 +1,6 @@
 const knownChains = [
   "hardhat",
+  "localhost",
   "bsctestnet",
   "bscmainnet",
   "sepolia",
@@ -24,6 +25,7 @@ export type BlocksPerYear = number | "time-based";
 
 export const blocksPerYear = {
   hardhat: 100,
+  localhost: 100,
   bsctestnet: 70_080_000, // 0.45 sec per block
   bscmainnet: 70_080_000,
   sepolia: 2_628_000, // 12 sec per block

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -47,12 +47,19 @@ export const getContractAddressOrNullAddress = async (deployments: DeploymentsEx
   }
 };
 
+export const isLocalNetwork = (networkName: string): boolean =>
+  networkName === "hardhat" || networkName === "localhost";
+
 export const onlyHardhat = () => async (hre: HardhatRuntimeEnvironment) => {
-  return hre.network.name !== "hardhat";
+  return !isLocalNetwork(hre.network.name);
 };
 
 export const skipRemoteNetworks = () => async (hre: HardhatRuntimeEnvironment) => {
-  return hre.network.name !== "bscmainnet" && hre.network.name !== "bsctestnet" && hre.network.name !== "hardhat";
+  return (
+    hre.network.name !== "bscmainnet" &&
+    hre.network.name !== "bsctestnet" &&
+    !isLocalNetwork(hre.network.name)
+  );
 };
 
 export const skipSourceNetworks =

--- a/helpers/markets/index.ts
+++ b/helpers/markets/index.ts
@@ -90,6 +90,7 @@ const parseMarkets = <chain extends Chain>(
 
 export const markets = {
   hardhat: parseMarkets("hardhat", hardhatMarketsList),
+  localhost: parseMarkets("localhost", hardhatMarketsList),
   bscmainnet: parseMarkets("bscmainnet", bscmainnetMarketsList),
   bsctestnet: parseMarkets("bsctestnet", bsctestnetMarketsList),
   sepolia: [],

--- a/helpers/tokens/index.ts
+++ b/helpers/tokens/index.ts
@@ -9,6 +9,7 @@ import { TokenConfig } from "./types";
 
 export const tokens = {
   hardhat: hardhatTokens,
+  localhost: hardhatTokens,
   bsctestnet: bsctestnetTokens,
   bscmainnet: bscmainnetTokens,
   sepolia: {},


### PR DESCRIPTION
## Summary
- Add `localhost` network targeting a running Hardhat node
- Register `localhost` in chain/token helpers and local deploy skip guards
- Compile `MockToken` via dependencyCompiler for local deployments
- Document `npx hardhat deploy --network localhost` in README

## Test plan
- [ ] Start `npx hardhat node`, then run `npx hardhat deploy --network localhost`
- [ ] Confirm MockToken artifacts resolve and VBep20 deploy scripts execute
