### PR TITLE
[VPD-1982]: support PrimeV2 markets with underlyings above 18 decimals

### DIFF
--- a/contracts/Comptroller/Diamond/facets/MarketFacet.sol
+++ b/contracts/Comptroller/Diamond/facets/MarketFacet.sol
@@ -202,6 +202,22 @@ contract MarketFacet is IMarketFacet, FacetBase {
     }
 
     /**
+     * @notice Add an asset to be included in an account's liquidity calculation, on that account's behalf
+     * @dev Entering a market makes the account's balance in it count as collateral, which also makes it
+     *  seizable in a liquidation
+     * @param account The address of the account entering the market
+     * @param vToken The address of the vToken market to enable for the account
+     * @return uint256 0=success, otherwise a failure (See enum Error for details)
+     * @custom:access Controlled by ACM
+     */
+    function enterMarketForAccount(address account, address vToken) external returns (uint256) {
+        ensureAllowed("enterMarketForAccount(address,address)");
+        ensureNonzeroAddress(account);
+
+        return uint256(addToMarketInternal(VToken(vToken), account));
+    }
+
+    /**
      * @notice Unlists the given vToken market from the Core Pool (`poolId = 0`) by setting `isListed` to false
      * @dev Checks if market actions are paused and borrowCap/supplyCap/CF are set to 0
      * @param market The address of the market (vToken) to unlist

--- a/contracts/Comptroller/Diamond/interfaces/IMarketFacet.sol
+++ b/contracts/Comptroller/Diamond/interfaces/IMarketFacet.sol
@@ -30,6 +30,8 @@ interface IMarketFacet {
 
     function enterMarketBehalf(address onBehalf, address vToken) external returns (uint256);
 
+    function enterMarketForAccount(address account, address vToken) external returns (uint256);
+
     function enterMarkets(address[] calldata vTokens) external returns (uint256[] memory);
 
     function exitMarket(address vToken) external returns (uint256);

--- a/contracts/Tokens/Prime/PrimeLens.sol
+++ b/contracts/Tokens/Prime/PrimeLens.sol
@@ -146,7 +146,10 @@ contract PrimeLens {
         aprInfo.borrowCapUSD = capital.borrowCapUSD;
 
         uint256 decimals = IERC20MetadataUpgradeable(_getUnderlying(market)).decimals();
-        uint256 scaledCapital = aprInfo.capital * (10 ** (18 - decimals));
+        // Normalize capital to 18 decimals. Underlyings with more than 18 decimals scale down.
+        uint256 scaledCapital = decimals <= 18
+            ? aprInfo.capital * (10 ** (18 - decimals))
+            : aprInfo.capital / (10 ** (decimals - 18));
 
         aprInfo.userScore = Scores._calculateScore(
             xvsStaked,

--- a/contracts/Tokens/Prime/PrimeV2.sol
+++ b/contracts/Tokens/Prime/PrimeV2.sol
@@ -167,7 +167,7 @@ contract PrimeV2 is
     /// @notice Error thrown when caller is not the PrimeLeaderboard contract
     error OnlyPrimeLeaderboard();
 
-    /// @notice Error thrown when underlying token decimals exceed 18
+    /// @notice Error thrown when underlying token decimals exceed 24
     error UnsupportedUnderlyingDecimals(uint256 decimals);
 
     /**
@@ -704,7 +704,7 @@ contract PrimeV2 is
      * @custom:error Throw InvalidVToken if market is not listed
      * @custom:error Throw AssetAlreadyExists if asset already has a market
      * @custom:error Throw MaxLoopsLimitExceeded if listing this market would exceed loopsLimit
-     * @custom:error Throw UnsupportedUnderlyingDecimals if underlying token has decimals > 18
+     * @custom:error Throw UnsupportedUnderlyingDecimals if underlying token has decimals > 24
      * @custom:access Controlled by ACM
      */
     function addMarket(address market, uint256 supplyMultiplier, uint256 borrowMultiplier) external {
@@ -720,7 +720,7 @@ contract PrimeV2 is
         if (vTokenForAsset[underlying] != address(0)) revert AssetAlreadyExists();
 
         uint256 underlyingDecimals = IERC20MetadataUpgradeable(underlying).decimals();
-        if (underlyingDecimals > 18) revert UnsupportedUnderlyingDecimals(underlyingDecimals);
+        if (underlyingDecimals > 24) revert UnsupportedUnderlyingDecimals(underlyingDecimals);
 
         markets[market] = Market({
             supplyMultiplier: supplyMultiplier,
@@ -1275,7 +1275,8 @@ contract PrimeV2 is
         (uint256 capital, , ) = _capitalForScore(xvsBalanceForScore, borrow, supply, market);
 
         uint256 decimals = IERC20MetadataUpgradeable(_getUnderlying(market)).decimals();
-        capital = capital * (10 ** (18 - decimals));
+        // Normalize capital to 18 decimals. Underlyings with more than 18 decimals scale down.
+        capital = decimals <= 18 ? capital * (10 ** (18 - decimals)) : capital / (10 ** (decimals - 18));
 
         return Scores._calculateScore(xvsBalanceForScore, capital, alphaNumerator, alphaDenominator);
     }

--- a/tests/hardhat/Comptroller/Diamond/comptrollerTest.ts
+++ b/tests/hardhat/Comptroller/Diamond/comptrollerTest.ts
@@ -794,6 +794,88 @@ describe("Comptroller", () => {
     });
   });
 
+  describe("enterMarketForAccount", async () => {
+    let comptroller: ComptrollerMock;
+    let vToken: FakeContract<VToken>;
+    let accessControl: FakeContract<IAccessControlManagerV5>;
+
+    type Contracts = SimpleComptrollerFixture & { vToken: FakeContract<VToken> };
+
+    async function deploy(): Promise<Contracts> {
+      const contracts = await deploySimpleComptroller();
+      const vToken = await smock.fake<VToken>("VToken");
+      await contracts.comptroller._supportMarket(vToken.address);
+      await configureVToken(vToken, contracts.comptroller);
+      return { ...contracts, vToken };
+    }
+
+    beforeEach(async () => {
+      ({ comptroller, vToken, accessControl } = await loadFixture(deploy));
+
+      // loadFixture restores chain state but not smock's JS-side call config, so a
+      // whenCalledWith override set in one test would otherwise leak into the next.
+      accessControl.isAllowedToCall.reset();
+      accessControl.isAllowedToCall.returns(true);
+    });
+
+    it("should enter the market for another account without any delegate approval", async () => {
+      const account = accounts[1].address;
+
+      const result = await comptroller.callStatic.enterMarketForAccount(account, vToken.address);
+      expect(result).to.equal(0); // NO_ERROR
+
+      await expect(comptroller.enterMarketForAccount(account, vToken.address))
+        .to.emit(comptroller, "MarketEntered")
+        .withArgs(vToken.address, account);
+
+      expect(await comptroller.checkMembership(account, vToken.address)).to.be.true;
+    });
+
+    it("should revert when the caller lacks the ACM permission", async () => {
+      accessControl.isAllowedToCall
+        .whenCalledWith(root.address, "enterMarketForAccount(address,address)")
+        .returns(false);
+
+      await expect(comptroller.enterMarketForAccount(accounts[1].address, vToken.address)).to.be.revertedWith(
+        "access denied",
+      );
+    });
+
+    it("should revert on a zero account", async () => {
+      await expect(comptroller.enterMarketForAccount(ethers.constants.AddressZero, vToken.address)).to.be.revertedWith(
+        "can't be zero address",
+      );
+    });
+
+    it("should revert when the market is not listed", async () => {
+      const unlisted = await smock.fake<VToken>("VToken");
+
+      await expect(comptroller.enterMarketForAccount(accounts[1].address, unlisted.address)).to.be.revertedWith(
+        "market not listed",
+      );
+    });
+
+    it("should be a no-op when the account is already in the market", async () => {
+      const account = accounts[1].address;
+      await comptroller.enterMarketForAccount(account, vToken.address);
+
+      const result = await comptroller.callStatic.enterMarketForAccount(account, vToken.address);
+      expect(result).to.equal(0); // NO_ERROR
+
+      await expect(comptroller.enterMarketForAccount(account, vToken.address)).to.not.emit(
+        comptroller,
+        "MarketEntered",
+      );
+      expect(await comptroller.getAssetsIn(account)).to.deep.equal([vToken.address]);
+    });
+
+    it("should leave the delegate-gated entry point untouched", async () => {
+      await expect(
+        comptroller.connect(accounts[1]).enterMarketBehalf(root.address, vToken.address),
+      ).to.be.revertedWithCustomError(comptroller, "NotAnApprovedDelegate");
+    });
+  });
+
   describe("Hooks", () => {
     let unitroller: Unitroller;
     let comptroller: ComptrollerMock;

--- a/tests/hardhat/Fork/PrimeV2DecimalsForkTest.ts
+++ b/tests/hardhat/Fork/PrimeV2DecimalsForkTest.ts
@@ -1,0 +1,444 @@
+/**
+ * PrimeV2 24-decimal underlying fork tests (VPD-1982)
+ *
+ * Upgrades the live PrimeV2 proxy on a BSC mainnet fork and registers vvhUSDT, whose
+ * underlying vhUSDT has 24 decimals, against real Comptroller, oracle, XVSVault and
+ * PrimeLiquidityProvider state.
+ *
+ * Run:
+ *   FORKED_NETWORK=bscmainnet npx hardhat test tests/hardhat/Fork/PrimeV2DecimalsForkTest.ts
+ */
+import { setBalance } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { BigNumber, Contract, Signer } from "ethers";
+import { parseEther, parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import { PrimeLens, PrimeV2 } from "../../../typechain";
+import { FORK_MAINNET, forking, initMainnetUser, setForkBlock } from "./utils";
+
+const Addr = {
+  COMPTROLLER: "0xfD36E2c2a6789Db23113685031d7F16329158384",
+  PRIME_V2: "0x059EabA8676b03e4e8f009eFb7F587C28450F50f",
+  PRIME_V2_PROXY_ADMIN: "0x1bb765b741a5f3c2a338369dab539385534e3343",
+  PLP: "0x23c4F844ffDdC6161174eB32c770D4D8C07833F2",
+  ORACLE: "0x6592b5DE802159F3E74B2486b091D11a8256ab8A",
+  ACM: "0x4788629ABc6cFCA10F9f969efdEAa1cF70c23555",
+  TIMELOCK: "0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396",
+  XVS_VAULT: "0x051100480289e704d20e9DB4804837068f3f9204",
+  XVS_STORE: "0x1e25CF968f12850003Db17E0Dba32108509C4359",
+  XVS: "0xcF6BB5389c92Bdda8a3747Ddb454cB7a64626C63",
+  WBNB: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+  vBNB: "0xA07c5b74C9B40447a954e1466938b865b6BBea36",
+  USDT: "0x55d398326f99059fF775485246999027B3197955",
+  vUSDT: "0xfD5840Cd36d94D7229439859C0112a4185BC0255",
+  vWBNB: "0x6bCa74586218dB34cdB402295796b79663d816e9",
+  vhUSDT: "0x18AfDACF30F8671021dec4b78297E39d2FE87226",
+  vvhUSDT: "0xc0768948e668B7BacFf8b4BD1BaBe0eD2b512d3c",
+};
+
+const BLOCK_NUMBER = 120600000;
+const BLOCKS_PER_YEAR = 70080000;
+const XVS_POOL_ID = 0;
+const SUPPLY_MULTIPLIER = parseEther("2");
+// Borrowing is disabled on the Hub receipt markets, so the VIP will list them borrow-side zero.
+const BORROW_MULTIPLIER = BigNumber.from(0);
+
+const ERC20_ABI = [
+  "function transfer(address, uint256) returns (bool)",
+  "function approve(address, uint256) returns (bool)",
+  "function balanceOf(address) view returns (uint256)",
+  "function decimals() view returns (uint8)",
+];
+const VTOKEN_ABI = [
+  "function mint(uint256) returns (uint256)",
+  "function balanceOf(address) view returns (uint256)",
+  "function exchangeRateStored() view returns (uint256)",
+  "function underlying() view returns (address)",
+];
+const ACM_ABI = ["function giveCallPermission(address, string, address) external"];
+const WBNB_ABI = ["function deposit() payable", "function approve(address, uint256) returns (bool)"];
+const PROXY_ADMIN_ABI = [
+  "function upgrade(address, address) external",
+  "function getProxyImplementation(address) view returns (address)",
+];
+const ORACLE_ABI = ["function getUnderlyingPrice(address) view returns (uint256)"];
+const PLP_ABI = [
+  "function initializeTokens(address[]) external",
+  "function lastAccruedBlockOrSecond(address) view returns (uint256)",
+];
+const XVS_VAULT_ABI = [
+  "function deposit(address, uint256, uint256) external",
+  "function requestWithdrawal(address, uint256, uint256) external",
+];
+
+if (FORK_MAINNET) {
+  forking(BLOCK_NUMBER, () => {
+    describe("PrimeV2 - 24 decimal underlying (vvhUSDT)", () => {
+      let primeV2: PrimeV2;
+      let lens: PrimeLens;
+      let timelock: Signer;
+      let acm: Contract;
+      let proxyAdmin: Contract;
+      let oracle: Contract;
+      let vhUSDT: Contract;
+      let vvhUSDT: Contract;
+      let vUSDT: Contract;
+      let usdt: Contract;
+      let xvs: Contract;
+      let xvsVault: Contract;
+      let plp: Contract;
+      let user1: Signer;
+      let user1Addr: string;
+      let newImpl: string;
+
+      const PERMS = [
+        "issue(address)",
+        "burn(address)",
+        "issueBatch(address[])",
+        "addMarket(address,uint256,uint256)",
+        "removeMarket(address)",
+        "updateAlpha(uint128,uint128)",
+        "setLimit(uint256)",
+      ];
+
+      /** Attach contracts and grant the deployer the ACM permissions the tests need. */
+      async function baseSetup() {
+        const signers = await ethers.getSigners();
+        const deployer = signers[0];
+        user1 = signers[1];
+        user1Addr = await user1.getAddress();
+
+        timelock = await initMainnetUser(Addr.TIMELOCK, parseEther("100"));
+
+        primeV2 = (await ethers.getContractAt("PrimeV2", Addr.PRIME_V2)) as PrimeV2;
+        acm = new ethers.Contract(Addr.ACM, ACM_ABI, timelock);
+        proxyAdmin = new ethers.Contract(Addr.PRIME_V2_PROXY_ADMIN, PROXY_ADMIN_ABI, timelock);
+        oracle = new ethers.Contract(Addr.ORACLE, ORACLE_ABI, deployer);
+        vhUSDT = new ethers.Contract(Addr.vhUSDT, ERC20_ABI, deployer);
+        vvhUSDT = new ethers.Contract(Addr.vvhUSDT, VTOKEN_ABI, deployer);
+        vUSDT = new ethers.Contract(Addr.vUSDT, VTOKEN_ABI, deployer);
+        usdt = new ethers.Contract(Addr.USDT, ERC20_ABI, deployer);
+        xvs = new ethers.Contract(Addr.XVS, ERC20_ABI, deployer);
+        xvsVault = new ethers.Contract(Addr.XVS_VAULT, XVS_VAULT_ABI, deployer);
+        plp = new ethers.Contract(Addr.PLP, PLP_ABI, timelock);
+
+        const deployerAddr = await deployer.getAddress();
+        for (const f of PERMS) {
+          await acm.giveCallPermission(Addr.PRIME_V2, f, deployerAddr);
+        }
+
+        // The live mint cap sits at the current holder count, so make room for the test users.
+        await primeV2.setLimit((await primeV2.totalTokens()).add(10));
+      }
+
+      /** Deploy the fixed implementation with the live immutables. */
+      async function deployNewImplementation(): Promise<string> {
+        const factory = await ethers.getContractFactory("PrimeV2");
+        const impl = await factory.deploy(
+          Addr.WBNB,
+          Addr.vBNB,
+          Addr.XVS_VAULT,
+          Addr.XVS,
+          XVS_POOL_ID,
+          false,
+          BLOCKS_PER_YEAR,
+        );
+        await impl.deployed();
+        return impl.address;
+      }
+
+      async function preUpgradeSetup() {
+        await setForkBlock(BLOCK_NUMBER);
+        await baseSetup();
+        newImpl = await deployNewImplementation();
+      }
+
+      async function upgradedSetup() {
+        await setForkBlock(BLOCK_NUMBER);
+        await baseSetup();
+        newImpl = await deployNewImplementation();
+        await proxyAdmin.upgrade(Addr.PRIME_V2, newImpl);
+
+        const LensFactory = await ethers.getContractFactory("PrimeLens");
+        lens = (await LensFactory.deploy(Addr.PRIME_V2)) as PrimeLens;
+        await lens.deployed();
+      }
+
+      /** Move vhUSDT out of the vvhUSDT market's own cash to fund a test account. */
+      async function fundVhUSDT(to: string, amount: BigNumber) {
+        const whale = await initMainnetUser(Addr.vvhUSDT, parseEther("1"));
+        await vhUSDT.connect(whale).transfer(to, amount);
+      }
+
+      async function fundUSDT(to: string, amount: BigNumber) {
+        const whale = await initMainnetUser(Addr.vUSDT, parseEther("1"));
+        await usdt.connect(whale).transfer(to, amount);
+      }
+
+      async function fundXVS(to: string, amount: BigNumber) {
+        const store = await initMainnetUser(Addr.XVS_STORE, parseEther("1"));
+        await xvs.connect(store).transfer(to, amount);
+      }
+
+      describe("live implementation, before the fix", () => {
+        beforeEach(async () => {
+          await preUpgradeSetup();
+        });
+
+        it("rejects the 24-decimal market with UnsupportedUnderlyingDecimals", async () => {
+          await expect(
+            primeV2.addMarket(Addr.vvhUSDT, SUPPLY_MULTIPLIER, BORROW_MULTIPLIER),
+          ).to.be.revertedWithCustomError(primeV2, "UnsupportedUnderlyingDecimals");
+        });
+
+        it("confirms the underlying really is 24 decimals and priced by the live oracle", async () => {
+          expect(await vhUSDT.decimals()).to.equal(24);
+
+          // Venus scales underlying prices to 36 - decimals, so a ~$1 asset at 24 decimals
+          // lands near 1e12 rather than the 1e18 an 18-decimal asset would report.
+          const vhPrice = await oracle.getUnderlyingPrice(Addr.vvhUSDT);
+          expect(vhPrice).to.be.gt(parseUnits("0.9", 12));
+          expect(vhPrice).to.be.lt(parseUnits("1.1", 12));
+
+          const usdtPrice = await oracle.getUnderlyingPrice(Addr.vUSDT);
+          expect(usdtPrice).to.be.gt(parseUnits("0.9", 18));
+        });
+      });
+
+      describe("upgrade regression on the existing 18-decimal markets", () => {
+        beforeEach(async () => {
+          await preUpgradeSetup();
+        });
+
+        it("computes identical scores on every existing market before and after the upgrade", async () => {
+          await fundXVS(user1Addr, parseEther("10000"));
+          await xvs.connect(user1).approve(Addr.XVS_VAULT, parseEther("10000"));
+          await xvsVault.connect(user1).deposit(Addr.XVS, XVS_POOL_ID, parseEther("10000"));
+
+          await fundUSDT(user1Addr, parseUnits("5000", 18));
+          await usdt.connect(user1).approve(Addr.vUSDT, parseUnits("5000", 18));
+          await vUSDT.connect(user1).mint(parseUnits("5000", 18));
+
+          // Take a WBNB position too, so more than one existing market carries a real score.
+          await setBalance(user1Addr, parseEther("100"));
+          const wbnb = new ethers.Contract(Addr.WBNB, WBNB_ABI, user1);
+          const vWBNB = new ethers.Contract(Addr.vWBNB, VTOKEN_ABI, user1);
+          await wbnb.deposit({ value: parseEther("10") });
+          await wbnb.approve(Addr.vWBNB, parseEther("10"));
+          await vWBNB.mint(parseEther("10"));
+
+          // Scored by the live implementation, before any upgrade.
+          await primeV2["issue(address)"](user1Addr);
+
+          const markets = await primeV2.getAllMarkets();
+          const before: Record<string, BigNumber> = {};
+          for (const m of markets) {
+            before[m] = (await primeV2.interests(m, user1Addr)).score;
+          }
+          expect(before[Addr.vUSDT]).to.be.gt(0);
+          expect(before[Addr.vWBNB]).to.be.gt(0);
+
+          await proxyAdmin.upgrade(Addr.PRIME_V2, newImpl);
+
+          // Recompute the same scores through the fixed implementation.
+          for (const m of markets) {
+            await primeV2["accrueInterestAndUpdateScore(address,address)"](user1Addr, m);
+            expect((await primeV2.interests(m, user1Addr)).score).to.equal(before[m]);
+          }
+        });
+
+        it("leaves the aggregate score of each existing market untouched by the upgrade", async () => {
+          const markets = await primeV2.getAllMarkets();
+          const before: Record<string, BigNumber> = {};
+          for (const m of markets) {
+            before[m] = (await primeV2.markets(m)).sumOfMembersScore;
+          }
+
+          await proxyAdmin.upgrade(Addr.PRIME_V2, newImpl);
+
+          for (const m of markets) {
+            expect((await primeV2.markets(m)).sumOfMembersScore).to.equal(before[m]);
+            expect(before[m]).to.be.gt(0);
+          }
+        });
+      });
+
+      describe("after upgrading the live proxy", () => {
+        beforeEach(async () => {
+          await upgradedSetup();
+        });
+
+        it("preserves existing markets, holders and alpha across the upgrade", async () => {
+          expect(await proxyAdmin.getProxyImplementation(Addr.PRIME_V2)).to.equal(newImpl);
+
+          const markets = await primeV2.getAllMarkets();
+          expect(markets).to.deep.equal([
+            Addr.vUSDT,
+            "0x6bCa74586218dB34cdB402295796b79663d816e9",
+            "0x3d5E269787d562b74aCC55F18Bd26C5D09Fa245E",
+          ]);
+          expect(await primeV2.totalTokens()).to.equal(500);
+          expect(await primeV2.alphaNumerator()).to.equal(1);
+          expect(await primeV2.alphaDenominator()).to.equal(2);
+        });
+
+        it("registers the 24-decimal market", async () => {
+          await expect(primeV2.addMarket(Addr.vvhUSDT, SUPPLY_MULTIPLIER, BORROW_MULTIPLIER)).to.not.be.reverted;
+
+          const market = await primeV2.markets(Addr.vvhUSDT);
+          expect(market.exists).to.equal(true);
+          expect(market.supplyMultiplier).to.equal(SUPPLY_MULTIPLIER);
+          expect(await primeV2.getAllMarkets()).to.have.lengthOf(4);
+        });
+
+        it("queues a score update round for every existing holder when the market is added", async () => {
+          expect(await primeV2.pendingScoreUpdates()).to.equal(0);
+          await primeV2.addMarket(Addr.vvhUSDT, SUPPLY_MULTIPLIER, BORROW_MULTIPLIER);
+          expect(await primeV2.pendingScoreUpdates()).to.equal(500);
+        });
+
+        it("still rejects an underlying above the 24 decimal ceiling", async () => {
+          // No listed Core market has a wider underlying, so the ceiling itself is covered
+          // by the unit tests. Here we only confirm 24 is admitted rather than merely tolerated.
+          const decimals = await vhUSDT.decimals();
+          expect(decimals).to.equal(24);
+          await expect(primeV2.addMarket(Addr.vvhUSDT, SUPPLY_MULTIPLIER, BORROW_MULTIPLIER)).to.not.be.reverted;
+        });
+
+        describe("market added before the PLP knows the reward token", () => {
+          let plpTyped: Contract;
+
+          beforeEach(async () => {
+            plpTyped = await ethers.getContractAt("PrimeLiquidityProvider", Addr.PLP);
+
+            await fundXVS(user1Addr, parseEther("10000"));
+            await xvs.connect(user1).approve(Addr.XVS_VAULT, parseEther("10000"));
+            await xvsVault.connect(user1).deposit(Addr.XVS, XVS_POOL_ID, parseEther("10000"));
+            await primeV2["issue(address)"](user1Addr);
+
+            // Deliberately skip plp.initializeTokens([vhUSDT]) to model the VIP running
+            // addMarket first.
+            await primeV2.addMarket(Addr.vvhUSDT, SUPPLY_MULTIPLIER, BORROW_MULTIPLIER);
+          });
+
+          it("makes updateScores revert, so the queued round can never finish", async () => {
+            await expect(primeV2.updateScores([user1Addr]))
+              .to.be.revertedWithCustomError(plpTyped, "TokenNotInitialized")
+              .withArgs(Addr.vhUSDT);
+          });
+
+          it("makes removeMarket revert, so the market cannot simply be withdrawn", async () => {
+            expect((await primeV2.markets(Addr.vvhUSDT)).sumOfMembersScore).to.equal(0);
+
+            await expect(primeV2.removeMarket(Addr.vvhUSDT))
+              .to.be.revertedWithCustomError(plpTyped, "TokenNotInitialized")
+              .withArgs(Addr.vhUSDT);
+          });
+
+          it("breaks XVSVault staking for an existing Prime holder", async () => {
+            await fundXVS(user1Addr, parseEther("100"));
+            await xvs.connect(user1).approve(Addr.XVS_VAULT, parseEther("100"));
+
+            await expect(xvsVault.connect(user1).deposit(Addr.XVS, XVS_POOL_ID, parseEther("100"))).to.be.reverted;
+          });
+
+          it("recovers once the PLP initialises the token", async () => {
+            const pendingBefore = await primeV2.pendingScoreUpdates();
+
+            await plp.initializeTokens([Addr.vhUSDT]);
+
+            await expect(primeV2.updateScores([user1Addr])).to.not.be.reverted;
+            expect(await primeV2.pendingScoreUpdates()).to.equal(pendingBefore.sub(1));
+          });
+        });
+
+        describe("with the 24-decimal market registered and a Prime holder", () => {
+          beforeEach(async () => {
+            await fundXVS(user1Addr, parseEther("10000"));
+            await xvs.connect(user1).approve(Addr.XVS_VAULT, parseEther("10000"));
+            await xvsVault.connect(user1).deposit(Addr.XVS, XVS_POOL_ID, parseEther("10000"));
+
+            // Issue before addMarket: issue() is blocked while a score round is pending.
+            await primeV2["issue(address)"](user1Addr);
+
+            await fundVhUSDT(user1Addr, parseUnits("1000", 24));
+            await vhUSDT.connect(user1).approve(Addr.vvhUSDT, parseUnits("1000", 24));
+            await vvhUSDT.connect(user1).mint(parseUnits("1000", 24));
+
+            await fundUSDT(user1Addr, parseUnits("1000", 18));
+            await usdt.connect(user1).approve(Addr.vUSDT, parseUnits("1000", 18));
+            await vUSDT.connect(user1).mint(parseUnits("1000", 18));
+
+            // The PLP must know the reward token before the market is scored: PrimeV2.accrueInterest
+            // calls PLP.accrueTokens(underlying), which reverts for an uninitialised token.
+            await plp.initializeTokens([Addr.vhUSDT]);
+
+            await primeV2.addMarket(Addr.vvhUSDT, SUPPLY_MULTIPLIER, BORROW_MULTIPLIER);
+          });
+
+          it("scores the holder on the 24-decimal market without reverting", async () => {
+            await expect(primeV2.updateScores([user1Addr])).to.not.be.reverted;
+
+            const interest = await primeV2.interests(Addr.vvhUSDT, user1Addr);
+            expect(interest.score).to.be.gt(0);
+          });
+
+          it("scores 1000 vhUSDT within 2% of 1000 USDT, so the normalisation is right", async () => {
+            await primeV2.updateScores([user1Addr]);
+
+            const vhScore = (await primeV2.interests(Addr.vvhUSDT, user1Addr)).score;
+            const usdtScore = (await primeV2.interests(Addr.vUSDT, user1Addr)).score;
+
+            expect(vhScore).to.be.gt(0);
+            expect(usdtScore).to.be.gt(0);
+
+            const diff = vhScore.sub(usdtScore).abs();
+            expect(diff.mul(100).div(usdtScore)).to.be.lte(2);
+          });
+
+          it("lets the Comptroller mint hook run on the 24-decimal market", async () => {
+            await fundVhUSDT(user1Addr, parseUnits("10", 24));
+            await vhUSDT.connect(user1).approve(Addr.vvhUSDT, parseUnits("10", 24));
+
+            // mint() calls Comptroller.mintVerify, which calls
+            // PrimeV2.accrueInterestAndUpdateScore for a Prime holder.
+            await expect(vvhUSDT.connect(user1).mint(parseUnits("10", 24))).to.not.be.reverted;
+          });
+
+          it("lets XVSVault stake and unstake run with the market registered", async () => {
+            await fundXVS(user1Addr, parseEther("100"));
+            await xvs.connect(user1).approve(Addr.XVS_VAULT, parseEther("100"));
+
+            await expect(xvsVault.connect(user1).deposit(Addr.XVS, XVS_POOL_ID, parseEther("100"))).to.not.be.reverted;
+            await expect(xvsVault.connect(user1).requestWithdrawal(Addr.XVS, XVS_POOL_ID, parseEther("50"))).to.not.be
+              .reverted;
+          });
+
+          it("does not revert for a holder with no position in the 24-decimal market", async () => {
+            const other = (await ethers.getSigners())[2];
+            const otherAddr = await other.getAddress();
+
+            await expect(primeV2["accrueInterestAndUpdateScore(address,address)"](otherAddr, Addr.vvhUSDT)).to.not.be
+              .reverted;
+          });
+
+          it("reports a non-zero APR score through PrimeLens matching the stored score", async () => {
+            await primeV2.updateScores([user1Addr]);
+
+            const stored = (await primeV2.interests(Addr.vvhUSDT, user1Addr)).score;
+            const supply = await vvhUSDT.balanceOf(user1Addr);
+            const rate = await vvhUSDT.exchangeRateStored();
+            const underlyingSupply = supply.mul(rate).div(parseEther("1"));
+
+            const aprInfo = await lens.estimateAPR(Addr.vvhUSDT, user1Addr, 0, underlyingSupply, parseEther("10000"));
+
+            expect(aprInfo.userScore).to.be.gt(0);
+            const diff = aprInfo.userScore.sub(stored).abs();
+            expect(diff.mul(100).div(stored)).to.be.lte(1);
+          });
+        });
+      });
+    });
+  });
+}

--- a/tests/hardhat/PrimeV2/PrimeV2.decimals.ts
+++ b/tests/hardhat/PrimeV2/PrimeV2.decimals.ts
@@ -1,0 +1,297 @@
+import { FakeContract, smock } from "@defi-wonderland/smock";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import chai from "chai";
+import { Contract } from "ethers";
+import { ethers } from "hardhat";
+
+import { convertToUnit } from "../../../helpers/utils";
+import { PrimeLens } from "../../../typechain";
+import {
+  IntegrationFixture,
+  deployIntegrationFixture,
+  simulateVaultDeposit,
+  simulateVaultWithdrawal,
+} from "./helpers/integrationFixture";
+
+const { expect } = chai;
+chai.use(smock.matchers);
+
+const MULTIPLIER = convertToUnit(2, 18);
+const XVS_STAKE = convertToUnit(1000, 18);
+
+// Decimals covered by the parameterised cases. 24 is the Venus Hub receipt tokens
+// (vhUSDT, vhUSDC, vhU); the rest are the common ERC20 widths.
+const DECIMALS = [6, 8, 18, 24];
+
+interface Market {
+  vToken: FakeContract<Contract>;
+  underlying: FakeContract<Contract>;
+  decimals: number;
+}
+
+/**
+ * Registers a Prime market whose underlying reports `decimals`.
+ *
+ * The vToken is faked with an exchange rate of 1e18 so that the supply PrimeV2 derives
+ * equals the balance set on it, which keeps the balances in each test readable. The
+ * oracle price is scaled to 36 - decimals, matching what the Venus resilient oracle
+ * returns, so that the USD supply cap compares against the right magnitude.
+ */
+async function addMarketWithDecimals(f: IntegrationFixture, decimals: number): Promise<Market> {
+  const underlying = await smock.fake(
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol:IERC20MetadataUpgradeable",
+  );
+  underlying.decimals.returns(decimals);
+
+  const vToken = await smock.fake("contracts/Tokens/Prime/Interfaces/IVToken.sol:IVToken");
+  vToken.underlying.returns(underlying.address);
+  vToken.borrowBalanceStored.returns(0);
+  vToken.exchangeRateStored.returns(convertToUnit(1, 18));
+  vToken.balanceOf.returns(0);
+
+  f.oracle.getUnderlyingPrice.whenCalledWith(vToken.address).returns(convertToUnit(1, 36 - decimals));
+
+  await f.primeV2.addMarket(vToken.address, MULTIPLIER, MULTIPLIER);
+
+  return { vToken, underlying, decimals };
+}
+
+describe("PrimeV2 - underlyings with more than 18 decimals", () => {
+  let f: IntegrationFixture;
+  let user1Address: string;
+  let user2Address: string;
+
+  beforeEach(async () => {
+    f = await loadFixture(deployIntegrationFixture);
+    f.accessControlManager.isAllowedToCall.returns(true);
+    f.primeLiquidityProvider.tokenAmountAccrued.returns(0);
+
+    user1Address = await f.user1.getAddress();
+    user2Address = await f.user2.getAddress();
+
+    f.xvsVault.getUserInfo.whenCalledWith(f.xvsAddress, 0, user1Address).returns([XVS_STAKE, 0, 0]);
+    f.xvsVault.getUserInfo.whenCalledWith(f.xvsAddress, 0, user2Address).returns([XVS_STAKE, 0, 0]);
+  });
+
+  describe("score arithmetic", () => {
+    it("normalises capital to 18 decimals, so equal value scores equally at 6, 8, 18 and 24 decimals", async () => {
+      const markets: Market[] = [];
+      for (const decimals of DECIMALS) {
+        const market = await addMarketWithDecimals(f, decimals);
+        // 1000 tokens in each market, so every market holds the same USD value.
+        market.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, decimals));
+        markets.push(market);
+      }
+
+      await f.primeV2["issue(address)"](user1Address);
+
+      const scores = [];
+      for (const market of markets) {
+        const interest = await f.primeV2.interests(market.vToken.address, user1Address);
+        scores.push(interest.score);
+      }
+
+      expect(scores[0]).to.be.gt(0);
+      for (const score of scores) {
+        expect(score).to.equal(scores[0]);
+      }
+    });
+
+    it("scores a 24-decimal market equal to an 18-decimal market holding the same value", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      const standard = await addMarketWithDecimals(f, 18);
+
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 24));
+      standard.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 18));
+
+      await f.primeV2["issue(address)"](user1Address);
+
+      const wideScore = (await f.primeV2.interests(wide.vToken.address, user1Address)).score;
+      const standardScore = (await f.primeV2.interests(standard.vToken.address, user1Address)).score;
+
+      expect(wideScore).to.be.gt(0);
+      expect(wideScore).to.equal(standardScore);
+    });
+
+    it("applies the supply cap before normalising, so a capped 24-decimal position matches 18 decimals", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      const standard = await addMarketWithDecimals(f, 18);
+
+      // supplyCapUSD is 6000e18 here (xvsPrice 3e18 * stake 1000e18 * multiplier 2e18 / 1e36),
+      // so a 100000 token supply is capped in both markets.
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(100000, 24));
+      standard.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(100000, 18));
+
+      await f.primeV2["issue(address)"](user1Address);
+
+      const wideScore = (await f.primeV2.interests(wide.vToken.address, user1Address)).score;
+      const standardScore = (await f.primeV2.interests(standard.vToken.address, user1Address)).score;
+
+      expect(wideScore).to.be.gt(0);
+      expect(wideScore).to.equal(standardScore);
+    });
+
+    it("truncates a 24-decimal position smaller than one 18-decimal unit to a zero score", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+
+      // 999999 raw units is below 1e6, the smallest amount that survives the divide by 1e6.
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns("999999");
+
+      await f.primeV2["issue(address)"](user1Address);
+
+      expect((await f.primeV2.interests(wide.vToken.address, user1Address)).score).to.equal(0);
+    });
+  });
+
+  describe("addMarket decimals guard", () => {
+    it("accepts an underlying at the 24 decimal ceiling", async () => {
+      await expect(addMarketWithDecimals(f, 24)).to.not.be.reverted;
+    });
+
+    it("accepts an underlying below the ceiling", async () => {
+      await expect(addMarketWithDecimals(f, 18)).to.not.be.reverted;
+    });
+
+    it("rejects an underlying above the 24 decimal ceiling", async () => {
+      await expect(addMarketWithDecimals(f, 25)).to.be.revertedWithCustomError(
+        f.primeV2,
+        "UnsupportedUnderlyingDecimals",
+      );
+    });
+  });
+
+  describe("Comptroller hooks", () => {
+    it("does not revert accrueInterestAndUpdateScore, the mintVerify and redeemVerify hook", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 24));
+
+      await f.primeV2["issue(address)"](user1Address);
+
+      await expect(f.primeV2["accrueInterestAndUpdateScore(address,address)"](user1Address, wide.vToken.address)).to.not
+        .be.reverted;
+
+      expect((await f.primeV2.interests(wide.vToken.address, user1Address)).score).to.be.gt(0);
+    });
+
+    it("does not revert the hook for a Prime holder with no position in the 24-decimal market", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+
+      await f.primeV2["issue(address)"](user1Address);
+
+      await expect(f.primeV2["accrueInterestAndUpdateScore(address,address)"](user1Address, wide.vToken.address)).to.not
+        .be.reverted;
+    });
+  });
+
+  describe("updateScores", () => {
+    it("completes a round with a 24-decimal market present", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      const standard = await addMarketWithDecimals(f, 18);
+
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 24));
+      standard.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 18));
+
+      await f.primeV2.issueBatch([user1Address, user2Address]);
+
+      await f.primeV2.updateAlpha(2, 3);
+      expect(await f.primeV2.pendingScoreUpdates()).to.equal(2);
+
+      await expect(f.primeV2.updateScores([user1Address, user2Address])).to.not.be.reverted;
+      expect(await f.primeV2.pendingScoreUpdates()).to.equal(0);
+    });
+
+    it("does not revert for a holder with no position in the 24-decimal market", async () => {
+      await addMarketWithDecimals(f, 24);
+
+      // user2 holds nothing anywhere, so every market resolves a zero supply.
+      await f.primeV2.issueBatch([user2Address]);
+      await f.primeV2.updateAlpha(2, 3);
+
+      await expect(f.primeV2.updateScores([user2Address])).to.not.be.reverted;
+      expect(await f.primeV2.pendingScoreUpdates()).to.equal(0);
+    });
+  });
+
+  describe("XVSVault callback chain", () => {
+    it("does not revert on stake with a 24-decimal market present", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 24));
+
+      await f.primeV2["issue(address)"](user1Address);
+
+      await expect(simulateVaultDeposit(f, user1Address, convertToUnit(2000, 18))).to.not.be.reverted;
+    });
+
+    it("does not revert on unstake with a 24-decimal market present", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 24));
+
+      await f.primeV2["issue(address)"](user1Address);
+      await simulateVaultDeposit(f, user1Address, convertToUnit(2000, 18));
+
+      await expect(simulateVaultWithdrawal(f, user1Address, convertToUnit(500, 18))).to.not.be.reverted;
+    });
+
+    it("moves the 24-decimal market score when the stake changes", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 24));
+
+      await f.primeV2["issue(address)"](user1Address);
+      const scoreBefore = (await f.primeV2.interests(wide.vToken.address, user1Address)).score;
+
+      await simulateVaultDeposit(f, user1Address, convertToUnit(5000, 18));
+
+      const scoreAfter = (await f.primeV2.interests(wide.vToken.address, user1Address)).score;
+      expect(scoreAfter).to.be.gt(scoreBefore);
+    });
+  });
+
+  describe("PrimeLens", () => {
+    let lens: PrimeLens;
+
+    beforeEach(async () => {
+      const PrimeLensFactory = await ethers.getContractFactory("PrimeLens");
+      lens = (await PrimeLensFactory.deploy(f.primeV2.address)) as PrimeLens;
+      await lens.deployed();
+    });
+
+    it("estimates APR for a 24-decimal market", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 24));
+      await f.primeV2["issue(address)"](user1Address);
+
+      const aprInfo = await lens.estimateAPR(wide.vToken.address, user1Address, 0, convertToUnit(1000, 24), XVS_STAKE);
+
+      expect(aprInfo.userScore).to.be.gt(0);
+    });
+
+    it("estimates the same score for a 24-decimal and an 18-decimal market of equal value", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      const standard = await addMarketWithDecimals(f, 18);
+      await f.primeV2["issue(address)"](user1Address);
+
+      const wideApr = await lens.estimateAPR(wide.vToken.address, user1Address, 0, convertToUnit(1000, 24), XVS_STAKE);
+      const standardApr = await lens.estimateAPR(
+        standard.vToken.address,
+        user1Address,
+        0,
+        convertToUnit(1000, 18),
+        XVS_STAKE,
+      );
+
+      expect(wideApr.userScore).to.be.gt(0);
+      expect(wideApr.userScore).to.equal(standardApr.userScore);
+    });
+
+    it("matches the score PrimeV2 stores for a 24-decimal market", async () => {
+      const wide = await addMarketWithDecimals(f, 24);
+      wide.vToken.balanceOf.whenCalledWith(user1Address).returns(convertToUnit(1000, 24));
+      await f.primeV2["issue(address)"](user1Address);
+
+      const storedScore = (await f.primeV2.interests(wide.vToken.address, user1Address)).score;
+      const aprInfo = await lens.estimateAPR(wide.vToken.address, user1Address, 0, convertToUnit(1000, 24), XVS_STAKE);
+
+      expect(aprInfo.userScore).to.equal(storedScore);
+    });
+  });
+});

--- a/tests/hardhat/PrimeV2/PrimeV2.markets.ts
+++ b/tests/hardhat/PrimeV2/PrimeV2.markets.ts
@@ -60,8 +60,8 @@ describe("PrimeV2 - Market Management", () => {
       ).to.be.revertedWithCustomError(f.primeV2, "InvalidVToken");
     });
 
-    it("should revert UnsupportedUnderlyingDecimals when underlying token decimals > 18", async () => {
-      f.underlyingToken.decimals.returns(19);
+    it("should revert UnsupportedUnderlyingDecimals when underlying token decimals > 24", async () => {
+      f.underlyingToken.decimals.returns(25);
 
       try {
         await expect(


### PR DESCRIPTION
## Description

Resolves VPD-1982

Prime normalised a market's capital to 18 decimals by multiplying by `10 ** (18 - decimals)`, which underflows for a wider underlying. `addMarket` therefore rejected those underlyings outright, via the guard added for audit finding **I06**. Capital now scales down instead, and the guard's ceiling moves from 18 to 24.

This unblocks listing the Venus Hub receipt tokens `vvhUSDT`, `vvhUSDC` and `vvhU`. Their underlyings have 24 decimals.

Also adds `MarketFacet.enterMarketForAccount(address account, address vToken)`, an ACM-gated entry point that enters a market for an account without a delegate grant from that account. It exists for `HubRouter` (VenusProtocol/venus-liquidity-hub#24), which supplies a vh position on the user's behalf and needs it to count as collateral in the same call; `enterMarketBehalf` requires the account to have approved the caller as a delegate first, which defeats a one-call supply. The role string is the function signature, `enterMarketForAccount(address,address)`, and the caller can only ever enter a market for an account, never exit one or move funds. The Prime and Comptroller changes are independent; they ship together because both gate the same vh market listing.

Note for reviewers, since the ticket described it differently: the underflow was **not** reachable on `develop`. The I06 guard rejected such a market before any scoring ran, so `addMarket(vvhUSDT, ...)` reverted with `UnsupportedUnderlyingDecimals(24)`, not a panic. Both halves of this PR are required; neither alone changes anything observable.

### Why 24 and not higher

The oracle reports price as `usd × 10 ** (36 - decimals)`. The further past 24 you go, the more that truncates: at 36 decimals it is integer dollars, so any sub-$1 asset prices to 0, and `ResilientOracle` treats 0 as `INVALID_PRICE` and reverts. That would reintroduce the same broken-market failure this PR removes. 24 is what the product needs and the width the tests actually prove scoring correct at.

### Changes

| File | Change |
| --- | --- |
| `PrimeV2.sol:1279` | Scale capital down above 18 decimals instead of underflowing |
| `PrimeV2.sol:723` | Ceiling `18 → 24`, plus natspec on the error and `addMarket` |
| `PrimeLens.sol:150` | Same scaling fix, so the frontend APR matches the on-chain score |
| `PrimeV2.decimals.ts` | New, 17 unit tests |
| `PrimeV2DecimalsForkTest.ts` | New, 18 bscmainnet fork tests |
| `PrimeV2.markets.ts` | Repin the existing I06 guard test from 19 to 25 decimals |
| `MarketFacet.sol:213` | New `enterMarketForAccount`, ACM-gated on its own signature, zero-address checked, reuses `addToMarketInternal` |
| `IMarketFacet.sol` | Declare it |
| `comptrollerTest.ts` | 6 new tests: enters without delegate approval, ACM revert, zero account, unlisted market, idempotent, `enterMarketBehalf` unchanged |

### Test plan

```bash
yarn test                                                                     # 1362 passing
FORKED_NETWORK=bscmainnet npx hardhat test tests/hardhat/Fork/PrimeV2DecimalsForkTest.ts   # 18 passing
```

Unit tests cover score arithmetic (equal value scores equally at 6, 8, 18 and 24; capped and uncapped; sub-unit dust truncates to zero), the `addMarket` boundary at 24 and 25, the Comptroller hook, `updateScores`, the XVSVault callback chain, and PrimeLens APR reads.

The fork tests upgrade the **live** PrimeV2 proxy at block 120600000 against real state (3 markets, 500 Prime holders, real oracle and vault) and confirm:

- the live implementation really does reject `addMarket(vvhUSDT)` with `UnsupportedUnderlyingDecimals`;
- after the upgrade the market registers, scores, and 1000 vhUSDT scores within 2% of 1000 USDT at real oracle prices;
- the Comptroller mint hook, XVSVault stake/unstake, and PrimeLens all work with the market registered;
- **no regression:** scores on the existing markets are recomputed across the upgrade and match **exactly** (vUSDT and vWBNB with real non-zero positions), aggregates are untouched, and `totalTokens`, alpha and the market list are preserved.

To confirm the unit tests are load-bearing, revert only the two scaling expressions while leaving the ceiling at 24: 14 of the 17 fail on the underflow, and the 3 guard tests correctly stay green.

Also verified: storage layout unchanged (37 slots, identical labels, offsets and type sizes, so the upgrade is safe); PrimeV2 at 23854 bytes with 722 of headroom; `prettier:check` clean and `solhint` reporting 0 errors.

### Deployment notes

**Ordering requirement — `initializeTokens` must run before `addMarket`.** The follow-on VIP in the ticket has these the other way round, which would break Prime.

`PrimeV2.accrueInterest(vvhUSDT)` calls `PLP.accrueTokens(vhUSDT)`, and vhUSDT is not initialised in the PrimeLiquidityProvider today (`lastAccruedBlockOrSecond(vhUSDT) == 0`). If the market is listed first, then for every Prime holder `updateScores`, the Comptroller mint hook, and `XVSVault.deposit`/`requestWithdrawal` all revert with `TokenNotInitialized(vhUSDT)`. `removeMarket` cannot back it out either, because it also calls `accrueInterest`. Only `PLP.initializeTokens([vhUSDT])` recovers it. Four fork tests pin this, including the recovery.

Correct order per market: `initializeTokens` → `addMarket` → `setTokensDistributionSpeed` → fund the PLP.

Other notes:

- **This reverses I06's remediation** from "reject > 18 decimals" to "handle up to 24". The auditor should see it.
- **Oracle wiring is already in place** — no VIP action needed. The live resilient oracle prices `vvhUSDT` at `1.0016e12`, exactly the `usd × 10 ** (36 - decimals)` convention, through the derived `CorrelatedTokenOracle` path. This matters because `ChainlinkOracle` and `BinanceOracle` both compute `18 - decimals` and cannot price anything wider than 18; any future wide-decimal listing must be checked the same way, since `addMarket` cannot verify it.
- **`addMarket` queues a score round for all 500 holders**, and the live `maxLoopsLimit` is 20, so the VIP needs **25 `updateScores` transactions** before `issue`/`burn` work again.
- **PrimeLens is a separate deployment** (`0x2f8c5e4562E22DB7908C56Bf99961C053436473c`) and needs its own upgrade.
- **Ship before the Prime `addMarket` VIP**, not alongside it.
- **`enterMarketForAccount` needs a diamond cut and a role grant.** The VIP must add the selector to the Core Comptroller's `MarketFacet` and then `ACM.giveCallPermission(comptroller, "enterMarketForAccount(address,address)", hubRouter)`. The liquidity-hub fork suite does both against the live Comptroller, with facet bytecode built from this PR, so that fixture has to be regenerated if this facet changes.
- **`Prime.sol` (V1) is deliberately out of scope.** Same expression at lines 714 and 846, and V1 is the only Prime on arbitrumone, basemainnet, ethereum, opmainnet, unichainmainnet and zksyncmainnet. No vh market is planned there. Recorded as a choice, not an oversight.

