### PR TITLE
refactor(prime-update-scores): target PrimeV2, split into index/update stages

### DIFF
--- a/scripts/prime-update-scores.ts
+++ b/scripts/prime-update-scores.ts
@@ -1,25 +1,14 @@
 /**
- * Drains PrimeV2's pendingScoreUpdates queue after addMarket / updateAlpha /
- * updateMultipliers. Two stages, so the holder list is reviewed before any tx:
+ * Drains PrimeV2's pendingScoreUpdates after addMarket / updateAlpha / updateMultipliers.
  *
- *   STAGE=index  npx hardhat run scripts/prime-update-scores.ts --network bscmainnet
- *     Replays Mint/Burn events since the PrimeV2 deploy block into the current
- *     holder set, checks the count against totalTokens(), writes HOLDERS_FILE.
+ *   STAGE=index   replay Mint/Burn into the holder set, check it against totalTokens(), write HOLDERS_FILE
+ *   STAGE=update  read HOLDERS_FILE, send updateScores in batches; skips users already done, so re-runnable
  *
- *   STAGE=update npx hardhat run scripts/prime-update-scores.ts --network bscmainnet
- *     Reads HOLDERS_FILE, skips users already done this round (isScoreUpdated),
- *     sends updateScores in batches. Re-runnable: a crashed run just resumes.
- *
- * WARNING — the holder list must match the contract at the moment STAGE=update runs.
- * The monthly Prime cycle (keeper burnBatch + issueBatch, 1st of the month ~00:00 UTC)
- * swaps holders, and a permissionless claimPrime can add one at any time. With a stale
- * list, updateScores never sees the new holders, pendingScoreUpdates never reaches 0, and
- * claimPrime/issue/burn keep reverting. Equal-count churn (13 out, 13 in) is invisible to
- * the totalTokens() check below. So: never run STAGE=update across the monthly cycle, and
- * re-run STAGE=index right before STAGE=update whenever time has passed since indexing.
- *
- * Configuration (env var, or constant below) — one line each: meaning · stage · default
+ * The list cannot go stale during a round: every mint/burn entry point reverts ScoreUpdateInProgress
+ * while pendingScoreUpdates > 0. index records the round id and update refuses any other round.
+ * Drain promptly: an open round also blocks the monthly keeper burnBatch/issueBatch.
  */
+import type { Event } from "ethers";
 import * as fs from "fs";
 import { deployments, ethers } from "hardhat";
 
@@ -28,11 +17,10 @@ const STAGE = process.env.STAGE;
 /** hardhat-deploy name the Prime address + ABI are read from (deployments/<network>/PrimeV2.json). Both stages. */
 const PRIME_DEPLOYMENT = "PrimeV2";
 /** Where the holder list is written (index) and read from (update). Default .prime-holders-<chainId>.json in cwd. */
-const HOLDERS_FILE = process.env.HOLDERS_FILE; // resolved in main() once chainId is known
-/** First block of the Mint/Burn scan. index only. Default: PrimeV2 proxy creation on bscmainnet
- *  (tx 0x41d505b974f7435664281ce32a39df8bcfee74e5a36548c2710f0deede74b0fe) — no Prime events exist before it; 0 elsewhere. */
+const HOLDERS_FILE = process.env.HOLDERS_FILE;
+/** First block of the Mint/Burn scan. index only. Default: the proxy's deployment block from the
+ *  hardhat-deploy artifact (bscmainnet 107,040,035 / bsctestnet 112,385,727) — no events exist before it. */
 const FROM_BLOCK = process.env.FROM_BLOCK ? Number(process.env.FROM_BLOCK) : undefined;
-const PRIMEV2_DEPLOY_BLOCK_BSCMAINNET = 107_040_035;
 /** Blocks per eth_getLogs call. index only. Default 5000 (safe on public RPCs; NodeReal takes 50000). */
 const BLOCK_RANGE = Number(process.env.BLOCK_RANGE ?? 5000);
 /** Users per updateScores tx. update only. Default 14: BSC caps a tx at 16,777,216 gas and one user
@@ -63,6 +51,10 @@ export function eventsToHolders(events: HolderEvent[]): string[] {
 }
 
 /** Both Prime and PrimeV2 name the event arg `user`, so this works for either ABI. */
+const toEvent =
+  (kind: HolderEvent["kind"]) =>
+  (e: Event): HolderEvent => ({ kind, user: e.args?.user, blockNumber: e.blockNumber, logIndex: e.logIndex });
+
 export async function fetchHolderEvents(
   prime: any,
   fromBlock: number,
@@ -74,11 +66,11 @@ export async function fetchHolderEvents(
   const events: HolderEvent[] = [];
   for (let from = fromBlock; from <= toBlock; from += blockRange) {
     const to = Math.min(from + blockRange - 1, toBlock);
-    for (const kind of ["Mint", "Burn"] as const) {
-      for (const e of await prime.queryFilter(prime.filters[kind](), from, to)) {
-        events.push({ kind, user: e.args.user, blockNumber: e.blockNumber, logIndex: e.logIndex });
-      }
-    }
+    const [mints, burns] = await Promise.all([
+      prime.queryFilter(prime.filters.Mint(), from, to),
+      prime.queryFilter(prime.filters.Burn(), from, to),
+    ]);
+    events.push(...mints.map(toEvent("Mint")), ...burns.map(toEvent("Burn")));
     log(`  scanned ${from}-${to}: ${events.length} events so far`);
   }
   return events;
@@ -103,7 +95,7 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
   const maxLoops = Number(await prime.maxLoopsLimit());
   log(`pendingScoreUpdates ${pendingBefore}, round ${round}, maxLoopsLimit ${maxLoops}`);
 
-  // ponytail: READ_CONCURRENCY reads in flight; fine for 500 holders, use a multicall if it ever isn't.
+  // READ_CONCURRENCY reads in flight; fine for 500 holders, use a multicall if it ever isn't.
   const done: boolean[] = [];
   for (const slice of chunk(holders, READ_CONCURRENCY))
     done.push(...(await Promise.all(slice.map(h => prime.isScoreUpdated(round, h)))));
@@ -141,15 +133,16 @@ async function main() {
   console.log(`${PRIME_DEPLOYMENT} ${dep.address} chainId ${chainId}, holders file ${file}`);
 
   if (STAGE === "index") {
-    const fromBlock = FROM_BLOCK ?? (chainId === 56 ? PRIMEV2_DEPLOY_BLOCK_BSCMAINNET : 0);
+    const fromBlock = FROM_BLOCK ?? dep.receipt?.blockNumber ?? 0;
     const toBlock = await ethers.provider.getBlockNumber();
     const events = await fetchHolderEvents(prime, fromBlock, BLOCK_RANGE, toBlock, console.log);
     const holders = eventsToHolders(events);
     const onChain = Number(await prime.totalTokens());
-    fs.writeFileSync(file, JSON.stringify({ address: dep.address, chainId, toBlock, holders }, null, 2));
-    console.log(`${events.length} events → ${holders.length} holders (on-chain totalTokens ${onChain}). Wrote ${file}`);
+    const round = Number(await prime.nextScoreUpdateRoundId());
     if (holders.length !== onChain)
-      throw new Error("indexed holder count != totalTokens — check FROM_BLOCK / RPC gaps");
+      throw new Error(`indexed ${holders.length} holders but totalTokens is ${onChain} — check FROM_BLOCK / RPC gaps`);
+    fs.writeFileSync(file, JSON.stringify({ address: dep.address, chainId, toBlock, round, holders }, null, 2));
+    console.log(`${events.length} events → ${holders.length} holders, round ${round}. Wrote ${file}`);
     return;
   }
 
@@ -157,12 +150,12 @@ async function main() {
   if (saved.address.toLowerCase() !== dep.address.toLowerCase() || saved.chainId !== chainId) {
     throw new Error(`${file} was indexed for ${saved.address} on chain ${saved.chainId}`);
   }
-  // Count-only check: catches a net change, not equal-count churn (see WARNING in the header).
-  // If the monthly cycle or any claimPrime happened since indexing, re-run STAGE=index first.
-  const onChain = Number(await prime.totalTokens());
-  console.log(`${saved.holders.length} holders indexed at block ${saved.toBlock}; on-chain totalTokens now ${onChain}`);
-  if (onChain !== saved.holders.length)
-    console.warn("WARNING: holder set changed since indexing — burned users are skipped, new mints are missing.");
+  // Same round id ⇒ same holder set (see header). A mid-round re-queue also bumps it; that just costs a re-index.
+  const round = Number(await prime.nextScoreUpdateRoundId());
+  if (saved.round !== round) {
+    throw new Error(`${file} was indexed during round ${saved.round}; current round is ${round} — re-run STAGE=index`);
+  }
+  console.log(`${saved.holders.length} holders indexed at block ${saved.toBlock}, round ${round}`);
   await runUpdate(prime, saved.holders, { dryRun: DRY_RUN, batchSize: BATCH_SIZE });
 }
 

--- a/scripts/prime-update-scores.ts
+++ b/scripts/prime-update-scores.ts
@@ -10,11 +10,32 @@
  *     Reads HOLDERS_FILE, skips users already done this round (isScoreUpdated),
  *     sends updateScores in batches. Re-runnable: a crashed run just resumes.
  *
- * Env: HOLDERS_FILE (default .prime-holders-<chainId>.json), FROM_BLOCK,
- *      BLOCK_RANGE (default 5000), BATCH_SIZE (default 14), DRY_RUN=1.
+ * Configuration (env var, or constant below) — one line each: meaning · stage · default
  */
 import * as fs from "fs";
 import { deployments, ethers } from "hardhat";
+
+/** Which stage to run: "index" (build holder list, no txs) or "update" (send updateScores). Required. */
+const STAGE = process.env.STAGE;
+/** hardhat-deploy name the Prime address + ABI are read from (deployments/<network>/PrimeV2.json). Both stages. */
+const PRIME_DEPLOYMENT = "PrimeV2";
+/** Where the holder list is written (index) and read from (update). Default .prime-holders-<chainId>.json in cwd. */
+const HOLDERS_FILE = process.env.HOLDERS_FILE; // resolved in main() once chainId is known
+/** First block of the Mint/Burn scan. index only. Default: PrimeV2 proxy creation on bscmainnet
+ *  (tx 0x41d505b974f7435664281ce32a39df8bcfee74e5a36548c2710f0deede74b0fe) — no Prime events exist before it; 0 elsewhere. */
+const FROM_BLOCK = process.env.FROM_BLOCK ? Number(process.env.FROM_BLOCK) : undefined;
+const PRIMEV2_DEPLOY_BLOCK_BSCMAINNET = 107_040_035;
+/** Blocks per eth_getLogs call. index only. Default 5000 (safe on public RPCs; NodeReal takes 50000). */
+const BLOCK_RANGE = Number(process.env.BLOCK_RANGE ?? 5000);
+/** Users per updateScores tx. update only. Default 14: BSC caps a tx at 16,777,216 gas and one user
+ *  costs ~0.93M, so 14 ≈ 13M. Must not exceed the contract's maxLoopsLimit (20). */
+const BATCH_SIZE = Number(process.env.BATCH_SIZE ?? 14);
+/** Gas limit sent with each updateScores tx (estimateGas is skipped). update only. */
+const TX_GAS_LIMIT = 15_000_000;
+/** isScoreUpdated reads kept in flight at once while filtering the holder list. update only. */
+const READ_CONCURRENCY = 20;
+/** "1" = do everything in the update stage except send the txs. Default off. index never sends. */
+const DRY_RUN = process.env.DRY_RUN === "1";
 
 export type HolderEvent = { kind: "Mint" | "Burn"; user: string; blockNumber: number; logIndex: number };
 
@@ -74,9 +95,9 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
   const maxLoops = Number(await prime.maxLoopsLimit());
   log(`pendingScoreUpdates ${pendingBefore}, round ${round}, maxLoopsLimit ${maxLoops}`);
 
-  // ponytail: 20 reads in flight at a time; fine for 500 holders, use a multicall if it ever isn't.
+  // ponytail: READ_CONCURRENCY reads in flight; fine for 500 holders, use a multicall if it ever isn't.
   const done: boolean[] = [];
-  for (const slice of chunk(holders, 20))
+  for (const slice of chunk(holders, READ_CONCURRENCY))
     done.push(...(await Promise.all(slice.map(h => prime.isScoreUpdated(round, h)))));
   const remaining = holders.filter((_, i) => !done[i]);
   log(`Pending this round: ${remaining.length}`);
@@ -93,8 +114,7 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
   for (const [i, batch] of batches.entries()) {
     log(`  [${i + 1}/${batches.length}] updateScores(${batch.length})`);
     if (opts.dryRun) continue;
-    // BSC caps a tx at 16,777,216 gas; ~0.93M per user, so 14 users ≈ 13M. Skip estimateGas.
-    const rcpt = await (await prime.updateScores(batch, { gasLimit: 15_000_000 })).wait();
+    const rcpt = await (await prime.updateScores(batch, { gasLimit: TX_GAS_LIMIT })).wait();
     log(`    ${rcpt.transactionHash} gasUsed=${rcpt.gasUsed}`);
   }
 
@@ -103,29 +123,19 @@ export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOp
   return { pendingBefore, pendingAfter, batchesSent: batches.length, usersUpdated: remaining.length };
 }
 
-// PrimeV2 proxy creation on bscmainnet, tx 0x41d505b974f7435664281ce32a39df8bcfee74e5a36548c2710f0deede74b0fe
-const PRIMEV2_DEPLOY_BLOCK_BSCMAINNET = 107_040_035;
-
 async function main() {
-  const stage = process.env.STAGE;
-  if (stage !== "index" && stage !== "update") throw new Error('STAGE must be "index" or "update"');
+  if (STAGE !== "index" && STAGE !== "update") throw new Error('STAGE must be "index" or "update"');
 
-  const dep = await deployments.get("PrimeV2");
+  const dep = await deployments.get(PRIME_DEPLOYMENT);
   const prime = await ethers.getContractAt(dep.abi, dep.address);
   const chainId = (await ethers.provider.getNetwork()).chainId;
-  const file = process.env.HOLDERS_FILE ?? `.prime-holders-${chainId}.json`;
-  console.log(`PrimeV2 ${dep.address} chainId ${chainId}, holders file ${file}`);
+  const file = HOLDERS_FILE ?? `.prime-holders-${chainId}.json`;
+  console.log(`${PRIME_DEPLOYMENT} ${dep.address} chainId ${chainId}, holders file ${file}`);
 
-  if (stage === "index") {
-    const fromBlock = Number(process.env.FROM_BLOCK ?? (chainId === 56 ? PRIMEV2_DEPLOY_BLOCK_BSCMAINNET : 0));
+  if (STAGE === "index") {
+    const fromBlock = FROM_BLOCK ?? (chainId === 56 ? PRIMEV2_DEPLOY_BLOCK_BSCMAINNET : 0);
     const toBlock = await ethers.provider.getBlockNumber();
-    const events = await fetchHolderEvents(
-      prime,
-      fromBlock,
-      Number(process.env.BLOCK_RANGE ?? 5000),
-      toBlock,
-      console.log,
-    );
+    const events = await fetchHolderEvents(prime, fromBlock, BLOCK_RANGE, toBlock, console.log);
     const holders = eventsToHolders(events);
     const onChain = Number(await prime.totalTokens());
     fs.writeFileSync(file, JSON.stringify({ address: dep.address, chainId, toBlock, holders }, null, 2));
@@ -143,10 +153,7 @@ async function main() {
   console.log(`${saved.holders.length} holders indexed at block ${saved.toBlock}; on-chain totalTokens now ${onChain}`);
   if (onChain !== saved.holders.length)
     console.warn("WARNING: holder set changed since indexing — burned users are skipped, new mints are missing.");
-  await runUpdate(prime, saved.holders, {
-    dryRun: process.env.DRY_RUN === "1",
-    batchSize: Number(process.env.BATCH_SIZE ?? 14),
-  });
+  await runUpdate(prime, saved.holders, { dryRun: DRY_RUN, batchSize: BATCH_SIZE });
 }
 
 if (require.main === module) {

--- a/scripts/prime-update-scores.ts
+++ b/scripts/prime-update-scores.ts
@@ -10,6 +10,14 @@
  *     Reads HOLDERS_FILE, skips users already done this round (isScoreUpdated),
  *     sends updateScores in batches. Re-runnable: a crashed run just resumes.
  *
+ * WARNING — the holder list must match the contract at the moment STAGE=update runs.
+ * The monthly Prime cycle (keeper burnBatch + issueBatch, 1st of the month ~00:00 UTC)
+ * swaps holders, and a permissionless claimPrime can add one at any time. With a stale
+ * list, updateScores never sees the new holders, pendingScoreUpdates never reaches 0, and
+ * claimPrime/issue/burn keep reverting. Equal-count churn (13 out, 13 in) is invisible to
+ * the totalTokens() check below. So: never run STAGE=update across the monthly cycle, and
+ * re-run STAGE=index right before STAGE=update whenever time has passed since indexing.
+ *
  * Configuration (env var, or constant below) — one line each: meaning · stage · default
  */
 import * as fs from "fs";
@@ -149,6 +157,8 @@ async function main() {
   if (saved.address.toLowerCase() !== dep.address.toLowerCase() || saved.chainId !== chainId) {
     throw new Error(`${file} was indexed for ${saved.address} on chain ${saved.chainId}`);
   }
+  // Count-only check: catches a net change, not equal-count churn (see WARNING in the header).
+  // If the monthly cycle or any claimPrime happened since indexing, re-run STAGE=index first.
   const onChain = Number(await prime.totalTokens());
   console.log(`${saved.holders.length} holders indexed at block ${saved.toBlock}; on-chain totalTokens now ${onChain}`);
   if (onChain !== saved.holders.length)

--- a/scripts/prime-update-scores.ts
+++ b/scripts/prime-update-scores.ts
@@ -1,42 +1,23 @@
 /**
- * Drains the Prime pendingScoreUpdates queue after a parameter change.
+ * Drains PrimeV2's pendingScoreUpdates queue after addMarket / updateAlpha /
+ * updateMultipliers. Two stages, so the holder list is reviewed before any tx:
  *
- * Triggers (functions that queue a fresh round of score updates by calling
- * `_startScoreUpdateRound()` internally):
- *   - addMarket
- *   - updateAlpha
- *   - updateMultipliers
+ *   STAGE=index  npx hardhat run scripts/prime-update-scores.ts --network bscmainnet
+ *     Replays Mint/Burn events since the PrimeV2 deploy block into the current
+ *     holder set, checks the count against totalTokens(), writes HOLDERS_FILE.
  *
- * Prime exposes no on-chain holder enumeration, so this script reconstructs
- * the current holder set from `Mint` and `Burn` events, then calls
- * `updateScores` in batches sized to `maxLoopsLimit()` until the queue drains.
+ *   STAGE=update npx hardhat run scripts/prime-update-scores.ts --network bscmainnet
+ *     Reads HOLDERS_FILE, skips users already done this round (isScoreUpdated),
+ *     sends updateScores in batches. Re-runnable: a crashed run just resumes.
  *
- * Resumes correctly across runs: per-user, per-round dedup via
- * `isScoreUpdated[roundId][user]` is read on-chain.
- *
- * Usage:
- *   npx hardhat run scripts/prime-update-scores.ts --network <network>
- *
- * Optional env vars:
- *   FROM_BLOCK         First block to scan for Mint/Burn
- *                      (default: BSC mainnet Prime deploy block, 33_264_762)
- *   BLOCK_RANGE        Max blocks per getLogs call (default: 5000)
- *   DRY_RUN            "1" to skip sending txs
+ * Env: HOLDERS_FILE (default .prime-holders-<chainId>.json), FROM_BLOCK,
+ *      BLOCK_RANGE (default 5000), BATCH_SIZE (default 14), DRY_RUN=1.
  */
 import * as fs from "fs";
 import { deployments, ethers } from "hardhat";
-import * as path from "path";
 
-export type HolderEvent = {
-  kind: "Mint" | "Burn";
-  user: string;
-  blockNumber: number;
-  logIndex: number;
-};
+export type HolderEvent = { kind: "Mint" | "Burn"; user: string; blockNumber: number; logIndex: number };
 
-/**
- * Pure function: split an array into chunks of at most `size` items.
- */
 export function chunk<T>(arr: T[], size: number): T[][] {
   if (size <= 0) throw new Error("chunk size must be > 0");
   const out: T[][] = [];
@@ -44,34 +25,15 @@ export function chunk<T>(arr: T[], size: number): T[][] {
   return out;
 }
 
-/**
- * Pure function: replay Mint/Burn events to compute the set of current holders.
- * Events must be applied in (blockNumber, logIndex) order. Mints set the
- * user as a holder; Burns unset. The final holder set is every address whose
- * last state was holder=true.
- */
+/** Replay Mint/Burn in (block, logIndex) order; a user's last event decides. */
 export function eventsToHolders(events: HolderEvent[]): string[] {
-  const ordered = [...events].sort((a, b) => {
-    if (a.blockNumber !== b.blockNumber) return a.blockNumber - b.blockNumber;
-    return a.logIndex - b.logIndex;
-  });
-
-  const holders = new Map<string, boolean>();
-  for (const ev of ordered) {
-    holders.set(ev.user, ev.kind === "Mint");
-  }
-
-  const current: string[] = [];
-  for (const [addr, isHolder] of holders) {
-    if (isHolder) current.push(addr);
-  }
-  return current;
+  const ordered = [...events].sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex);
+  const state = new Map<string, boolean>();
+  for (const e of ordered) state.set(e.user, e.kind === "Mint");
+  return [...state].filter(([, held]) => held).map(([user]) => user);
 }
 
-/**
- * Fetch all Mint and Burn events from a Prime contract, paginated.
- * Uses `prime.filters.Mint()` / `prime.filters.Burn()` and `queryFilter`.
- */
+/** Both Prime and PrimeV2 name the event arg `user`, so this works for either ABI. */
 export async function fetchHolderEvents(
   prime: any,
   fromBlock: number,
@@ -79,39 +41,21 @@ export async function fetchHolderEvents(
   latest?: number,
   log: (msg: string) => void = () => undefined,
 ): Promise<HolderEvent[]> {
-  const toLatest = latest ?? (await prime.provider.getBlockNumber());
-  const mintFilter = prime.filters.Mint();
-  const burnFilter = prime.filters.Burn();
-
+  const toBlock = latest ?? (await prime.provider.getBlockNumber());
   const events: HolderEvent[] = [];
-
-  for (let from = fromBlock; from <= toLatest; from += blockRange) {
-    const to = Math.min(from + blockRange - 1, toLatest);
-    const [mints, burns] = await Promise.all([
-      prime.queryFilter(mintFilter, from, to),
-      prime.queryFilter(burnFilter, from, to),
-    ]);
-
-    // Mint(address indexed user, bool isIrrevocable): we only need `user`.
-    for (const m of mints) {
-      events.push({ kind: "Mint", user: m.args!.user, blockNumber: m.blockNumber, logIndex: m.logIndex });
+  for (let from = fromBlock; from <= toBlock; from += blockRange) {
+    const to = Math.min(from + blockRange - 1, toBlock);
+    for (const kind of ["Mint", "Burn"] as const) {
+      for (const e of await prime.queryFilter(prime.filters[kind](), from, to)) {
+        events.push({ kind, user: e.args.user, blockNumber: e.blockNumber, logIndex: e.logIndex });
+      }
     }
-    // Burn(address indexed user)
-    for (const b of burns) {
-      events.push({ kind: "Burn", user: b.args!.user, blockNumber: b.blockNumber, logIndex: b.logIndex });
-    }
-
-    log(`  scanned blocks ${from}-${to}: +${mints.length} mints, -${burns.length} burns`);
+    log(`  scanned ${from}-${to}: ${events.length} events so far`);
   }
-
   return events;
 }
 
-export type RunUpdateOptions = {
-  dryRun?: boolean;
-  log?: (msg: string) => void;
-};
-
+export type RunUpdateOptions = { dryRun?: boolean; batchSize?: number; log?: (msg: string) => void };
 export type RunUpdateResult = {
   pendingBefore: bigint;
   pendingAfter: bigint;
@@ -119,154 +63,92 @@ export type RunUpdateResult = {
   usersUpdated: number;
 };
 
-/**
- * Drains pendingScoreUpdates for the given holders.
- * Filters out users already processed in the current round via isScoreUpdated.
- * Batches by maxLoopsLimit() and calls updateScores() per batch.
- */
 export async function runUpdate(prime: any, holders: string[], opts: RunUpdateOptions = {}): Promise<RunUpdateResult> {
-  const dryRun = opts.dryRun ?? false;
-  const log = opts.log ?? ((msg: string) => console.log(msg));
-
+  const log = opts.log ?? console.log;
   const pendingBefore: bigint = (await prime.pendingScoreUpdates()).toBigInt();
   if (pendingBefore === 0n) {
     log("pendingScoreUpdates = 0 — nothing to do");
-    return { pendingBefore: 0n, pendingAfter: 0n, batchesSent: 0, usersUpdated: 0 };
+    return { pendingBefore, pendingAfter: 0n, batchesSent: 0, usersUpdated: 0 };
   }
-  log(`pendingScoreUpdates: ${pendingBefore}`);
+  const round = await prime.nextScoreUpdateRoundId();
+  const maxLoops = Number(await prime.maxLoopsLimit());
+  log(`pendingScoreUpdates ${pendingBefore}, round ${round}, maxLoopsLimit ${maxLoops}`);
 
-  const roundId: bigint = (await prime.nextScoreUpdateRoundId()).toBigInt();
-  const maxLoops: bigint = (await prime.maxLoopsLimit()).toBigInt();
-  log(`round ${roundId}, maxLoopsLimit ${maxLoops}`);
-
-  // Parallelize isScoreUpdated reads in batches to avoid serial RPC latency
-  // when there are many holders. RPC providers tolerate ~20 in-flight reads
-  // comfortably without rate-limiting. Retry transient transport errors
-  // (ECONNRESET / TLS disconnect) up to 5 times with exponential backoff.
-  const ISSCOREUPDATED_BATCH = 20;
-  const retryRead = async (h: string): Promise<boolean> => {
-    let lastErr: any;
-    for (let attempt = 0; attempt < 5; attempt++) {
-      try {
-        return await prime.isScoreUpdated(roundId, h);
-      } catch (e: any) {
-        lastErr = e;
-        const msg = String(e?.message ?? e);
-        const transient = /ECONNRESET|socket disconnect|ETIMEDOUT|EAI_AGAIN|network|timeout|fetch failed/i.test(msg);
-        if (!transient) throw e;
-        await new Promise(r => setTimeout(r, 250 * 2 ** attempt));
-      }
-    }
-    throw lastErr;
-  };
-  const remaining: string[] = [];
-  for (let i = 0; i < holders.length; i += ISSCOREUPDATED_BATCH) {
-    const slice = holders.slice(i, i + ISSCOREUPDATED_BATCH);
-    const flags: boolean[] = await Promise.all(slice.map(retryRead));
-    for (let j = 0; j < slice.length; j++) {
-      if (!flags[j]) remaining.push(slice[j]);
-    }
-  }
+  // ponytail: 20 reads in flight at a time; fine for 500 holders, use a multicall if it ever isn't.
+  const done: boolean[] = [];
+  for (const slice of chunk(holders, 20))
+    done.push(...(await Promise.all(slice.map(h => prime.isScoreUpdated(round, h)))));
+  const remaining = holders.filter((_, i) => !done[i]);
   log(`Pending this round: ${remaining.length}`);
-
   if (remaining.length === 0) {
     log(
-      "All current holders already updated for this round. Pending counter may include burned users — verify off-chain.",
+      "Every listed holder is already updated. If pendingScoreUpdates > 0 the list is missing someone — re-run STAGE=index.",
     );
     return { pendingBefore, pendingAfter: pendingBefore, batchesSent: 0, usersUpdated: 0 };
   }
 
-  // BSC RPC nodes cap per-tx gas at ~16.7M (2^24). The contract's maxLoopsLimit
-  // (20) implies ~20M gas per batch — over the cap. Allow operator override.
-  const batchSize = process.env.BATCH_SIZE ? Number(process.env.BATCH_SIZE) : Number(maxLoops);
+  const batchSize = opts.batchSize ?? maxLoops;
+  if (batchSize > maxLoops) throw new Error(`BATCH_SIZE ${batchSize} > maxLoopsLimit ${maxLoops}`);
   const batches = chunk(remaining, batchSize);
-  log(`Sending ${batches.length} batch(es) of up to ${batchSize} users`);
-
-  let usersUpdated = 0;
-  for (let i = 0; i < batches.length; i++) {
-    const batch = batches[i];
-    log(`  [${i + 1}/${batches.length}] updateScores(${batch.length} users)`);
-    if (dryRun) {
-      usersUpdated += batch.length;
-      continue;
-    }
-
-    // Bypass eth_estimateGas. BSC RPC nodes cap per-tx gas at 16,777,216 (2^24),
-    // so we must stay under that. 14 users * ~0.93M/user ≈ 13M; 15M leaves margin.
-    let rcpt: any;
-    let lastErr: any;
-    for (let attempt = 0; attempt < 5; attempt++) {
-      try {
-        // If a previous attempt broadcast a tx whose receipt fetch failed,
-        // wait for that specific hash before resending (avoids nonce conflict).
-        if (lastErr?.transactionHash) {
-          rcpt = await prime.provider.waitForTransaction(lastErr.transactionHash, 1, 60_000);
-        } else {
-          const tx = await prime.updateScores(batch, { gasLimit: 15_000_000 });
-          rcpt = await tx.wait();
-        }
-        break;
-      } catch (e: any) {
-        lastErr = e;
-        const msg = String(e?.message ?? e);
-        const transient =
-          /ECONNRESET|socket disconnect|ETIMEDOUT|EAI_AGAIN|network|timeout|fetch failed|server response/i.test(msg);
-        if (!transient || attempt === 4) throw e;
-        log(`    transient error (attempt ${attempt + 1}/5): ${msg.slice(0, 100)}`);
-        await new Promise(r => setTimeout(r, 500 * 2 ** attempt));
-      }
-    }
-    log(`    tx ${rcpt.transactionHash} gasUsed=${rcpt.gasUsed.toString()}`);
-    usersUpdated += batch.length;
+  for (const [i, batch] of batches.entries()) {
+    log(`  [${i + 1}/${batches.length}] updateScores(${batch.length})`);
+    if (opts.dryRun) continue;
+    // BSC caps a tx at 16,777,216 gas; ~0.93M per user, so 14 users ≈ 13M. Skip estimateGas.
+    const rcpt = await (await prime.updateScores(batch, { gasLimit: 15_000_000 })).wait();
+    log(`    ${rcpt.transactionHash} gasUsed=${rcpt.gasUsed}`);
   }
 
   const pendingAfter: bigint = (await prime.pendingScoreUpdates()).toBigInt();
   log(`pendingScoreUpdates after: ${pendingAfter}`);
-
-  return { pendingBefore, pendingAfter, batchesSent: batches.length, usersUpdated };
+  return { pendingBefore, pendingAfter, batchesSent: batches.length, usersUpdated: remaining.length };
 }
 
-// BSC mainnet Prime deployment block (proxy creation tx
-// 0xfd09cf4011f863f65f1dc6a37cb325468f0ce6311849f77205e891bd36107433).
-// Used as the default lower bound for the Mint/Burn event scan so an
-// operator on bscmainnet doesn't have to look it up manually.
-const PRIME_BSCMAINNET_DEPLOY_BLOCK = 33_264_762;
+// PrimeV2 proxy creation on bscmainnet, tx 0x41d505b974f7435664281ce32a39df8bcfee74e5a36548c2710f0deede74b0fe
+const PRIMEV2_DEPLOY_BLOCK_BSCMAINNET = 107_040_035;
 
 async function main() {
-  const fromBlock = Number(process.env.FROM_BLOCK ?? PRIME_BSCMAINNET_DEPLOY_BLOCK);
-  const blockRange = Number(process.env.BLOCK_RANGE ?? 5000);
-  const dryRun = process.env.DRY_RUN === "1";
+  const stage = process.env.STAGE;
+  if (stage !== "index" && stage !== "update") throw new Error('STAGE must be "index" or "update"');
 
-  const dep = await deployments.get("Prime");
-  console.log(`Prime: ${dep.address}`);
-
-  const prime = await ethers.getContractAt("Prime", dep.address);
-
-  // Holder list is expensive to reconstruct (full event-log scan from Prime
-  // deploy block). Cache it on disk so reruns after a crash / partial drain
-  // can skip the scan. Set HOLDERS_FILE=- to force a fresh scan.
+  const dep = await deployments.get("PrimeV2");
+  const prime = await ethers.getContractAt(dep.abi, dep.address);
   const chainId = (await ethers.provider.getNetwork()).chainId;
-  const cachePath = process.env.HOLDERS_FILE ?? path.join(__dirname, `..`, `.prime-holders-${chainId}.json`);
+  const file = process.env.HOLDERS_FILE ?? `.prime-holders-${chainId}.json`;
+  console.log(`PrimeV2 ${dep.address} chainId ${chainId}, holders file ${file}`);
 
-  let holders: string[];
-  if (cachePath !== "-" && fs.existsSync(cachePath)) {
-    holders = JSON.parse(fs.readFileSync(cachePath, "utf8"));
-    console.log(`Loaded ${holders.length} holders from cache: ${cachePath}`);
-  } else {
-    console.log("Reconstructing holder set from Mint/Burn events...");
-    const events = await fetchHolderEvents(prime, fromBlock, blockRange, undefined, m => console.log(m));
-    holders = eventsToHolders(events);
-    console.log(`Total current holders: ${holders.length}`);
-    if (cachePath !== "-") {
-      fs.writeFileSync(cachePath, JSON.stringify(holders, null, 2));
-      console.log(`Wrote holder cache: ${cachePath}`);
-    }
+  if (stage === "index") {
+    const fromBlock = Number(process.env.FROM_BLOCK ?? (chainId === 56 ? PRIMEV2_DEPLOY_BLOCK_BSCMAINNET : 0));
+    const toBlock = await ethers.provider.getBlockNumber();
+    const events = await fetchHolderEvents(
+      prime,
+      fromBlock,
+      Number(process.env.BLOCK_RANGE ?? 5000),
+      toBlock,
+      console.log,
+    );
+    const holders = eventsToHolders(events);
+    const onChain = Number(await prime.totalTokens());
+    fs.writeFileSync(file, JSON.stringify({ address: dep.address, chainId, toBlock, holders }, null, 2));
+    console.log(`${events.length} events → ${holders.length} holders (on-chain totalTokens ${onChain}). Wrote ${file}`);
+    if (holders.length !== onChain)
+      throw new Error("indexed holder count != totalTokens — check FROM_BLOCK / RPC gaps");
+    return;
   }
 
-  await runUpdate(prime, holders, { dryRun, log: m => console.log(m) });
+  const saved = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (saved.address.toLowerCase() !== dep.address.toLowerCase() || saved.chainId !== chainId) {
+    throw new Error(`${file} was indexed for ${saved.address} on chain ${saved.chainId}`);
+  }
+  const onChain = Number(await prime.totalTokens());
+  console.log(`${saved.holders.length} holders indexed at block ${saved.toBlock}; on-chain totalTokens now ${onChain}`);
+  if (onChain !== saved.holders.length)
+    console.warn("WARNING: holder set changed since indexing — burned users are skipped, new mints are missing.");
+  await runUpdate(prime, saved.holders, {
+    dryRun: process.env.DRY_RUN === "1",
+    batchSize: Number(process.env.BATCH_SIZE ?? 14),
+  });
 }
 
-// Only execute when invoked directly via `hardhat run`, not when imported by tests.
 if (require.main === module) {
   main().catch(err => {
     console.error(err);


### PR DESCRIPTION
## Why

The next Prime allocation VIP (vips PR #763) calls `PrimeV2.addMarket(vU, 0, 2e18)`. On PrimeV2 that sets `pendingScoreUpdates = totalTokens` (currently 500) and, until the round is drained with `updateScores`, `claimPrime/claimPrimeBatch/issue/issueBatch/burn/burnBatch` revert with `ScoreUpdateInProgress`, no holder has a vU score (U rewards land in `undistributedReward`), and the monthly cycle cannot run. VIP-637's two `addMarket` calls ran at 0 holders, so this is the first real round on PrimeV2.

`scripts/prime-update-scores.ts` is the only tool for this, but it targets the legacy `Prime` deployment (name, ABI, deploy block 33,264,762) and does scan + send in one go.

## What

- Target `PrimeV2`; scan Mint/Burn from the proxy deploy block in the hardhat-deploy artifact (bscmainnet 107,040,035 / bsctestnet 112,385,727). Uses the deployment ABI, so the `Mint(address)` vs legacy `Mint(address,bool)` difference doesn't matter — both name the arg `user`.
- Two explicit stages, so the holder list is reviewed before any transaction:
  - `STAGE=index` — replay events into the current holder set, check it equals `totalTokens()`, write `HOLDERS_FILE` with the current `nextScoreUpdateRoundId`, stop. Mismatch is an error.
  - `STAGE=update` — refuses to run without `HOLDERS_FILE` or if the round id differs from the file's; skips users already done this round via `isScoreUpdated`; sends in batches of `BATCH_SIZE` (default 14, BSC's 16.78M gas cap ÷ ~0.93M per user).
- The list cannot go stale during a round: every mint/burn entry point (`claimPrime`, `claimPrimeBatch`, `issue`, `issueBatch`, `burn`, `burnBatch`) reverts `ScoreUpdateInProgress` while `pendingScoreUpdates > 0`. The only stale window is index → round open, and the round-id check closes it.
- Dropped the two retry loops: the run is idempotent through `isScoreUpdated`, so a failed run is simply re-run. 203 lines → 85.

## Verified

- `yarn lint` clean; `hardhat test tests/hardhat/Scripts/*` — 46 passing (unit + e2e, unchanged).
- `STAGE=index` on bscmainnet: 754 events → 500 holders == `totalTokens()`, all 500 `isPrimeHolder == true`, the 13 minted / 13 burned in the Sep 1 cycle are in / out. Matches an independently produced list address-for-address. Re-run 2026-09-04 after the review fixes: same 500, round 2; `BLOCK_RANGE=50000` on NodeReal takes ~50 s.
- `STAGE=update DRY_RUN=1` on bscmainnet: reads the file, reports `pendingScoreUpdates = 0 — nothing to do` (no round open yet).

## Runbook after the VIP executes

```
export ARCHIVE_NODE_bscmainnet=… DEPLOYER_PRIVATE_KEY=…
STAGE=index  npx hardhat run scripts/prime-update-scores.ts --network bscmainnet   # after the VIP executes (round open)
STAGE=update npx hardhat run scripts/prime-update-scores.ts --network bscmainnet   # ~36 txs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
